### PR TITLE
Use $prefix for namespaces, mark them abstract, fix naming of extensions

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -12,9 +12,7 @@ analyzer:
     # necessary
     camel_case_extensions: ignore
     camel_case_types: ignore
-    library_private_types_in_public_api: ignore
     non_constant_identifier_names: ignore
-    unused_element: ignore
 
 linter:
   rules:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -10,7 +10,6 @@ analyzer:
   errors:
     # Ideally we'd fix all of these - or ignore them at the line-level where
     # necessary
-    camel_case_extensions: ignore
     camel_case_types: ignore
     non_constant_identifier_names: ignore
 

--- a/lib/src/dom/angle_instanced_arrays.dart
+++ b/lib/src/dom/angle_instanced_arrays.dart
@@ -18,7 +18,7 @@ class ANGLE_instanced_arrays {
   external static GLenum get VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE;
 }
 
-extension ANGLE_instanced_arraysExtension on ANGLE_instanced_arrays {
+extension ANGLEInstancedArraysExtension on ANGLE_instanced_arrays {
   external JSVoid drawArraysInstancedANGLE(
     GLenum mode,
     GLint first,

--- a/lib/src/dom/console.dart
+++ b/lib/src/dom/console.dart
@@ -17,7 +17,7 @@ class Console_ {
   external factory Console_();
 }
 
-extension Console_Extension on Console_ {
+extension ConsoleExtension on Console_ {
   @JS('assert')
   external JSVoid assert_0_();
   @JS('assert')

--- a/lib/src/dom/console.dart
+++ b/lib/src/dom/console.dart
@@ -9,15 +9,15 @@ import 'dart:js_interop';
 import 'package:js/js.dart' hide JS;
 
 @JS()
-external Console_ get console;
+external $Console get console;
 
 @JS('console')
 @staticInterop
-class Console_ {
-  external factory Console_();
+abstract class $Console {
+  external factory $Console();
 }
 
-extension ConsoleExtension on Console_ {
+extension $ConsoleExtension on $Console {
   @JS('assert')
   external JSVoid assert_0_();
   @JS('assert')

--- a/lib/src/dom/console.dart
+++ b/lib/src/dom/console.dart
@@ -9,15 +9,15 @@ import 'dart:js_interop';
 import 'package:js/js.dart' hide JS;
 
 @JS()
-external _Console get console;
+external Console_ get console;
 
 @JS('console')
 @staticInterop
-class _Console {
-  external factory _Console();
+class Console_ {
+  external factory Console_();
 }
 
-extension _ConsoleExtension on _Console {
+extension Console_Extension on Console_ {
   @JS('assert')
   external JSVoid assert_0_();
   @JS('assert')

--- a/lib/src/dom/cssom.dart
+++ b/lib/src/dom/cssom.dart
@@ -274,15 +274,15 @@ extension ElementCSSInlineStyleExtension on ElementCSSInlineStyle {
 }
 
 @JS()
-external _CSS get CSS;
+external CSS_ get CSS;
 
 @JS('CSS')
 @staticInterop
-class _CSS {
-  external factory _CSS();
+class CSS_ {
+  external factory CSS_();
 }
 
-extension _CSSExtension on _CSS {
+extension CSS_Extension on CSS_ {
   external Worklet get animationWorklet;
   external JSBoolean supports(
     JSString property,

--- a/lib/src/dom/cssom.dart
+++ b/lib/src/dom/cssom.dart
@@ -274,15 +274,15 @@ extension ElementCSSInlineStyleExtension on ElementCSSInlineStyle {
 }
 
 @JS()
-external CSS_ get CSS;
+external $CSS get CSS;
 
 @JS('CSS')
 @staticInterop
-class CSS_ {
-  external factory CSS_();
+abstract class $CSS {
+  external factory $CSS();
 }
 
-extension CSSExtension on CSS_ {
+extension $CSSExtension on $CSS {
   external Worklet get animationWorklet;
   external JSBoolean supports(
     JSString property,

--- a/lib/src/dom/cssom.dart
+++ b/lib/src/dom/cssom.dart
@@ -282,7 +282,7 @@ class CSS_ {
   external factory CSS_();
 }
 
-extension CSS_Extension on CSS_ {
+extension CSSExtension on CSS_ {
   external Worklet get animationWorklet;
   external JSBoolean supports(
     JSString property,

--- a/lib/src/dom/ext_disjoint_timer_query.dart
+++ b/lib/src/dom/ext_disjoint_timer_query.dart
@@ -32,7 +32,7 @@ class EXT_disjoint_timer_query {
   external static GLenum get GPU_DISJOINT_EXT;
 }
 
-extension EXT_disjoint_timer_queryExtension on EXT_disjoint_timer_query {
+extension EXTDisjointTimerQueryExtension on EXT_disjoint_timer_query {
   external WebGLTimerQueryEXT? createQueryEXT();
   external JSVoid deleteQueryEXT(WebGLTimerQueryEXT? query);
   external JSBoolean isQueryEXT(WebGLTimerQueryEXT? query);

--- a/lib/src/dom/ext_disjoint_timer_query_webgl2.dart
+++ b/lib/src/dom/ext_disjoint_timer_query_webgl2.dart
@@ -22,7 +22,7 @@ class EXT_disjoint_timer_query_webgl2 {
   external static GLenum get GPU_DISJOINT_EXT;
 }
 
-extension EXT_disjoint_timer_query_webgl2Extension
+extension EXTDisjointTimerQueryWebgl2Extension
     on EXT_disjoint_timer_query_webgl2 {
   external JSVoid queryCounterEXT(
     WebGLQuery query,

--- a/lib/src/dom/oes_draw_buffers_indexed.dart
+++ b/lib/src/dom/oes_draw_buffers_indexed.dart
@@ -16,7 +16,7 @@ class OES_draw_buffers_indexed {
   external factory OES_draw_buffers_indexed();
 }
 
-extension OES_draw_buffers_indexedExtension on OES_draw_buffers_indexed {
+extension OESDrawBuffersIndexedExtension on OES_draw_buffers_indexed {
   external JSVoid enableiOES(
     GLenum target,
     GLuint index,

--- a/lib/src/dom/oes_vertex_array_object.dart
+++ b/lib/src/dom/oes_vertex_array_object.dart
@@ -24,7 +24,7 @@ class OES_vertex_array_object {
   external static GLenum get VERTEX_ARRAY_BINDING_OES;
 }
 
-extension OES_vertex_array_objectExtension on OES_vertex_array_object {
+extension OESVertexArrayObjectExtension on OES_vertex_array_object {
   external WebGLVertexArrayObjectOES? createVertexArrayOES();
   external JSVoid deleteVertexArrayOES(WebGLVertexArrayObjectOES? arrayObject);
   external GLboolean isVertexArrayOES(WebGLVertexArrayObjectOES? arrayObject);

--- a/lib/src/dom/ovr_multiview2.dart
+++ b/lib/src/dom/ovr_multiview2.dart
@@ -21,7 +21,7 @@ class OVR_multiview2 {
   external static GLenum get FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR;
 }
 
-extension OVR_multiview2Extension on OVR_multiview2 {
+extension OVRMultiview2Extension on OVR_multiview2 {
   external JSVoid framebufferTextureMultiviewOVR(
     GLenum target,
     GLenum attachment,

--- a/lib/src/dom/testutils.dart
+++ b/lib/src/dom/testutils.dart
@@ -9,14 +9,14 @@ import 'dart:js_interop';
 import 'package:js/js.dart' hide JS;
 
 @JS()
-external _TestUtils get TestUtils;
+external TestUtils_ get TestUtils;
 
 @JS('TestUtils')
 @staticInterop
-class _TestUtils {
-  external factory _TestUtils();
+class TestUtils_ {
+  external factory TestUtils_();
 }
 
-extension _TestUtilsExtension on _TestUtils {
+extension TestUtils_Extension on TestUtils_ {
   external JSPromise gc();
 }

--- a/lib/src/dom/testutils.dart
+++ b/lib/src/dom/testutils.dart
@@ -9,14 +9,14 @@ import 'dart:js_interop';
 import 'package:js/js.dart' hide JS;
 
 @JS()
-external TestUtils_ get TestUtils;
+external $TestUtils get TestUtils;
 
 @JS('TestUtils')
 @staticInterop
-class TestUtils_ {
-  external factory TestUtils_();
+abstract class $TestUtils {
+  external factory $TestUtils();
 }
 
-extension TestUtilsExtension on TestUtils_ {
+extension $TestUtilsExtension on $TestUtils {
   external JSPromise gc();
 }

--- a/lib/src/dom/testutils.dart
+++ b/lib/src/dom/testutils.dart
@@ -17,6 +17,6 @@ class TestUtils_ {
   external factory TestUtils_();
 }
 
-extension TestUtils_Extension on TestUtils_ {
+extension TestUtilsExtension on TestUtils_ {
   external JSPromise gc();
 }

--- a/lib/src/dom/wasm_js_api.dart
+++ b/lib/src/dom/wasm_js_api.dart
@@ -32,7 +32,7 @@ class WebAssembly_ {
   external factory WebAssembly_();
 }
 
-extension WebAssembly_Extension on WebAssembly_ {
+extension WebAssemblyExtension on WebAssembly_ {
   external JSBoolean validate(BufferSource bytes);
   external JSPromise compile(BufferSource bytes);
   external JSPromise instantiate(BufferSource bytes);

--- a/lib/src/dom/wasm_js_api.dart
+++ b/lib/src/dom/wasm_js_api.dart
@@ -24,15 +24,15 @@ extension WebAssemblyInstantiatedSourceExtension
     on WebAssemblyInstantiatedSource {}
 
 @JS()
-external WebAssembly_ get WebAssembly;
+external $WebAssembly get WebAssembly;
 
 @JS('WebAssembly')
 @staticInterop
-class WebAssembly_ {
-  external factory WebAssembly_();
+abstract class $WebAssembly {
+  external factory $WebAssembly();
 }
 
-extension WebAssemblyExtension on WebAssembly_ {
+extension $WebAssemblyExtension on $WebAssembly {
   external JSBoolean validate(BufferSource bytes);
   external JSPromise compile(BufferSource bytes);
   external JSPromise instantiate(BufferSource bytes);

--- a/lib/src/dom/wasm_js_api.dart
+++ b/lib/src/dom/wasm_js_api.dart
@@ -24,15 +24,15 @@ extension WebAssemblyInstantiatedSourceExtension
     on WebAssemblyInstantiatedSource {}
 
 @JS()
-external _WebAssembly get WebAssembly;
+external WebAssembly_ get WebAssembly;
 
 @JS('WebAssembly')
 @staticInterop
-class _WebAssembly {
-  external factory _WebAssembly();
+class WebAssembly_ {
+  external factory WebAssembly_();
 }
 
-extension _WebAssemblyExtension on _WebAssembly {
+extension WebAssembly_Extension on WebAssembly_ {
   external JSBoolean validate(BufferSource bytes);
   external JSPromise compile(BufferSource bytes);
   external JSPromise instantiate(BufferSource bytes);

--- a/lib/src/dom/webgl_compressed_texture_astc.dart
+++ b/lib/src/dom/webgl_compressed_texture_astc.dart
@@ -45,7 +45,6 @@ class WEBGL_compressed_texture_astc {
   external static GLenum get COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR;
 }
 
-extension WEBGL_compressed_texture_astcExtension
-    on WEBGL_compressed_texture_astc {
+extension WEBGLCompressedTextureAstcExtension on WEBGL_compressed_texture_astc {
   external JSArray getSupportedProfiles();
 }

--- a/lib/src/dom/webgl_debug_shaders.dart
+++ b/lib/src/dom/webgl_debug_shaders.dart
@@ -16,6 +16,6 @@ class WEBGL_debug_shaders {
   external factory WEBGL_debug_shaders();
 }
 
-extension WEBGL_debug_shadersExtension on WEBGL_debug_shaders {
+extension WEBGLDebugShadersExtension on WEBGL_debug_shaders {
   external JSString getTranslatedShaderSource(WebGLShader shader);
 }

--- a/lib/src/dom/webgl_draw_buffers.dart
+++ b/lib/src/dom/webgl_draw_buffers.dart
@@ -51,6 +51,6 @@ class WEBGL_draw_buffers {
   external static GLenum get MAX_DRAW_BUFFERS_WEBGL;
 }
 
-extension WEBGL_draw_buffersExtension on WEBGL_draw_buffers {
+extension WEBGLDrawBuffersExtension on WEBGL_draw_buffers {
   external JSVoid drawBuffersWEBGL(JSArray buffers);
 }

--- a/lib/src/dom/webgl_draw_instanced_base_vertex_base_instance.dart
+++ b/lib/src/dom/webgl_draw_instanced_base_vertex_base_instance.dart
@@ -16,7 +16,7 @@ class WEBGL_draw_instanced_base_vertex_base_instance {
   external factory WEBGL_draw_instanced_base_vertex_base_instance();
 }
 
-extension WEBGL_draw_instanced_base_vertex_base_instanceExtension
+extension WEBGLDrawInstancedBaseVertexBaseInstanceExtension
     on WEBGL_draw_instanced_base_vertex_base_instance {
   external JSVoid drawArraysInstancedBaseInstanceWEBGL(
     GLenum mode,

--- a/lib/src/dom/webgl_lose_context.dart
+++ b/lib/src/dom/webgl_lose_context.dart
@@ -14,7 +14,7 @@ class WEBGL_lose_context {
   external factory WEBGL_lose_context();
 }
 
-extension WEBGL_lose_contextExtension on WEBGL_lose_context {
+extension WEBGLLoseContextExtension on WEBGL_lose_context {
   external JSVoid loseContext();
   external JSVoid restoreContext();
 }

--- a/lib/src/dom/webgl_multi_draw.dart
+++ b/lib/src/dom/webgl_multi_draw.dart
@@ -16,7 +16,7 @@ class WEBGL_multi_draw {
   external factory WEBGL_multi_draw();
 }
 
-extension WEBGL_multi_drawExtension on WEBGL_multi_draw {
+extension WEBGLMultiDrawExtension on WEBGL_multi_draw {
   external JSVoid multiDrawArraysWEBGL(
     GLenum mode,
     JSAny firstsList,

--- a/lib/src/dom/webgl_multi_draw_instanced_base_vertex_base_instance.dart
+++ b/lib/src/dom/webgl_multi_draw_instanced_base_vertex_base_instance.dart
@@ -16,7 +16,7 @@ class WEBGL_multi_draw_instanced_base_vertex_base_instance {
   external factory WEBGL_multi_draw_instanced_base_vertex_base_instance();
 }
 
-extension WEBGL_multi_draw_instanced_base_vertex_base_instanceExtension
+extension WEBGLMultiDrawInstancedBaseVertexBaseInstanceExtension
     on WEBGL_multi_draw_instanced_base_vertex_base_instance {
   external JSVoid multiDrawArraysInstancedBaseInstanceWEBGL(
     GLenum mode,

--- a/lib/src/dom/webgl_provoking_vertex.dart
+++ b/lib/src/dom/webgl_provoking_vertex.dart
@@ -20,6 +20,6 @@ class WEBGL_provoking_vertex {
   external static GLenum get PROVOKING_VERTEX_WEBGL;
 }
 
-extension WEBGL_provoking_vertexExtension on WEBGL_provoking_vertex {
+extension WEBGLProvokingVertexExtension on WEBGL_provoking_vertex {
   external JSVoid provokingVertexWEBGL(GLenum provokeMode);
 }

--- a/lib/src/dom/webgpu.dart
+++ b/lib/src/dom/webgpu.dart
@@ -289,12 +289,12 @@ class GPUBufferDescriptor extends GPUObjectDescriptorBase {
 extension GPUBufferDescriptorExtension on GPUBufferDescriptor {}
 
 @JS()
-external GPUBufferUsage_ get GPUBufferUsage;
+external $GPUBufferUsage get GPUBufferUsage;
 
 @JS('GPUBufferUsage')
 @staticInterop
-class GPUBufferUsage_ {
-  external factory GPUBufferUsage_();
+abstract class $GPUBufferUsage {
+  external factory $GPUBufferUsage();
 
   external static GPUFlagsConstant get MAP_READ;
   external static GPUFlagsConstant get MAP_WRITE;
@@ -309,12 +309,12 @@ class GPUBufferUsage_ {
 }
 
 @JS()
-external GPUMapMode_ get GPUMapMode;
+external $GPUMapMode get GPUMapMode;
 
 @JS('GPUMapMode')
 @staticInterop
-class GPUMapMode_ {
-  external factory GPUMapMode_();
+abstract class $GPUMapMode {
+  external factory $GPUMapMode();
 
   external static GPUFlagsConstant get READ;
   external static GPUFlagsConstant get WRITE;
@@ -349,12 +349,12 @@ class GPUTextureDescriptor extends GPUObjectDescriptorBase {
 extension GPUTextureDescriptorExtension on GPUTextureDescriptor {}
 
 @JS()
-external GPUTextureUsage_ get GPUTextureUsage;
+external $GPUTextureUsage get GPUTextureUsage;
 
 @JS('GPUTextureUsage')
 @staticInterop
-class GPUTextureUsage_ {
-  external factory GPUTextureUsage_();
+abstract class $GPUTextureUsage {
+  external factory $GPUTextureUsage();
 
   external static GPUFlagsConstant get COPY_SRC;
   external static GPUFlagsConstant get COPY_DST;
@@ -430,12 +430,12 @@ class GPUBindGroupLayoutEntry {
 extension GPUBindGroupLayoutEntryExtension on GPUBindGroupLayoutEntry {}
 
 @JS()
-external GPUShaderStage_ get GPUShaderStage;
+external $GPUShaderStage get GPUShaderStage;
 
 @JS('GPUShaderStage')
 @staticInterop
-class GPUShaderStage_ {
-  external factory GPUShaderStage_();
+abstract class $GPUShaderStage {
+  external factory $GPUShaderStage();
 
   external static GPUFlagsConstant get VERTEX;
   external static GPUFlagsConstant get FRAGMENT;
@@ -696,12 +696,12 @@ class GPUBlendState {
 extension GPUBlendStateExtension on GPUBlendState {}
 
 @JS()
-external GPUColorWrite_ get GPUColorWrite;
+external $GPUColorWrite get GPUColorWrite;
 
 @JS('GPUColorWrite')
 @staticInterop
-class GPUColorWrite_ {
-  external factory GPUColorWrite_();
+abstract class $GPUColorWrite {
+  external factory $GPUColorWrite();
 
   external static GPUFlagsConstant get RED;
   external static GPUFlagsConstant get GREEN;

--- a/lib/src/dom/webgpu.dart
+++ b/lib/src/dom/webgpu.dart
@@ -289,12 +289,12 @@ class GPUBufferDescriptor extends GPUObjectDescriptorBase {
 extension GPUBufferDescriptorExtension on GPUBufferDescriptor {}
 
 @JS()
-external _GPUBufferUsage get GPUBufferUsage;
+external GPUBufferUsage_ get GPUBufferUsage;
 
 @JS('GPUBufferUsage')
 @staticInterop
-class _GPUBufferUsage {
-  external factory _GPUBufferUsage();
+class GPUBufferUsage_ {
+  external factory GPUBufferUsage_();
 
   external static GPUFlagsConstant get MAP_READ;
   external static GPUFlagsConstant get MAP_WRITE;
@@ -309,12 +309,12 @@ class _GPUBufferUsage {
 }
 
 @JS()
-external _GPUMapMode get GPUMapMode;
+external GPUMapMode_ get GPUMapMode;
 
 @JS('GPUMapMode')
 @staticInterop
-class _GPUMapMode {
-  external factory _GPUMapMode();
+class GPUMapMode_ {
+  external factory GPUMapMode_();
 
   external static GPUFlagsConstant get READ;
   external static GPUFlagsConstant get WRITE;
@@ -349,12 +349,12 @@ class GPUTextureDescriptor extends GPUObjectDescriptorBase {
 extension GPUTextureDescriptorExtension on GPUTextureDescriptor {}
 
 @JS()
-external _GPUTextureUsage get GPUTextureUsage;
+external GPUTextureUsage_ get GPUTextureUsage;
 
 @JS('GPUTextureUsage')
 @staticInterop
-class _GPUTextureUsage {
-  external factory _GPUTextureUsage();
+class GPUTextureUsage_ {
+  external factory GPUTextureUsage_();
 
   external static GPUFlagsConstant get COPY_SRC;
   external static GPUFlagsConstant get COPY_DST;
@@ -430,12 +430,12 @@ class GPUBindGroupLayoutEntry {
 extension GPUBindGroupLayoutEntryExtension on GPUBindGroupLayoutEntry {}
 
 @JS()
-external _GPUShaderStage get GPUShaderStage;
+external GPUShaderStage_ get GPUShaderStage;
 
 @JS('GPUShaderStage')
 @staticInterop
-class _GPUShaderStage {
-  external factory _GPUShaderStage();
+class GPUShaderStage_ {
+  external factory GPUShaderStage_();
 
   external static GPUFlagsConstant get VERTEX;
   external static GPUFlagsConstant get FRAGMENT;
@@ -696,12 +696,12 @@ class GPUBlendState {
 extension GPUBlendStateExtension on GPUBlendState {}
 
 @JS()
-external _GPUColorWrite get GPUColorWrite;
+external GPUColorWrite_ get GPUColorWrite;
 
 @JS('GPUColorWrite')
 @staticInterop
-class _GPUColorWrite {
-  external factory _GPUColorWrite();
+class GPUColorWrite_ {
+  external factory GPUColorWrite_();
 
   external static GPUFlagsConstant get RED;
   external static GPUFlagsConstant get GREEN;

--- a/tool/bindings_generator/generate_bindings.dart
+++ b/tool/bindings_generator/generate_bindings.dart
@@ -4,6 +4,7 @@
 
 import 'dart:js_interop';
 import 'dart:js_util';
+
 import 'translator.dart';
 import 'util.dart';
 import 'webref_idl_api.dart';
@@ -14,7 +15,7 @@ Future<TranslationResult> generateBindings(
   final array = objectEntries(await promiseToFuture<JSObject>(idl.parseAll()));
   for (var i = 0; i < array.length; i++) {
     final entry = array[i] as JSArray;
-    final shortname = kebabToSnake((entry[0] as JSString).toDart);
+    final shortname = (entry[0] as JSString).toDart.kebabToSnake;
     final ast = entry[1] as JSArray;
     translator.collect(shortname, ast);
   }

--- a/tool/bindings_generator/translator.dart
+++ b/tool/bindings_generator/translator.dart
@@ -222,23 +222,6 @@ class Translator {
     ..name = name
     ..definition = _typeReference(type));
 
-  code.TypeDef _translateTypedef(idl.Typedef typedef) =>
-      _typedef(typedef.name.toDart, _typeRaw(typedef.idlType));
-
-  // TODO(joshualitt): We should lower callbacks and callback interfaces to a
-  // Dart function that takes a typed Dart function, and returns an JSFunction.
-  code.TypeDef _translateCallback(idl.Callback callback) =>
-      _typedef(callback.name.toDart, 'JSFunction');
-
-  code.TypeDef _translateCallbackInterface(
-          idl.Interfacelike callbackInterface) =>
-      _typedef(callbackInterface.name.toDart, 'JSFunction');
-
-  // TODO(joshualitt): Enums in the WebIDL are just strings, but we could make
-  // them easier to work with on the Dart side.
-  code.TypeDef _translateEnum(idl.Enum enum_) =>
-      _typedef(enum_.name.toDart, 'JSString');
-
   code.Method _topLevelGetter(String dartName, String getterName) =>
       code.Method((b) => b
         ..annotations.addAll(_jsOverride(''))
@@ -456,7 +439,7 @@ class Translator {
     // Namespaces have lowercase names. We also translate them to
     // private classes, and make their first character uppercase in the process.
     final dartClassName = type == 'namespace'
-        ? '_${jsName[0].toUpperCase()}${jsName.substring(1)}'
+        ? '${jsName[0].toUpperCase()}${jsName.substring(1)}_'
         : jsName;
 
     // We create a getter for namespaces with the expected name. We also create

--- a/tool/bindings_generator/translator.dart
+++ b/tool/bindings_generator/translator.dart
@@ -406,7 +406,7 @@ class Translator {
 
   code.Extension _extension(String name, List<idl.Member> members) =>
       code.Extension((b) => b
-        ..name = '${name}Extension'
+        ..name = '${name.snakeToPascal}Extension'
         ..on = _typeReference(name)
         ..methods.addAll(_members(members)));
 

--- a/tool/bindings_generator/util.dart
+++ b/tool/bindings_generator/util.dart
@@ -3,7 +3,9 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:js_interop';
+
 import 'package:js/js.dart';
+
 import 'filesystem_api.dart';
 
 // TODO(joshualitt): Let's find a better place for these.
@@ -30,6 +32,15 @@ final List<String> licenseHeader = [
   'BSD-style license that can be found in the LICENSE file.',
 ];
 
-String kebabToSnake(String input) => input.toLowerCase().replaceAll('-', '_');
+extension StringExt on String {
+  String get kebabToSnake => toLowerCase().replaceAll('-', '_');
+
+  String get snakeToPascal => replaceAllMapped(
+        _snakeBit,
+        (match) => match[0]!.toUpperCase(),
+      ).replaceAll('_', '');
+}
+
+final _snakeBit = RegExp('_[a-zA-Z]');
 
 const packageRoot = 'package:web';


### PR DESCRIPTION
Avoids making types private
Remove associated ignores from analysis options
