### PR TITLE
Cleanup handling of overridden functions / constructors

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -16,7 +16,6 @@ analyzer:
 linter:
   rules:
   - avoid_bool_literals_in_conditional_expressions
-  - avoid_classes_with_only_static_members
   - avoid_private_typedef_functions
   - avoid_redundant_argument_values
   - avoid_returning_null

--- a/lib/src/dom/accelerometer.dart
+++ b/lib/src/dom/accelerometer.dart
@@ -14,12 +14,8 @@ typedef AccelerometerLocalCoordinateSystem = JSString;
 
 @JS('Accelerometer')
 @staticInterop
-class Accelerometer extends Sensor {
-  external factory Accelerometer();
-
-  external factory Accelerometer.a1();
-
-  external factory Accelerometer.a2(AccelerometerSensorOptions options);
+class Accelerometer implements Sensor {
+  external factory Accelerometer([AccelerometerSensorOptions options]);
 }
 
 extension AccelerometerExtension on Accelerometer {
@@ -31,7 +27,7 @@ extension AccelerometerExtension on Accelerometer {
 @JS()
 @staticInterop
 @anonymous
-class AccelerometerSensorOptions extends SensorOptions {
+class AccelerometerSensorOptions implements SensorOptions {
   external factory AccelerometerSensorOptions(
       {AccelerometerLocalCoordinateSystem referenceFrame = 'device'});
 }
@@ -43,23 +39,15 @@ extension AccelerometerSensorOptionsExtension on AccelerometerSensorOptions {
 
 @JS('LinearAccelerationSensor')
 @staticInterop
-class LinearAccelerationSensor extends Accelerometer {
-  external factory LinearAccelerationSensor();
-
-  external factory LinearAccelerationSensor.a1();
-
-  external factory LinearAccelerationSensor.a2(
-      AccelerometerSensorOptions options);
+class LinearAccelerationSensor implements Accelerometer {
+  external factory LinearAccelerationSensor(
+      [AccelerometerSensorOptions options]);
 }
 
 @JS('GravitySensor')
 @staticInterop
-class GravitySensor extends Accelerometer {
-  external factory GravitySensor();
-
-  external factory GravitySensor.a1();
-
-  external factory GravitySensor.a2(AccelerometerSensorOptions options);
+class GravitySensor implements Accelerometer {
+  external factory GravitySensor([AccelerometerSensorOptions options]);
 }
 
 @JS()
@@ -85,13 +73,13 @@ extension AccelerometerReadingValuesExtension on AccelerometerReadingValues {
 @JS()
 @staticInterop
 @anonymous
-class LinearAccelerationReadingValues extends AccelerometerReadingValues {
+class LinearAccelerationReadingValues implements AccelerometerReadingValues {
   external factory LinearAccelerationReadingValues();
 }
 
 @JS()
 @staticInterop
 @anonymous
-class GravityReadingValues extends AccelerometerReadingValues {
+class GravityReadingValues implements AccelerometerReadingValues {
   external factory GravityReadingValues();
 }

--- a/lib/src/dom/ambient_light.dart
+++ b/lib/src/dom/ambient_light.dart
@@ -12,12 +12,8 @@ import 'generic_sensor.dart';
 
 @JS('AmbientLightSensor')
 @staticInterop
-class AmbientLightSensor extends Sensor {
-  external factory AmbientLightSensor();
-
-  external factory AmbientLightSensor.a1();
-
-  external factory AmbientLightSensor.a2(SensorOptions sensorOptions);
+class AmbientLightSensor implements Sensor {
+  external factory AmbientLightSensor([SensorOptions sensorOptions]);
 }
 
 extension AmbientLightSensorExtension on AmbientLightSensor {

--- a/lib/src/dom/anchors.dart
+++ b/lib/src/dom/anchors.dart
@@ -12,20 +12,16 @@ import 'webxr.dart';
 
 @JS('XRAnchor')
 @staticInterop
-class XRAnchor {
-  external factory XRAnchor();
-}
+class XRAnchor {}
 
 extension XRAnchorExtension on XRAnchor {
-  external XRSpace get anchorSpace;
   external JSPromise requestPersistentHandle();
   external JSVoid delete();
+  external XRSpace get anchorSpace;
 }
 
 @JS('XRAnchorSet')
 @staticInterop
-class XRAnchorSet {
-  external factory XRAnchorSet();
-}
+class XRAnchorSet {}
 
 extension XRAnchorSetExtension on XRAnchorSet {}

--- a/lib/src/dom/angle_instanced_arrays.dart
+++ b/lib/src/dom/angle_instanced_arrays.dart
@@ -13,8 +13,6 @@ import 'webgl1.dart';
 @JS('ANGLE_instanced_arrays')
 @staticInterop
 class ANGLE_instanced_arrays {
-  external factory ANGLE_instanced_arrays();
-
   external static GLenum get VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE;
 }
 

--- a/lib/src/dom/attribution_reporting_api.dart
+++ b/lib/src/dom/attribution_reporting_api.dart
@@ -10,9 +10,7 @@ import 'package:js/js.dart' hide JS;
 
 @JS('HTMLAttributionSrcElementUtils')
 @staticInterop
-class HTMLAttributionSrcElementUtils {
-  external factory HTMLAttributionSrcElementUtils();
-}
+class HTMLAttributionSrcElementUtils {}
 
 extension HTMLAttributionSrcElementUtilsExtension
     on HTMLAttributionSrcElementUtils {

--- a/lib/src/dom/background_fetch.dart
+++ b/lib/src/dom/background_fetch.dart
@@ -18,20 +18,14 @@ typedef BackgroundFetchFailureReason = JSString;
 
 @JS('BackgroundFetchManager')
 @staticInterop
-class BackgroundFetchManager {
-  external factory BackgroundFetchManager();
-}
+class BackgroundFetchManager {}
 
 extension BackgroundFetchManagerExtension on BackgroundFetchManager {
   external JSPromise fetch(
     JSString id,
-    JSAny requests,
-  );
-  external JSPromise fetch1(
-    JSString id,
-    JSAny requests,
+    JSAny requests, [
     BackgroundFetchOptions options,
-  );
+  ]);
   external JSPromise get(JSString id);
   external JSPromise getIds();
 }
@@ -56,7 +50,7 @@ extension BackgroundFetchUIOptionsExtension on BackgroundFetchUIOptions {
 @JS()
 @staticInterop
 @anonymous
-class BackgroundFetchOptions extends BackgroundFetchUIOptions {
+class BackgroundFetchOptions implements BackgroundFetchUIOptions {
   external factory BackgroundFetchOptions({JSNumber downloadTotal = 0});
 }
 
@@ -67,11 +61,18 @@ extension BackgroundFetchOptionsExtension on BackgroundFetchOptions {
 
 @JS('BackgroundFetchRegistration')
 @staticInterop
-class BackgroundFetchRegistration extends EventTarget {
-  external factory BackgroundFetchRegistration();
-}
+class BackgroundFetchRegistration implements EventTarget {}
 
 extension BackgroundFetchRegistrationExtension on BackgroundFetchRegistration {
+  external JSPromise abort();
+  external JSPromise match(
+    RequestInfo request, [
+    CacheQueryOptions options,
+  ]);
+  external JSPromise matchAll([
+    RequestInfo request,
+    CacheQueryOptions options,
+  ]);
   external JSString get id;
   external JSNumber get uploadTotal;
   external JSNumber get uploaded;
@@ -82,25 +83,11 @@ extension BackgroundFetchRegistrationExtension on BackgroundFetchRegistration {
   external JSBoolean get recordsAvailable;
   external set onprogress(EventHandler value);
   external EventHandler get onprogress;
-  external JSPromise abort();
-  external JSPromise match(RequestInfo request);
-  external JSPromise match1(
-    RequestInfo request,
-    CacheQueryOptions options,
-  );
-  external JSPromise matchAll();
-  external JSPromise matchAll1(RequestInfo request);
-  external JSPromise matchAll2(
-    RequestInfo request,
-    CacheQueryOptions options,
-  );
 }
 
 @JS('BackgroundFetchRecord')
 @staticInterop
-class BackgroundFetchRecord {
-  external factory BackgroundFetchRecord();
-}
+class BackgroundFetchRecord {}
 
 extension BackgroundFetchRecordExtension on BackgroundFetchRecord {
   external Request get request;
@@ -109,10 +96,8 @@ extension BackgroundFetchRecordExtension on BackgroundFetchRecord {
 
 @JS('BackgroundFetchEvent')
 @staticInterop
-class BackgroundFetchEvent extends ExtendableEvent {
-  external factory BackgroundFetchEvent();
-
-  external factory BackgroundFetchEvent.a1(
+class BackgroundFetchEvent implements ExtendableEvent {
+  external factory BackgroundFetchEvent(
     JSString type,
     BackgroundFetchEventInit init,
   );
@@ -125,7 +110,7 @@ extension BackgroundFetchEventExtension on BackgroundFetchEvent {
 @JS()
 @staticInterop
 @anonymous
-class BackgroundFetchEventInit extends ExtendableEventInit {
+class BackgroundFetchEventInit implements ExtendableEventInit {
   external factory BackgroundFetchEventInit(
       {required BackgroundFetchRegistration registration});
 }
@@ -137,10 +122,8 @@ extension BackgroundFetchEventInitExtension on BackgroundFetchEventInit {
 
 @JS('BackgroundFetchUpdateUIEvent')
 @staticInterop
-class BackgroundFetchUpdateUIEvent extends BackgroundFetchEvent {
-  external factory BackgroundFetchUpdateUIEvent();
-
-  external factory BackgroundFetchUpdateUIEvent.a1(
+class BackgroundFetchUpdateUIEvent implements BackgroundFetchEvent {
+  external factory BackgroundFetchUpdateUIEvent(
     JSString type,
     BackgroundFetchEventInit init,
   );
@@ -148,6 +131,5 @@ class BackgroundFetchUpdateUIEvent extends BackgroundFetchEvent {
 
 extension BackgroundFetchUpdateUIEventExtension
     on BackgroundFetchUpdateUIEvent {
-  external JSPromise updateUI();
-  external JSPromise updateUI1(BackgroundFetchUIOptions options);
+  external JSPromise updateUI([BackgroundFetchUIOptions options]);
 }

--- a/lib/src/dom/background_sync.dart
+++ b/lib/src/dom/background_sync.dart
@@ -12,9 +12,7 @@ import 'service_workers.dart';
 
 @JS('SyncManager')
 @staticInterop
-class SyncManager {
-  external factory SyncManager();
-}
+class SyncManager {}
 
 extension SyncManagerExtension on SyncManager {
   external JSPromise register(JSString tag);
@@ -23,10 +21,8 @@ extension SyncManagerExtension on SyncManager {
 
 @JS('SyncEvent')
 @staticInterop
-class SyncEvent extends ExtendableEvent {
-  external factory SyncEvent();
-
-  external factory SyncEvent.a1(
+class SyncEvent implements ExtendableEvent {
+  external factory SyncEvent(
     JSString type,
     SyncEventInit init,
   );
@@ -40,7 +36,7 @@ extension SyncEventExtension on SyncEvent {
 @JS()
 @staticInterop
 @anonymous
-class SyncEventInit extends ExtendableEventInit {
+class SyncEventInit implements ExtendableEventInit {
   external factory SyncEventInit({
     required JSString tag,
     JSBoolean lastChance = false,

--- a/lib/src/dom/badging.dart
+++ b/lib/src/dom/badging.dart
@@ -10,12 +10,9 @@ import 'package:js/js.dart' hide JS;
 
 @JS('NavigatorBadge')
 @staticInterop
-class NavigatorBadge {
-  external factory NavigatorBadge();
-}
+class NavigatorBadge {}
 
 extension NavigatorBadgeExtension on NavigatorBadge {
-  external JSPromise setAppBadge();
-  external JSPromise setAppBadge1(JSNumber contents);
+  external JSPromise setAppBadge([JSNumber contents]);
   external JSPromise clearAppBadge();
 }

--- a/lib/src/dom/battery_status.dart
+++ b/lib/src/dom/battery_status.dart
@@ -13,9 +13,7 @@ import 'html.dart';
 
 @JS('BatteryManager')
 @staticInterop
-class BatteryManager extends EventTarget {
-  external factory BatteryManager();
-}
+class BatteryManager implements EventTarget {}
 
 extension BatteryManagerExtension on BatteryManager {
   external JSBoolean get charging;

--- a/lib/src/dom/clipboard_apis.dart
+++ b/lib/src/dom/clipboard_apis.dart
@@ -19,7 +19,7 @@ typedef PresentationStyle = JSString;
 @JS()
 @staticInterop
 @anonymous
-class ClipboardEventInit extends EventInit {
+class ClipboardEventInit implements EventInit {
   external factory ClipboardEventInit({DataTransfer? clipboardData});
 }
 
@@ -30,15 +30,11 @@ extension ClipboardEventInitExtension on ClipboardEventInit {
 
 @JS('ClipboardEvent')
 @staticInterop
-class ClipboardEvent extends Event {
-  external factory ClipboardEvent();
-
-  external factory ClipboardEvent.a1(JSString type);
-
-  external factory ClipboardEvent.a2(
-    JSString type,
+class ClipboardEvent implements Event {
+  external factory ClipboardEvent(
+    JSString type, [
     ClipboardEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension ClipboardEventExtension on ClipboardEvent {
@@ -48,20 +44,16 @@ extension ClipboardEventExtension on ClipboardEvent {
 @JS('ClipboardItem')
 @staticInterop
 class ClipboardItem {
-  external factory ClipboardItem();
-
-  external factory ClipboardItem.a1(JSAny items);
-
-  external factory ClipboardItem.a2(
-    JSAny items,
+  external factory ClipboardItem(
+    JSAny items, [
     ClipboardItemOptions options,
-  );
+  ]);
 }
 
 extension ClipboardItemExtension on ClipboardItem {
+  external JSPromise getType(JSString type);
   external PresentationStyle get presentationStyle;
   external JSArray get types;
-  external JSPromise getType(JSString type);
 }
 
 @JS()
@@ -79,9 +71,7 @@ extension ClipboardItemOptionsExtension on ClipboardItemOptions {
 
 @JS('Clipboard')
 @staticInterop
-class Clipboard extends EventTarget {
-  external factory Clipboard();
-}
+class Clipboard implements EventTarget {}
 
 extension ClipboardExtension on Clipboard {
   external JSPromise read();
@@ -93,7 +83,7 @@ extension ClipboardExtension on Clipboard {
 @JS()
 @staticInterop
 @anonymous
-class ClipboardPermissionDescriptor extends PermissionDescriptor {
+class ClipboardPermissionDescriptor implements PermissionDescriptor {
   external factory ClipboardPermissionDescriptor(
       {JSBoolean allowWithoutGesture = false});
 }

--- a/lib/src/dom/close_watcher.dart
+++ b/lib/src/dom/close_watcher.dart
@@ -13,12 +13,8 @@ import 'html.dart';
 
 @JS('CloseWatcher')
 @staticInterop
-class CloseWatcher extends EventTarget {
-  external factory CloseWatcher();
-
-  external factory CloseWatcher.a1();
-
-  external factory CloseWatcher.a2(CloseWatcherOptions options);
+class CloseWatcher implements EventTarget {
+  external factory CloseWatcher([CloseWatcherOptions options]);
 }
 
 extension CloseWatcherExtension on CloseWatcher {

--- a/lib/src/dom/compression.dart
+++ b/lib/src/dom/compression.dart
@@ -13,15 +13,11 @@ import 'streams.dart';
 @JS('CompressionStream')
 @staticInterop
 class CompressionStream implements GenericTransformStream {
-  external factory CompressionStream();
-
-  external factory CompressionStream.a1(JSString format);
+  external factory CompressionStream(JSString format);
 }
 
 @JS('DecompressionStream')
 @staticInterop
 class DecompressionStream implements GenericTransformStream {
-  external factory DecompressionStream();
-
-  external factory DecompressionStream.a1(JSString format);
+  external factory DecompressionStream(JSString format);
 }

--- a/lib/src/dom/compute_pressure.dart
+++ b/lib/src/dom/compute_pressure.dart
@@ -18,14 +18,10 @@ typedef PressureSource = JSString;
 @JS('PressureObserver')
 @staticInterop
 class PressureObserver {
-  external factory PressureObserver();
-
-  external factory PressureObserver.a1(PressureUpdateCallback callback);
-
-  external factory PressureObserver.a2(
-    PressureUpdateCallback callback,
+  external factory PressureObserver(
+    PressureUpdateCallback callback, [
     PressureObserverOptions options,
-  );
+  ]);
 
   external static JSArray get supportedSources;
 }
@@ -39,16 +35,14 @@ extension PressureObserverExtension on PressureObserver {
 
 @JS('PressureRecord')
 @staticInterop
-class PressureRecord {
-  external factory PressureRecord();
-}
+class PressureRecord {}
 
 extension PressureRecordExtension on PressureRecord {
+  external JSObject toJSON();
   external PressureSource get source;
   external PressureState get state;
   external JSArray get factors;
   external DOMHighResTimeStamp get time;
-  external JSObject toJSON();
 }
 
 @JS()

--- a/lib/src/dom/console.dart
+++ b/lib/src/dom/console.dart
@@ -13,52 +13,39 @@ external $Console get console;
 
 @JS('console')
 @staticInterop
-abstract class $Console {
-  external factory $Console();
-}
+abstract class $Console {}
 
 extension $ConsoleExtension on $Console {
   @JS('assert')
-  external JSVoid assert_0_();
-  @JS('assert')
-  external JSVoid assert_0_1(
+  external JSVoid assert_(
+    JSAny data, [
     JSBoolean condition,
-    JSAny data,
-  );
+  ]);
   external JSVoid clear();
   external JSVoid debug(JSAny data);
   external JSVoid error(JSAny data);
   external JSVoid info(JSAny data);
   external JSVoid log(JSAny data);
-  external JSVoid table();
-  external JSVoid table1(JSAny tabularData);
-  external JSVoid table2(
+  external JSVoid table([
     JSAny tabularData,
     JSArray properties,
-  );
+  ]);
   external JSVoid trace(JSAny data);
   external JSVoid warn(JSAny data);
-  external JSVoid dir();
-  external JSVoid dir1(JSAny item);
-  external JSVoid dir2(
+  external JSVoid dir([
     JSAny item,
     JSObject? options,
-  );
+  ]);
   external JSVoid dirxml(JSAny data);
-  external JSVoid count();
-  external JSVoid count1(JSString label);
-  external JSVoid countReset();
-  external JSVoid countReset1(JSString label);
+  external JSVoid count([JSString label]);
+  external JSVoid countReset([JSString label]);
   external JSVoid group(JSAny data);
   external JSVoid groupCollapsed(JSAny data);
   external JSVoid groupEnd();
-  external JSVoid time();
-  external JSVoid time1(JSString label);
-  external JSVoid timeLog();
-  external JSVoid timeLog1(
+  external JSVoid time([JSString label]);
+  external JSVoid timeLog(
+    JSAny data, [
     JSString label,
-    JSAny data,
-  );
-  external JSVoid timeEnd();
-  external JSVoid timeEnd1(JSString label);
+  ]);
+  external JSVoid timeEnd([JSString label]);
 }

--- a/lib/src/dom/contact_picker.dart
+++ b/lib/src/dom/contact_picker.dart
@@ -12,9 +12,7 @@ typedef ContactProperty = JSString;
 
 @JS('ContactAddress')
 @staticInterop
-class ContactAddress {
-  external factory ContactAddress();
-}
+class ContactAddress {}
 
 extension ContactAddressExtension on ContactAddress {
   external JSObject toJSON();
@@ -70,15 +68,12 @@ extension ContactsSelectOptionsExtension on ContactsSelectOptions {
 
 @JS('ContactsManager')
 @staticInterop
-class ContactsManager {
-  external factory ContactsManager();
-}
+class ContactsManager {}
 
 extension ContactsManagerExtension on ContactsManager {
   external JSPromise getProperties();
-  external JSPromise select(JSArray properties);
-  external JSPromise select1(
-    JSArray properties,
+  external JSPromise select(
+    JSArray properties, [
     ContactsSelectOptions options,
-  );
+  ]);
 }

--- a/lib/src/dom/content_index.dart
+++ b/lib/src/dom/content_index.dart
@@ -43,9 +43,7 @@ extension ContentDescriptionExtension on ContentDescription {
 
 @JS('ContentIndex')
 @staticInterop
-class ContentIndex {
-  external factory ContentIndex();
-}
+class ContentIndex {}
 
 extension ContentIndexExtension on ContentIndex {
   external JSPromise add(ContentDescription description);
@@ -56,7 +54,7 @@ extension ContentIndexExtension on ContentIndex {
 @JS()
 @staticInterop
 @anonymous
-class ContentIndexEventInit extends ExtendableEventInit {
+class ContentIndexEventInit implements ExtendableEventInit {
   external factory ContentIndexEventInit({required JSString id});
 }
 
@@ -67,10 +65,8 @@ extension ContentIndexEventInitExtension on ContentIndexEventInit {
 
 @JS('ContentIndexEvent')
 @staticInterop
-class ContentIndexEvent extends ExtendableEvent {
-  external factory ContentIndexEvent();
-
-  external factory ContentIndexEvent.a1(
+class ContentIndexEvent implements ExtendableEvent {
+  external factory ContentIndexEvent(
     JSString type,
     ContentIndexEventInit init,
   );

--- a/lib/src/dom/cookie_store.dart
+++ b/lib/src/dom/cookie_store.dart
@@ -18,30 +18,16 @@ typedef CookieSameSite = JSString;
 
 @JS('CookieStore')
 @staticInterop
-class CookieStore extends EventTarget {
-  external factory CookieStore();
-}
+class CookieStore implements EventTarget {}
 
 extension CookieStoreExtension on CookieStore {
-  external JSPromise get(JSString name);
-  @JS('get')
-  external JSPromise get_1_();
-  @JS('get')
-  external JSPromise get_1_1(CookieStoreGetOptions options);
-  external JSPromise getAll(JSString name);
-  @JS('getAll')
-  external JSPromise getAll_1_();
-  @JS('getAll')
-  external JSPromise getAll_1_1(CookieStoreGetOptions options);
+  external JSPromise get([JSAny nameOrOptions]);
+  external JSPromise getAll([JSAny nameOrOptions]);
   external JSPromise set(
-    JSString name,
+    JSAny nameOrOptions, [
     JSString value,
-  );
-  @JS('set')
-  external JSPromise set_1_(CookieInit options);
-  external JSPromise delete(JSString name);
-  @JS('delete')
-  external JSPromise delete_1_(CookieStoreDeleteOptions options);
+  ]);
+  external JSPromise delete(JSAny nameOrOptions);
   external set onchange(EventHandler value);
   external EventHandler get onchange;
 }
@@ -146,9 +132,7 @@ extension CookieListItemExtension on CookieListItem {
 
 @JS('CookieStoreManager')
 @staticInterop
-class CookieStoreManager {
-  external factory CookieStoreManager();
-}
+class CookieStoreManager {}
 
 extension CookieStoreManagerExtension on CookieStoreManager {
   external JSPromise subscribe(JSArray subscriptions);
@@ -158,15 +142,11 @@ extension CookieStoreManagerExtension on CookieStoreManager {
 
 @JS('CookieChangeEvent')
 @staticInterop
-class CookieChangeEvent extends Event {
-  external factory CookieChangeEvent();
-
-  external factory CookieChangeEvent.a1(JSString type);
-
-  external factory CookieChangeEvent.a2(
-    JSString type,
+class CookieChangeEvent implements Event {
+  external factory CookieChangeEvent(
+    JSString type, [
     CookieChangeEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension CookieChangeEventExtension on CookieChangeEvent {
@@ -177,7 +157,7 @@ extension CookieChangeEventExtension on CookieChangeEvent {
 @JS()
 @staticInterop
 @anonymous
-class CookieChangeEventInit extends EventInit {
+class CookieChangeEventInit implements EventInit {
   external factory CookieChangeEventInit({
     CookieList changed,
     CookieList deleted,
@@ -193,15 +173,11 @@ extension CookieChangeEventInitExtension on CookieChangeEventInit {
 
 @JS('ExtendableCookieChangeEvent')
 @staticInterop
-class ExtendableCookieChangeEvent extends ExtendableEvent {
-  external factory ExtendableCookieChangeEvent();
-
-  external factory ExtendableCookieChangeEvent.a1(JSString type);
-
-  external factory ExtendableCookieChangeEvent.a2(
-    JSString type,
+class ExtendableCookieChangeEvent implements ExtendableEvent {
+  external factory ExtendableCookieChangeEvent(
+    JSString type, [
     ExtendableCookieChangeEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension ExtendableCookieChangeEventExtension on ExtendableCookieChangeEvent {
@@ -212,7 +188,7 @@ extension ExtendableCookieChangeEventExtension on ExtendableCookieChangeEvent {
 @JS()
 @staticInterop
 @anonymous
-class ExtendableCookieChangeEventInit extends ExtendableEventInit {
+class ExtendableCookieChangeEventInit implements ExtendableEventInit {
   external factory ExtendableCookieChangeEventInit({
     CookieList changed,
     CookieList deleted,

--- a/lib/src/dom/crash_reporting.dart
+++ b/lib/src/dom/crash_reporting.dart
@@ -12,9 +12,7 @@ import 'reporting.dart';
 
 @JS('CrashReportBody')
 @staticInterop
-class CrashReportBody extends ReportBody {
-  external factory CrashReportBody();
-}
+class CrashReportBody implements ReportBody {}
 
 extension CrashReportBodyExtension on CrashReportBody {
   external JSObject toJSON();

--- a/lib/src/dom/credential_management.dart
+++ b/lib/src/dom/credential_management.dart
@@ -10,7 +10,6 @@ import 'package:js/js.dart' hide JS;
 
 import 'dom.dart';
 import 'fedcm.dart';
-import 'html.dart';
 import 'web_otp.dart';
 import 'webauthn.dart';
 
@@ -20,8 +19,6 @@ typedef CredentialMediationRequirement = JSString;
 @JS('Credential')
 @staticInterop
 class Credential {
-  external factory Credential();
-
   external static JSPromise isConditionalMediationAvailable();
 }
 
@@ -32,9 +29,7 @@ extension CredentialExtension on Credential {
 
 @JS('CredentialUserData')
 @staticInterop
-class CredentialUserData {
-  external factory CredentialUserData();
-}
+class CredentialUserData {}
 
 extension CredentialUserDataExtension on CredentialUserData {
   external JSString get name;
@@ -43,16 +38,12 @@ extension CredentialUserDataExtension on CredentialUserData {
 
 @JS('CredentialsContainer')
 @staticInterop
-class CredentialsContainer {
-  external factory CredentialsContainer();
-}
+class CredentialsContainer {}
 
 extension CredentialsContainerExtension on CredentialsContainer {
-  external JSPromise get();
-  external JSPromise get1(CredentialRequestOptions options);
+  external JSPromise get([CredentialRequestOptions options]);
   external JSPromise store(Credential credential);
-  external JSPromise create();
-  external JSPromise create1(CredentialCreationOptions options);
+  external JSPromise create([CredentialCreationOptions options]);
   external JSPromise preventSilentAccess();
 }
 
@@ -125,12 +116,8 @@ extension CredentialCreationOptionsExtension on CredentialCreationOptions {
 
 @JS('PasswordCredential')
 @staticInterop
-class PasswordCredential extends Credential implements CredentialUserData {
-  external factory PasswordCredential();
-
-  external factory PasswordCredential.a1(HTMLFormElement form);
-
-  external factory PasswordCredential.a2(PasswordCredentialData data);
+class PasswordCredential implements Credential, CredentialUserData {
+  external factory PasswordCredential(JSAny dataOrForm);
 }
 
 extension PasswordCredentialExtension on PasswordCredential {
@@ -140,7 +127,7 @@ extension PasswordCredentialExtension on PasswordCredential {
 @JS()
 @staticInterop
 @anonymous
-class PasswordCredentialData extends CredentialData {
+class PasswordCredentialData implements CredentialData {
   external factory PasswordCredentialData({
     JSString name,
     JSString iconURL,
@@ -162,10 +149,8 @@ extension PasswordCredentialDataExtension on PasswordCredentialData {
 
 @JS('FederatedCredential')
 @staticInterop
-class FederatedCredential extends Credential implements CredentialUserData {
-  external factory FederatedCredential();
-
-  external factory FederatedCredential.a1(FederatedCredentialInit data);
+class FederatedCredential implements Credential, CredentialUserData {
+  external factory FederatedCredential(FederatedCredentialInit data);
 }
 
 extension FederatedCredentialExtension on FederatedCredential {
@@ -194,7 +179,7 @@ extension FederatedCredentialRequestOptionsExtension
 @JS()
 @staticInterop
 @anonymous
-class FederatedCredentialInit extends CredentialData {
+class FederatedCredentialInit implements CredentialData {
   external factory FederatedCredentialInit({
     JSString name,
     JSString iconURL,

--- a/lib/src/dom/csp.dart
+++ b/lib/src/dom/csp.dart
@@ -15,9 +15,7 @@ typedef SecurityPolicyViolationEventDisposition = JSString;
 
 @JS('CSPViolationReportBody')
 @staticInterop
-class CSPViolationReportBody extends ReportBody {
-  external factory CSPViolationReportBody();
-}
+class CSPViolationReportBody implements ReportBody {}
 
 extension CSPViolationReportBodyExtension on CSPViolationReportBody {
   external JSObject toJSON();
@@ -36,15 +34,11 @@ extension CSPViolationReportBodyExtension on CSPViolationReportBody {
 
 @JS('SecurityPolicyViolationEvent')
 @staticInterop
-class SecurityPolicyViolationEvent extends Event {
-  external factory SecurityPolicyViolationEvent();
-
-  external factory SecurityPolicyViolationEvent.a1(JSString type);
-
-  external factory SecurityPolicyViolationEvent.a2(
-    JSString type,
+class SecurityPolicyViolationEvent implements Event {
+  external factory SecurityPolicyViolationEvent(
+    JSString type, [
     SecurityPolicyViolationEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension SecurityPolicyViolationEventExtension
@@ -66,7 +60,7 @@ extension SecurityPolicyViolationEventExtension
 @JS()
 @staticInterop
 @anonymous
-class SecurityPolicyViolationEventInit extends EventInit {
+class SecurityPolicyViolationEventInit implements EventInit {
   external factory SecurityPolicyViolationEventInit({
     required JSString documentURI,
     JSString referrer = '',

--- a/lib/src/dom/csp_next.dart
+++ b/lib/src/dom/csp_next.dart
@@ -14,9 +14,7 @@ typedef ScriptingPolicyViolationType = JSString;
 
 @JS('ScriptingPolicyReportBody')
 @staticInterop
-class ScriptingPolicyReportBody extends ReportBody {
-  external factory ScriptingPolicyReportBody();
-}
+class ScriptingPolicyReportBody implements ReportBody {}
 
 extension ScriptingPolicyReportBodyExtension on ScriptingPolicyReportBody {
   external JSObject toJSON();

--- a/lib/src/dom/css_animation_worklet.dart
+++ b/lib/src/dom/css_animation_worklet.dart
@@ -15,9 +15,7 @@ typedef AnimatorInstanceConstructor = JSFunction;
 
 @JS('AnimationWorkletGlobalScope')
 @staticInterop
-class AnimationWorkletGlobalScope extends WorkletGlobalScope {
-  external factory AnimationWorkletGlobalScope();
-}
+class AnimationWorkletGlobalScope implements WorkletGlobalScope {}
 
 extension AnimationWorkletGlobalScopeExtension on AnimationWorkletGlobalScope {
   external JSVoid registerAnimator(
@@ -28,9 +26,7 @@ extension AnimationWorkletGlobalScopeExtension on AnimationWorkletGlobalScope {
 
 @JS('WorkletAnimationEffect')
 @staticInterop
-class WorkletAnimationEffect {
-  external factory WorkletAnimationEffect();
-}
+class WorkletAnimationEffect {}
 
 extension WorkletAnimationEffectExtension on WorkletAnimationEffect {
   external EffectTiming getTiming();
@@ -41,28 +37,13 @@ extension WorkletAnimationEffectExtension on WorkletAnimationEffect {
 
 @JS('WorkletAnimation')
 @staticInterop
-class WorkletAnimation extends Animation {
-  external factory WorkletAnimation();
-
-  external factory WorkletAnimation.a1(JSString animatorName);
-
-  external factory WorkletAnimation.a2(
-    JSString animatorName,
-    JSAny? effects,
-  );
-
-  external factory WorkletAnimation.a3(
-    JSString animatorName,
-    JSAny? effects,
-    AnimationTimeline? timeline,
-  );
-
-  external factory WorkletAnimation.a4(
-    JSString animatorName,
+class WorkletAnimation implements Animation {
+  external factory WorkletAnimation(
+    JSString animatorName, [
     JSAny? effects,
     AnimationTimeline? timeline,
     JSAny options,
-  );
+  ]);
 }
 
 extension WorkletAnimationExtension on WorkletAnimation {
@@ -71,9 +52,7 @@ extension WorkletAnimationExtension on WorkletAnimation {
 
 @JS('WorkletGroupEffect')
 @staticInterop
-class WorkletGroupEffect {
-  external factory WorkletGroupEffect();
-}
+class WorkletGroupEffect {}
 
 extension WorkletGroupEffectExtension on WorkletGroupEffect {
   external JSArray getChildren();

--- a/lib/src/dom/css_animations.dart
+++ b/lib/src/dom/css_animations.dart
@@ -13,15 +13,11 @@ import 'dom.dart';
 
 @JS('AnimationEvent')
 @staticInterop
-class AnimationEvent extends Event {
-  external factory AnimationEvent();
-
-  external factory AnimationEvent.a1(JSString type);
-
-  external factory AnimationEvent.a2(
-    JSString type,
+class AnimationEvent implements Event {
+  external factory AnimationEvent(
+    JSString type, [
     AnimationEventInit animationEventInitDict,
-  );
+  ]);
 }
 
 extension AnimationEventExtension on AnimationEvent {
@@ -33,7 +29,7 @@ extension AnimationEventExtension on AnimationEvent {
 @JS()
 @staticInterop
 @anonymous
-class AnimationEventInit extends EventInit {
+class AnimationEventInit implements EventInit {
   external factory AnimationEventInit({
     JSString animationName = '',
     JSNumber elapsedTime = 0.0,
@@ -52,9 +48,7 @@ extension AnimationEventInitExtension on AnimationEventInit {
 
 @JS('CSSKeyframeRule')
 @staticInterop
-class CSSKeyframeRule extends CSSRule {
-  external factory CSSKeyframeRule();
-}
+class CSSKeyframeRule implements CSSRule {}
 
 extension CSSKeyframeRuleExtension on CSSKeyframeRule {
   external set keyText(JSString value);
@@ -64,16 +58,14 @@ extension CSSKeyframeRuleExtension on CSSKeyframeRule {
 
 @JS('CSSKeyframesRule')
 @staticInterop
-class CSSKeyframesRule extends CSSRule {
-  external factory CSSKeyframesRule();
-}
+class CSSKeyframesRule implements CSSRule {}
 
 extension CSSKeyframesRuleExtension on CSSKeyframesRule {
+  external JSVoid appendRule(JSString rule);
+  external JSVoid deleteRule(JSString select);
+  external CSSKeyframeRule? findRule(JSString select);
   external set name(JSString value);
   external JSString get name;
   external CSSRuleList get cssRules;
   external JSNumber get length;
-  external JSVoid appendRule(JSString rule);
-  external JSVoid deleteRule(JSString select);
-  external CSSKeyframeRule? findRule(JSString select);
 }

--- a/lib/src/dom/css_animations_2.dart
+++ b/lib/src/dom/css_animations_2.dart
@@ -12,9 +12,7 @@ import 'web_animations.dart';
 
 @JS('CSSAnimation')
 @staticInterop
-class CSSAnimation extends Animation {
-  external factory CSSAnimation();
-}
+class CSSAnimation implements Animation {}
 
 extension CSSAnimationExtension on CSSAnimation {
   external JSString get animationName;

--- a/lib/src/dom/css_cascade.dart
+++ b/lib/src/dom/css_cascade.dart
@@ -12,9 +12,7 @@ import 'cssom.dart';
 
 @JS('CSSLayerBlockRule')
 @staticInterop
-class CSSLayerBlockRule extends CSSGroupingRule {
-  external factory CSSLayerBlockRule();
-}
+class CSSLayerBlockRule implements CSSGroupingRule {}
 
 extension CSSLayerBlockRuleExtension on CSSLayerBlockRule {
   external JSString get name;
@@ -22,9 +20,7 @@ extension CSSLayerBlockRuleExtension on CSSLayerBlockRule {
 
 @JS('CSSLayerStatementRule')
 @staticInterop
-class CSSLayerStatementRule extends CSSRule {
-  external factory CSSLayerStatementRule();
-}
+class CSSLayerStatementRule implements CSSRule {}
 
 extension CSSLayerStatementRuleExtension on CSSLayerStatementRule {
   external JSArray get nameList;

--- a/lib/src/dom/css_color_5.dart
+++ b/lib/src/dom/css_color_5.dart
@@ -12,9 +12,7 @@ import 'cssom.dart';
 
 @JS('CSSColorProfileRule')
 @staticInterop
-class CSSColorProfileRule extends CSSRule {
-  external factory CSSColorProfileRule();
-}
+class CSSColorProfileRule implements CSSRule {}
 
 extension CSSColorProfileRuleExtension on CSSColorProfileRule {
   external JSString get name;

--- a/lib/src/dom/css_conditional.dart
+++ b/lib/src/dom/css_conditional.dart
@@ -12,9 +12,7 @@ import 'cssom.dart';
 
 @JS('CSSConditionRule')
 @staticInterop
-class CSSConditionRule extends CSSGroupingRule {
-  external factory CSSConditionRule();
-}
+class CSSConditionRule implements CSSGroupingRule {}
 
 extension CSSConditionRuleExtension on CSSConditionRule {
   external JSString get conditionText;
@@ -22,9 +20,7 @@ extension CSSConditionRuleExtension on CSSConditionRule {
 
 @JS('CSSMediaRule')
 @staticInterop
-class CSSMediaRule extends CSSConditionRule {
-  external factory CSSMediaRule();
-}
+class CSSMediaRule implements CSSConditionRule {}
 
 extension CSSMediaRuleExtension on CSSMediaRule {
   external MediaList get media;
@@ -32,6 +28,4 @@ extension CSSMediaRuleExtension on CSSMediaRule {
 
 @JS('CSSSupportsRule')
 @staticInterop
-class CSSSupportsRule extends CSSConditionRule {
-  external factory CSSSupportsRule();
-}
+class CSSSupportsRule implements CSSConditionRule {}

--- a/lib/src/dom/css_contain.dart
+++ b/lib/src/dom/css_contain.dart
@@ -12,15 +12,11 @@ import 'dom.dart';
 
 @JS('ContentVisibilityAutoStateChangedEvent')
 @staticInterop
-class ContentVisibilityAutoStateChangedEvent extends Event {
-  external factory ContentVisibilityAutoStateChangedEvent();
-
-  external factory ContentVisibilityAutoStateChangedEvent.a1(JSString type);
-
-  external factory ContentVisibilityAutoStateChangedEvent.a2(
-    JSString type,
+class ContentVisibilityAutoStateChangedEvent implements Event {
+  external factory ContentVisibilityAutoStateChangedEvent(
+    JSString type, [
     ContentVisibilityAutoStateChangedEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension ContentVisibilityAutoStateChangedEventExtension
@@ -31,7 +27,7 @@ extension ContentVisibilityAutoStateChangedEventExtension
 @JS()
 @staticInterop
 @anonymous
-class ContentVisibilityAutoStateChangedEventInit extends EventInit {
+class ContentVisibilityAutoStateChangedEventInit implements EventInit {
   external factory ContentVisibilityAutoStateChangedEventInit(
       {JSBoolean skipped = false});
 }

--- a/lib/src/dom/css_contain_3.dart
+++ b/lib/src/dom/css_contain_3.dart
@@ -12,9 +12,7 @@ import 'css_conditional.dart';
 
 @JS('CSSContainerRule')
 @staticInterop
-class CSSContainerRule extends CSSConditionRule {
-  external factory CSSContainerRule();
-}
+class CSSContainerRule implements CSSConditionRule {}
 
 extension CSSContainerRuleExtension on CSSContainerRule {
   external JSString get containerName;

--- a/lib/src/dom/css_counter_styles.dart
+++ b/lib/src/dom/css_counter_styles.dart
@@ -12,9 +12,7 @@ import 'cssom.dart';
 
 @JS('CSSCounterStyleRule')
 @staticInterop
-class CSSCounterStyleRule extends CSSRule {
-  external factory CSSCounterStyleRule();
-}
+class CSSCounterStyleRule implements CSSRule {}
 
 extension CSSCounterStyleRuleExtension on CSSCounterStyleRule {
   external set name(JSString value);

--- a/lib/src/dom/css_font_loading.dart
+++ b/lib/src/dom/css_font_loading.dart
@@ -62,21 +62,15 @@ extension FontFaceDescriptorsExtension on FontFaceDescriptors {
 @JS('FontFace')
 @staticInterop
 class FontFace {
-  external factory FontFace();
-
-  external factory FontFace.a1(
+  external factory FontFace(
     JSString family,
-    JSAny source,
-  );
-
-  external factory FontFace.a2(
-    JSString family,
-    JSAny source,
+    JSAny source, [
     FontFaceDescriptors descriptors,
-  );
+  ]);
 }
 
 extension FontFaceExtension on FontFace {
+  external JSPromise load();
   external set family(JSString value);
   external JSString get family;
   external set style(JSString value);
@@ -102,7 +96,6 @@ extension FontFaceExtension on FontFace {
   external set lineGapOverride(JSString value);
   external JSString get lineGapOverride;
   external FontFaceLoadStatus get status;
-  external JSPromise load();
   external JSPromise get loaded;
   external FontFaceFeatures get features;
   external FontFaceVariations get variations;
@@ -111,15 +104,11 @@ extension FontFaceExtension on FontFace {
 
 @JS('FontFaceFeatures')
 @staticInterop
-class FontFaceFeatures {
-  external factory FontFaceFeatures();
-}
+class FontFaceFeatures {}
 
 @JS('FontFaceVariationAxis')
 @staticInterop
-class FontFaceVariationAxis {
-  external factory FontFaceVariationAxis();
-}
+class FontFaceVariationAxis {}
 
 extension FontFaceVariationAxisExtension on FontFaceVariationAxis {
   external JSString get name;
@@ -131,17 +120,13 @@ extension FontFaceVariationAxisExtension on FontFaceVariationAxis {
 
 @JS('FontFaceVariations')
 @staticInterop
-class FontFaceVariations {
-  external factory FontFaceVariations();
-}
+class FontFaceVariations {}
 
 extension FontFaceVariationsExtension on FontFaceVariations {}
 
 @JS('FontFacePalette')
 @staticInterop
-class FontFacePalette {
-  external factory FontFacePalette();
-}
+class FontFacePalette {}
 
 extension FontFacePaletteExtension on FontFacePalette {
   external JSNumber get length;
@@ -151,9 +136,7 @@ extension FontFacePaletteExtension on FontFacePalette {
 
 @JS('FontFacePalettes')
 @staticInterop
-class FontFacePalettes {
-  external factory FontFacePalettes();
-}
+class FontFacePalettes {}
 
 extension FontFacePalettesExtension on FontFacePalettes {
   external JSNumber get length;
@@ -162,7 +145,7 @@ extension FontFacePalettesExtension on FontFacePalettes {
 @JS()
 @staticInterop
 @anonymous
-class FontFaceSetLoadEventInit extends EventInit {
+class FontFaceSetLoadEventInit implements EventInit {
   external factory FontFaceSetLoadEventInit({JSArray fontfaces = const []});
 }
 
@@ -173,15 +156,11 @@ extension FontFaceSetLoadEventInitExtension on FontFaceSetLoadEventInit {
 
 @JS('FontFaceSetLoadEvent')
 @staticInterop
-class FontFaceSetLoadEvent extends Event {
-  external factory FontFaceSetLoadEvent();
-
-  external factory FontFaceSetLoadEvent.a1(JSString type);
-
-  external factory FontFaceSetLoadEvent.a2(
-    JSString type,
+class FontFaceSetLoadEvent implements Event {
+  external factory FontFaceSetLoadEvent(
+    JSString type, [
     FontFaceSetLoadEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension FontFaceSetLoadEventExtension on FontFaceSetLoadEvent {
@@ -190,41 +169,35 @@ extension FontFaceSetLoadEventExtension on FontFaceSetLoadEvent {
 
 @JS('FontFaceSet')
 @staticInterop
-class FontFaceSet extends EventTarget {
-  external factory FontFaceSet();
-
-  external factory FontFaceSet.a1(JSArray initialFaces);
+class FontFaceSet implements EventTarget {
+  external factory FontFaceSet(JSArray initialFaces);
 }
 
 extension FontFaceSetExtension on FontFaceSet {
   external FontFaceSet add(FontFace font);
   external JSBoolean delete(FontFace font);
   external JSVoid clear();
+  external JSPromise load(
+    JSString font, [
+    JSString text,
+  ]);
+  external JSBoolean check(
+    JSString font, [
+    JSString text,
+  ]);
   external set onloading(EventHandler value);
   external EventHandler get onloading;
   external set onloadingdone(EventHandler value);
   external EventHandler get onloadingdone;
   external set onloadingerror(EventHandler value);
   external EventHandler get onloadingerror;
-  external JSPromise load(JSString font);
-  external JSPromise load1(
-    JSString font,
-    JSString text,
-  );
-  external JSBoolean check(JSString font);
-  external JSBoolean check1(
-    JSString font,
-    JSString text,
-  );
   external JSPromise get ready;
   external FontFaceSetLoadStatus get status;
 }
 
 @JS('FontFaceSource')
 @staticInterop
-class FontFaceSource {
-  external factory FontFaceSource();
-}
+class FontFaceSource {}
 
 extension FontFaceSourceExtension on FontFaceSource {
   external FontFaceSet get fonts;

--- a/lib/src/dom/css_fonts.dart
+++ b/lib/src/dom/css_fonts.dart
@@ -12,9 +12,7 @@ import 'cssom.dart';
 
 @JS('CSSFontFaceRule')
 @staticInterop
-class CSSFontFaceRule extends CSSRule {
-  external factory CSSFontFaceRule();
-}
+class CSSFontFaceRule implements CSSRule {}
 
 extension CSSFontFaceRuleExtension on CSSFontFaceRule {
   external CSSStyleDeclaration get style;
@@ -22,9 +20,7 @@ extension CSSFontFaceRuleExtension on CSSFontFaceRule {
 
 @JS('CSSFontFeatureValuesRule')
 @staticInterop
-class CSSFontFeatureValuesRule extends CSSRule {
-  external factory CSSFontFeatureValuesRule();
-}
+class CSSFontFeatureValuesRule implements CSSRule {}
 
 extension CSSFontFeatureValuesRuleExtension on CSSFontFeatureValuesRule {
   external set fontFamily(JSString value);
@@ -39,9 +35,7 @@ extension CSSFontFeatureValuesRuleExtension on CSSFontFeatureValuesRule {
 
 @JS('CSSFontFeatureValuesMap')
 @staticInterop
-class CSSFontFeatureValuesMap {
-  external factory CSSFontFeatureValuesMap();
-}
+class CSSFontFeatureValuesMap {}
 
 extension CSSFontFeatureValuesMapExtension on CSSFontFeatureValuesMap {
   external JSVoid set(
@@ -52,9 +46,7 @@ extension CSSFontFeatureValuesMapExtension on CSSFontFeatureValuesMap {
 
 @JS('CSSFontPaletteValuesRule')
 @staticInterop
-class CSSFontPaletteValuesRule extends CSSRule {
-  external factory CSSFontPaletteValuesRule();
-}
+class CSSFontPaletteValuesRule implements CSSRule {}
 
 extension CSSFontPaletteValuesRuleExtension on CSSFontPaletteValuesRule {
   external JSString get name;

--- a/lib/src/dom/css_highlight_api.dart
+++ b/lib/src/dom/css_highlight_api.dart
@@ -15,9 +15,7 @@ typedef HighlightType = JSString;
 @JS('Highlight')
 @staticInterop
 class Highlight {
-  external factory Highlight();
-
-  external factory Highlight.a1(AbstractRange initialRanges);
+  external factory Highlight(AbstractRange initialRanges);
 }
 
 extension HighlightExtension on Highlight {
@@ -29,8 +27,6 @@ extension HighlightExtension on Highlight {
 
 @JS('HighlightRegistry')
 @staticInterop
-class HighlightRegistry {
-  external factory HighlightRegistry();
-}
+class HighlightRegistry {}
 
 extension HighlightRegistryExtension on HighlightRegistry {}

--- a/lib/src/dom/css_layout_api.dart
+++ b/lib/src/dom/css_layout_api.dart
@@ -19,9 +19,7 @@ typedef BreakType = JSString;
 
 @JS('LayoutWorkletGlobalScope')
 @staticInterop
-class LayoutWorkletGlobalScope extends WorkletGlobalScope {
-  external factory LayoutWorkletGlobalScope();
-}
+class LayoutWorkletGlobalScope implements WorkletGlobalScope {}
 
 extension LayoutWorkletGlobalScopeExtension on LayoutWorkletGlobalScope {
   external JSVoid registerLayout(
@@ -49,24 +47,20 @@ extension LayoutOptionsExtension on LayoutOptions {
 
 @JS('LayoutChild')
 @staticInterop
-class LayoutChild {
-  external factory LayoutChild();
-}
+class LayoutChild {}
 
 extension LayoutChildExtension on LayoutChild {
-  external StylePropertyMapReadOnly get styleMap;
   external JSPromise intrinsicSizes();
   external JSPromise layoutNextFragment(
     LayoutConstraintsOptions constraints,
     ChildBreakToken breakToken,
   );
+  external StylePropertyMapReadOnly get styleMap;
 }
 
 @JS('LayoutFragment')
 @staticInterop
-class LayoutFragment {
-  external factory LayoutFragment();
-}
+class LayoutFragment {}
 
 extension LayoutFragmentExtension on LayoutFragment {
   external JSNumber get inlineSize;
@@ -81,9 +75,7 @@ extension LayoutFragmentExtension on LayoutFragment {
 
 @JS('IntrinsicSizes')
 @staticInterop
-class IntrinsicSizes {
-  external factory IntrinsicSizes();
-}
+class IntrinsicSizes {}
 
 extension IntrinsicSizesExtension on IntrinsicSizes {
   external JSNumber get minContentSize;
@@ -92,9 +84,7 @@ extension IntrinsicSizesExtension on IntrinsicSizes {
 
 @JS('LayoutConstraints')
 @staticInterop
-class LayoutConstraints {
-  external factory LayoutConstraints();
-}
+class LayoutConstraints {}
 
 extension LayoutConstraintsExtension on LayoutConstraints {
   external JSNumber get availableInlineSize;
@@ -148,9 +138,7 @@ extension LayoutConstraintsOptionsExtension on LayoutConstraintsOptions {
 
 @JS('ChildBreakToken')
 @staticInterop
-class ChildBreakToken {
-  external factory ChildBreakToken();
-}
+class ChildBreakToken {}
 
 extension ChildBreakTokenExtension on ChildBreakToken {
   external BreakType get breakType;
@@ -159,9 +147,7 @@ extension ChildBreakTokenExtension on ChildBreakToken {
 
 @JS('BreakToken')
 @staticInterop
-class BreakToken {
-  external factory BreakToken();
-}
+class BreakToken {}
 
 extension BreakTokenExtension on BreakToken {
   external JSArray get childBreakTokens;
@@ -187,9 +173,7 @@ extension BreakTokenOptionsExtension on BreakTokenOptions {
 
 @JS('LayoutEdges')
 @staticInterop
-class LayoutEdges {
-  external factory LayoutEdges();
-}
+class LayoutEdges {}
 
 extension LayoutEdgesExtension on LayoutEdges {
   external JSNumber get inlineStart;
@@ -232,11 +216,7 @@ extension FragmentResultOptionsExtension on FragmentResultOptions {
 @JS('FragmentResult')
 @staticInterop
 class FragmentResult {
-  external factory FragmentResult();
-
-  external factory FragmentResult.a1();
-
-  external factory FragmentResult.a2(FragmentResultOptions options);
+  external factory FragmentResult([FragmentResultOptions options]);
 }
 
 extension FragmentResultExtension on FragmentResult {

--- a/lib/src/dom/css_masking.dart
+++ b/lib/src/dom/css_masking.dart
@@ -12,9 +12,7 @@ import 'svg.dart';
 
 @JS('SVGClipPathElement')
 @staticInterop
-class SVGClipPathElement extends SVGElement {
-  external factory SVGClipPathElement();
-}
+class SVGClipPathElement implements SVGElement {}
 
 extension SVGClipPathElementExtension on SVGClipPathElement {
   external SVGAnimatedEnumeration get clipPathUnits;
@@ -23,9 +21,7 @@ extension SVGClipPathElementExtension on SVGClipPathElement {
 
 @JS('SVGMaskElement')
 @staticInterop
-class SVGMaskElement extends SVGElement {
-  external factory SVGMaskElement();
-}
+class SVGMaskElement implements SVGElement {}
 
 extension SVGMaskElementExtension on SVGMaskElement {
   external SVGAnimatedEnumeration get maskUnits;

--- a/lib/src/dom/css_nav.dart
+++ b/lib/src/dom/css_nav.dart
@@ -46,15 +46,11 @@ extension SpatialNavigationSearchOptionsExtension
 
 @JS('NavigationEvent')
 @staticInterop
-class NavigationEvent extends UIEvent {
-  external factory NavigationEvent();
-
-  external factory NavigationEvent.a1(JSString type);
-
-  external factory NavigationEvent.a2(
-    JSString type,
+class NavigationEvent implements UIEvent {
+  external factory NavigationEvent(
+    JSString type, [
     NavigationEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension NavigationEventExtension on NavigationEvent {
@@ -65,7 +61,7 @@ extension NavigationEventExtension on NavigationEvent {
 @JS()
 @staticInterop
 @anonymous
-class NavigationEventInit extends UIEventInit {
+class NavigationEventInit implements UIEventInit {
   external factory NavigationEventInit({
     SpatialNavigationDirection dir,
     EventTarget? relatedTarget,

--- a/lib/src/dom/css_paint_api.dart
+++ b/lib/src/dom/css_paint_api.dart
@@ -13,9 +13,7 @@ import 'webidl.dart';
 
 @JS('PaintWorkletGlobalScope')
 @staticInterop
-class PaintWorkletGlobalScope extends WorkletGlobalScope {
-  external factory PaintWorkletGlobalScope();
-}
+class PaintWorkletGlobalScope implements WorkletGlobalScope {}
 
 extension PaintWorkletGlobalScopeExtension on PaintWorkletGlobalScope {
   external JSVoid registerPaint(
@@ -52,15 +50,11 @@ class PaintRenderingContext2D
         CanvasDrawPath,
         CanvasDrawImage,
         CanvasPathDrawingStyles,
-        CanvasPath {
-  external factory PaintRenderingContext2D();
-}
+        CanvasPath {}
 
 @JS('PaintSize')
 @staticInterop
-class PaintSize {
-  external factory PaintSize();
-}
+class PaintSize {}
 
 extension PaintSizeExtension on PaintSize {
   external JSNumber get width;

--- a/lib/src/dom/css_parser_api.dart
+++ b/lib/src/dom/css_parser_api.dart
@@ -25,25 +25,16 @@ extension CSSParserOptionsExtension on CSSParserOptions {
 
 @JS('CSSParserRule')
 @staticInterop
-class CSSParserRule {
-  external factory CSSParserRule();
-}
+class CSSParserRule {}
 
 @JS('CSSParserAtRule')
 @staticInterop
-class CSSParserAtRule extends CSSParserRule {
-  external factory CSSParserAtRule();
-
-  external factory CSSParserAtRule.a1(
+class CSSParserAtRule implements CSSParserRule {
+  external factory CSSParserAtRule(
     JSString name,
-    JSArray prelude,
-  );
-
-  external factory CSSParserAtRule.a2(
-    JSString name,
-    JSArray prelude,
+    JSArray prelude, [
     JSArray? body,
-  );
+  ]);
 }
 
 extension CSSParserAtRuleExtension on CSSParserAtRule {
@@ -54,15 +45,11 @@ extension CSSParserAtRuleExtension on CSSParserAtRule {
 
 @JS('CSSParserQualifiedRule')
 @staticInterop
-class CSSParserQualifiedRule extends CSSParserRule {
-  external factory CSSParserQualifiedRule();
-
-  external factory CSSParserQualifiedRule.a1(JSArray prelude);
-
-  external factory CSSParserQualifiedRule.a2(
-    JSArray prelude,
+class CSSParserQualifiedRule implements CSSParserRule {
+  external factory CSSParserQualifiedRule(
+    JSArray prelude, [
     JSArray? body,
-  );
+  ]);
 }
 
 extension CSSParserQualifiedRuleExtension on CSSParserQualifiedRule {
@@ -72,15 +59,11 @@ extension CSSParserQualifiedRuleExtension on CSSParserQualifiedRule {
 
 @JS('CSSParserDeclaration')
 @staticInterop
-class CSSParserDeclaration extends CSSParserRule {
-  external factory CSSParserDeclaration();
-
-  external factory CSSParserDeclaration.a1(JSString name);
-
-  external factory CSSParserDeclaration.a2(
-    JSString name,
+class CSSParserDeclaration implements CSSParserRule {
+  external factory CSSParserDeclaration(
+    JSString name, [
     JSArray body,
-  );
+  ]);
 }
 
 extension CSSParserDeclarationExtension on CSSParserDeclaration {
@@ -90,16 +73,12 @@ extension CSSParserDeclarationExtension on CSSParserDeclaration {
 
 @JS('CSSParserValue')
 @staticInterop
-class CSSParserValue {
-  external factory CSSParserValue();
-}
+class CSSParserValue {}
 
 @JS('CSSParserBlock')
 @staticInterop
-class CSSParserBlock extends CSSParserValue {
-  external factory CSSParserBlock();
-
-  external factory CSSParserBlock.a1(
+class CSSParserBlock implements CSSParserValue {
+  external factory CSSParserBlock(
     JSString name,
     JSArray body,
   );
@@ -112,10 +91,8 @@ extension CSSParserBlockExtension on CSSParserBlock {
 
 @JS('CSSParserFunction')
 @staticInterop
-class CSSParserFunction extends CSSParserValue {
-  external factory CSSParserFunction();
-
-  external factory CSSParserFunction.a1(
+class CSSParserFunction implements CSSParserValue {
+  external factory CSSParserFunction(
     JSString name,
     JSArray args,
   );

--- a/lib/src/dom/css_properties_values_api.dart
+++ b/lib/src/dom/css_properties_values_api.dart
@@ -35,9 +35,7 @@ extension PropertyDefinitionExtension on PropertyDefinition {
 
 @JS('CSSPropertyRule')
 @staticInterop
-class CSSPropertyRule extends CSSRule {
-  external factory CSSPropertyRule();
-}
+class CSSPropertyRule implements CSSRule {}
 
 extension CSSPropertyRuleExtension on CSSPropertyRule {
   external JSString get name;

--- a/lib/src/dom/css_pseudo.dart
+++ b/lib/src/dom/css_pseudo.dart
@@ -13,13 +13,11 @@ import 'dom.dart';
 
 @JS('CSSPseudoElement')
 @staticInterop
-class CSSPseudoElement extends EventTarget implements GeometryUtils {
-  external factory CSSPseudoElement();
-}
+class CSSPseudoElement implements EventTarget, GeometryUtils {}
 
 extension CSSPseudoElementExtension on CSSPseudoElement {
+  external CSSPseudoElement? pseudo(JSString type);
   external JSString get type;
   external Element get element;
   external JSAny get parent;
-  external CSSPseudoElement? pseudo(JSString type);
 }

--- a/lib/src/dom/css_regions.dart
+++ b/lib/src/dom/css_regions.dart
@@ -12,34 +12,28 @@ import 'dom.dart';
 
 @JS('NamedFlowMap')
 @staticInterop
-class NamedFlowMap {
-  external factory NamedFlowMap();
-}
+class NamedFlowMap {}
 
 extension NamedFlowMapExtension on NamedFlowMap {}
 
 @JS('NamedFlow')
 @staticInterop
-class NamedFlow extends EventTarget {
-  external factory NamedFlow();
-}
+class NamedFlow implements EventTarget {}
 
 extension NamedFlowExtension on NamedFlow {
-  external JSString get name;
-  external JSBoolean get overset;
   external JSArray getRegions();
-  external JSNumber get firstEmptyRegionIndex;
   external JSArray getContent();
   external JSArray getRegionsByContent(Node node);
+  external JSString get name;
+  external JSBoolean get overset;
+  external JSNumber get firstEmptyRegionIndex;
 }
 
 @JS('Region')
 @staticInterop
-class Region {
-  external factory Region();
-}
+class Region {}
 
 extension RegionExtension on Region {
-  external JSString get regionOverset;
   external JSArray? getRegionFlowRanges();
+  external JSString get regionOverset;
 }

--- a/lib/src/dom/css_transitions.dart
+++ b/lib/src/dom/css_transitions.dart
@@ -12,15 +12,11 @@ import 'dom.dart';
 
 @JS('TransitionEvent')
 @staticInterop
-class TransitionEvent extends Event {
-  external factory TransitionEvent();
-
-  external factory TransitionEvent.a1(JSString type);
-
-  external factory TransitionEvent.a2(
-    JSString type,
+class TransitionEvent implements Event {
+  external factory TransitionEvent(
+    JSString type, [
     TransitionEventInit transitionEventInitDict,
-  );
+  ]);
 }
 
 extension TransitionEventExtension on TransitionEvent {
@@ -32,7 +28,7 @@ extension TransitionEventExtension on TransitionEvent {
 @JS()
 @staticInterop
 @anonymous
-class TransitionEventInit extends EventInit {
+class TransitionEventInit implements EventInit {
   external factory TransitionEventInit({
     JSString propertyName = '',
     JSNumber elapsedTime = 0.0,

--- a/lib/src/dom/css_transitions_2.dart
+++ b/lib/src/dom/css_transitions_2.dart
@@ -12,9 +12,7 @@ import 'web_animations.dart';
 
 @JS('CSSTransition')
 @staticInterop
-class CSSTransition extends Animation {
-  external factory CSSTransition();
-}
+class CSSTransition implements Animation {}
 
 extension CSSTransitionExtension on CSSTransition {
   external JSString get transitionProperty;

--- a/lib/src/dom/css_typed_om.dart
+++ b/lib/src/dom/css_typed_om.dart
@@ -24,8 +24,6 @@ typedef CSSMathOperator = JSString;
 @JS('CSSStyleValue')
 @staticInterop
 class CSSStyleValue {
-  external factory CSSStyleValue();
-
   external static CSSStyleValue parse(
     JSString property,
     JSString cssText,
@@ -38,9 +36,7 @@ class CSSStyleValue {
 
 @JS('StylePropertyMapReadOnly')
 @staticInterop
-class StylePropertyMapReadOnly {
-  external factory StylePropertyMapReadOnly();
-}
+class StylePropertyMapReadOnly {}
 
 extension StylePropertyMapReadOnlyExtension on StylePropertyMapReadOnly {
   external JSAny get(JSString property);
@@ -51,9 +47,7 @@ extension StylePropertyMapReadOnlyExtension on StylePropertyMapReadOnly {
 
 @JS('StylePropertyMap')
 @staticInterop
-class StylePropertyMap extends StylePropertyMapReadOnly {
-  external factory StylePropertyMap();
-}
+class StylePropertyMap implements StylePropertyMapReadOnly {}
 
 extension StylePropertyMapExtension on StylePropertyMap {
   external JSVoid set(
@@ -70,10 +64,8 @@ extension StylePropertyMapExtension on StylePropertyMap {
 
 @JS('CSSUnparsedValue')
 @staticInterop
-class CSSUnparsedValue extends CSSStyleValue {
-  external factory CSSUnparsedValue();
-
-  external factory CSSUnparsedValue.a1(JSArray members);
+class CSSUnparsedValue implements CSSStyleValue {
+  external factory CSSUnparsedValue(JSArray members);
 }
 
 extension CSSUnparsedValueExtension on CSSUnparsedValue {
@@ -83,14 +75,10 @@ extension CSSUnparsedValueExtension on CSSUnparsedValue {
 @JS('CSSVariableReferenceValue')
 @staticInterop
 class CSSVariableReferenceValue {
-  external factory CSSVariableReferenceValue();
-
-  external factory CSSVariableReferenceValue.a1(JSString variable);
-
-  external factory CSSVariableReferenceValue.a2(
-    JSString variable,
+  external factory CSSVariableReferenceValue(
+    JSString variable, [
     CSSUnparsedValue? fallback,
-  );
+  ]);
 }
 
 extension CSSVariableReferenceValueExtension on CSSVariableReferenceValue {
@@ -101,10 +89,8 @@ extension CSSVariableReferenceValueExtension on CSSVariableReferenceValue {
 
 @JS('CSSKeywordValue')
 @staticInterop
-class CSSKeywordValue extends CSSStyleValue {
-  external factory CSSKeywordValue();
-
-  external factory CSSKeywordValue.a1(JSString value);
+class CSSKeywordValue implements CSSStyleValue {
+  external factory CSSKeywordValue(JSString value);
 }
 
 extension CSSKeywordValueExtension on CSSKeywordValue {
@@ -149,9 +135,7 @@ extension CSSNumericTypeExtension on CSSNumericType {
 
 @JS('CSSNumericValue')
 @staticInterop
-class CSSNumericValue extends CSSStyleValue {
-  external factory CSSNumericValue();
-
+class CSSNumericValue implements CSSStyleValue {
   external static CSSNumericValue parse(JSString cssText);
 }
 
@@ -170,10 +154,8 @@ extension CSSNumericValueExtension on CSSNumericValue {
 
 @JS('CSSUnitValue')
 @staticInterop
-class CSSUnitValue extends CSSNumericValue {
-  external factory CSSUnitValue();
-
-  external factory CSSUnitValue.a1(
+class CSSUnitValue implements CSSNumericValue {
+  external factory CSSUnitValue(
     JSNumber value,
     JSString unit,
   );
@@ -187,9 +169,7 @@ extension CSSUnitValueExtension on CSSUnitValue {
 
 @JS('CSSMathValue')
 @staticInterop
-class CSSMathValue extends CSSNumericValue {
-  external factory CSSMathValue();
-}
+class CSSMathValue implements CSSNumericValue {}
 
 extension CSSMathValueExtension on CSSMathValue {
   external CSSMathOperator get operator;
@@ -197,10 +177,8 @@ extension CSSMathValueExtension on CSSMathValue {
 
 @JS('CSSMathSum')
 @staticInterop
-class CSSMathSum extends CSSMathValue {
-  external factory CSSMathSum();
-
-  external factory CSSMathSum.a1(CSSNumberish args);
+class CSSMathSum implements CSSMathValue {
+  external factory CSSMathSum(CSSNumberish args);
 }
 
 extension CSSMathSumExtension on CSSMathSum {
@@ -209,10 +187,8 @@ extension CSSMathSumExtension on CSSMathSum {
 
 @JS('CSSMathProduct')
 @staticInterop
-class CSSMathProduct extends CSSMathValue {
-  external factory CSSMathProduct();
-
-  external factory CSSMathProduct.a1(CSSNumberish args);
+class CSSMathProduct implements CSSMathValue {
+  external factory CSSMathProduct(CSSNumberish args);
 }
 
 extension CSSMathProductExtension on CSSMathProduct {
@@ -221,10 +197,8 @@ extension CSSMathProductExtension on CSSMathProduct {
 
 @JS('CSSMathNegate')
 @staticInterop
-class CSSMathNegate extends CSSMathValue {
-  external factory CSSMathNegate();
-
-  external factory CSSMathNegate.a1(CSSNumberish arg);
+class CSSMathNegate implements CSSMathValue {
+  external factory CSSMathNegate(CSSNumberish arg);
 }
 
 extension CSSMathNegateExtension on CSSMathNegate {
@@ -233,10 +207,8 @@ extension CSSMathNegateExtension on CSSMathNegate {
 
 @JS('CSSMathInvert')
 @staticInterop
-class CSSMathInvert extends CSSMathValue {
-  external factory CSSMathInvert();
-
-  external factory CSSMathInvert.a1(CSSNumberish arg);
+class CSSMathInvert implements CSSMathValue {
+  external factory CSSMathInvert(CSSNumberish arg);
 }
 
 extension CSSMathInvertExtension on CSSMathInvert {
@@ -245,10 +217,8 @@ extension CSSMathInvertExtension on CSSMathInvert {
 
 @JS('CSSMathMin')
 @staticInterop
-class CSSMathMin extends CSSMathValue {
-  external factory CSSMathMin();
-
-  external factory CSSMathMin.a1(CSSNumberish args);
+class CSSMathMin implements CSSMathValue {
+  external factory CSSMathMin(CSSNumberish args);
 }
 
 extension CSSMathMinExtension on CSSMathMin {
@@ -257,10 +227,8 @@ extension CSSMathMinExtension on CSSMathMin {
 
 @JS('CSSMathMax')
 @staticInterop
-class CSSMathMax extends CSSMathValue {
-  external factory CSSMathMax();
-
-  external factory CSSMathMax.a1(CSSNumberish args);
+class CSSMathMax implements CSSMathValue {
+  external factory CSSMathMax(CSSNumberish args);
 }
 
 extension CSSMathMaxExtension on CSSMathMax {
@@ -269,10 +237,8 @@ extension CSSMathMaxExtension on CSSMathMax {
 
 @JS('CSSMathClamp')
 @staticInterop
-class CSSMathClamp extends CSSMathValue {
-  external factory CSSMathClamp();
-
-  external factory CSSMathClamp.a1(
+class CSSMathClamp implements CSSMathValue {
+  external factory CSSMathClamp(
     CSSNumberish lower,
     CSSNumberish value,
     CSSNumberish upper,
@@ -287,9 +253,7 @@ extension CSSMathClampExtension on CSSMathClamp {
 
 @JS('CSSNumericArray')
 @staticInterop
-class CSSNumericArray {
-  external factory CSSNumericArray();
-}
+class CSSNumericArray {}
 
 extension CSSNumericArrayExtension on CSSNumericArray {
   external JSNumber get length;
@@ -297,45 +261,34 @@ extension CSSNumericArrayExtension on CSSNumericArray {
 
 @JS('CSSTransformValue')
 @staticInterop
-class CSSTransformValue extends CSSStyleValue {
-  external factory CSSTransformValue();
-
-  external factory CSSTransformValue.a1(JSArray transforms);
+class CSSTransformValue implements CSSStyleValue {
+  external factory CSSTransformValue(JSArray transforms);
 }
 
 extension CSSTransformValueExtension on CSSTransformValue {
+  external DOMMatrix toMatrix();
   external JSNumber get length;
   external JSBoolean get is2D;
-  external DOMMatrix toMatrix();
 }
 
 @JS('CSSTransformComponent')
 @staticInterop
-class CSSTransformComponent {
-  external factory CSSTransformComponent();
-}
+class CSSTransformComponent {}
 
 extension CSSTransformComponentExtension on CSSTransformComponent {
+  external DOMMatrix toMatrix();
   external set is2D(JSBoolean value);
   external JSBoolean get is2D;
-  external DOMMatrix toMatrix();
 }
 
 @JS('CSSTranslate')
 @staticInterop
-class CSSTranslate extends CSSTransformComponent {
-  external factory CSSTranslate();
-
-  external factory CSSTranslate.a1(
+class CSSTranslate implements CSSTransformComponent {
+  external factory CSSTranslate(
     CSSNumericValue x,
-    CSSNumericValue y,
-  );
-
-  external factory CSSTranslate.a2(
-    CSSNumericValue x,
-    CSSNumericValue y,
+    CSSNumericValue y, [
     CSSNumericValue z,
-  );
+  ]);
 }
 
 extension CSSTranslateExtension on CSSTranslate {
@@ -349,17 +302,13 @@ extension CSSTranslateExtension on CSSTranslate {
 
 @JS('CSSRotate')
 @staticInterop
-class CSSRotate extends CSSTransformComponent {
-  external factory CSSRotate();
-
-  external factory CSSRotate.a1(CSSNumericValue angle);
-
-  external factory CSSRotate.a2(
-    CSSNumberish x,
+class CSSRotate implements CSSTransformComponent {
+  external factory CSSRotate(
+    JSAny angleOrX, [
     CSSNumberish y,
     CSSNumberish z,
     CSSNumericValue angle,
-  );
+  ]);
 }
 
 extension CSSRotateExtension on CSSRotate {
@@ -375,19 +324,12 @@ extension CSSRotateExtension on CSSRotate {
 
 @JS('CSSScale')
 @staticInterop
-class CSSScale extends CSSTransformComponent {
-  external factory CSSScale();
-
-  external factory CSSScale.a1(
+class CSSScale implements CSSTransformComponent {
+  external factory CSSScale(
     CSSNumberish x,
-    CSSNumberish y,
-  );
-
-  external factory CSSScale.a2(
-    CSSNumberish x,
-    CSSNumberish y,
+    CSSNumberish y, [
     CSSNumberish z,
-  );
+  ]);
 }
 
 extension CSSScaleExtension on CSSScale {
@@ -401,10 +343,8 @@ extension CSSScaleExtension on CSSScale {
 
 @JS('CSSSkew')
 @staticInterop
-class CSSSkew extends CSSTransformComponent {
-  external factory CSSSkew();
-
-  external factory CSSSkew.a1(
+class CSSSkew implements CSSTransformComponent {
+  external factory CSSSkew(
     CSSNumericValue ax,
     CSSNumericValue ay,
   );
@@ -419,10 +359,8 @@ extension CSSSkewExtension on CSSSkew {
 
 @JS('CSSSkewX')
 @staticInterop
-class CSSSkewX extends CSSTransformComponent {
-  external factory CSSSkewX();
-
-  external factory CSSSkewX.a1(CSSNumericValue ax);
+class CSSSkewX implements CSSTransformComponent {
+  external factory CSSSkewX(CSSNumericValue ax);
 }
 
 extension CSSSkewXExtension on CSSSkewX {
@@ -432,10 +370,8 @@ extension CSSSkewXExtension on CSSSkewX {
 
 @JS('CSSSkewY')
 @staticInterop
-class CSSSkewY extends CSSTransformComponent {
-  external factory CSSSkewY();
-
-  external factory CSSSkewY.a1(CSSNumericValue ay);
+class CSSSkewY implements CSSTransformComponent {
+  external factory CSSSkewY(CSSNumericValue ay);
 }
 
 extension CSSSkewYExtension on CSSSkewY {
@@ -445,10 +381,8 @@ extension CSSSkewYExtension on CSSSkewY {
 
 @JS('CSSPerspective')
 @staticInterop
-class CSSPerspective extends CSSTransformComponent {
-  external factory CSSPerspective();
-
-  external factory CSSPerspective.a1(CSSPerspectiveValue length);
+class CSSPerspective implements CSSTransformComponent {
+  external factory CSSPerspective(CSSPerspectiveValue length);
 }
 
 extension CSSPerspectiveExtension on CSSPerspective {
@@ -458,15 +392,11 @@ extension CSSPerspectiveExtension on CSSPerspective {
 
 @JS('CSSMatrixComponent')
 @staticInterop
-class CSSMatrixComponent extends CSSTransformComponent {
-  external factory CSSMatrixComponent();
-
-  external factory CSSMatrixComponent.a1(DOMMatrixReadOnly matrix);
-
-  external factory CSSMatrixComponent.a2(
-    DOMMatrixReadOnly matrix,
+class CSSMatrixComponent implements CSSTransformComponent {
+  external factory CSSMatrixComponent(
+    DOMMatrixReadOnly matrix, [
     CSSMatrixComponentOptions options,
-  );
+  ]);
 }
 
 extension CSSMatrixComponentExtension on CSSMatrixComponent {
@@ -488,35 +418,23 @@ extension CSSMatrixComponentOptionsExtension on CSSMatrixComponentOptions {
 
 @JS('CSSImageValue')
 @staticInterop
-class CSSImageValue extends CSSStyleValue {
-  external factory CSSImageValue();
-}
+class CSSImageValue implements CSSStyleValue {}
 
 @JS('CSSColorValue')
 @staticInterop
-class CSSColorValue extends CSSStyleValue {
-  external factory CSSColorValue();
-
+class CSSColorValue implements CSSStyleValue {
   external static JSAny parse(JSString cssText);
 }
 
 @JS('CSSRGB')
 @staticInterop
-class CSSRGB extends CSSColorValue {
-  external factory CSSRGB();
-
-  external factory CSSRGB.a1(
+class CSSRGB implements CSSColorValue {
+  external factory CSSRGB(
     CSSColorRGBComp r,
     CSSColorRGBComp g,
-    CSSColorRGBComp b,
-  );
-
-  external factory CSSRGB.a2(
-    CSSColorRGBComp r,
-    CSSColorRGBComp g,
-    CSSColorRGBComp b,
+    CSSColorRGBComp b, [
     CSSColorPercent alpha,
-  );
+  ]);
 }
 
 extension CSSRGBExtension on CSSRGB {
@@ -532,21 +450,13 @@ extension CSSRGBExtension on CSSRGB {
 
 @JS('CSSHSL')
 @staticInterop
-class CSSHSL extends CSSColorValue {
-  external factory CSSHSL();
-
-  external factory CSSHSL.a1(
+class CSSHSL implements CSSColorValue {
+  external factory CSSHSL(
     CSSColorAngle h,
     CSSColorPercent s,
-    CSSColorPercent l,
-  );
-
-  external factory CSSHSL.a2(
-    CSSColorAngle h,
-    CSSColorPercent s,
-    CSSColorPercent l,
+    CSSColorPercent l, [
     CSSColorPercent alpha,
-  );
+  ]);
 }
 
 extension CSSHSLExtension on CSSHSL {
@@ -562,21 +472,13 @@ extension CSSHSLExtension on CSSHSL {
 
 @JS('CSSHWB')
 @staticInterop
-class CSSHWB extends CSSColorValue {
-  external factory CSSHWB();
-
-  external factory CSSHWB.a1(
+class CSSHWB implements CSSColorValue {
+  external factory CSSHWB(
     CSSNumericValue h,
     CSSNumberish w,
-    CSSNumberish b,
-  );
-
-  external factory CSSHWB.a2(
-    CSSNumericValue h,
-    CSSNumberish w,
-    CSSNumberish b,
+    CSSNumberish b, [
     CSSNumberish alpha,
-  );
+  ]);
 }
 
 extension CSSHWBExtension on CSSHWB {
@@ -592,21 +494,13 @@ extension CSSHWBExtension on CSSHWB {
 
 @JS('CSSLab')
 @staticInterop
-class CSSLab extends CSSColorValue {
-  external factory CSSLab();
-
-  external factory CSSLab.a1(
+class CSSLab implements CSSColorValue {
+  external factory CSSLab(
     CSSColorPercent l,
     CSSColorNumber a,
-    CSSColorNumber b,
-  );
-
-  external factory CSSLab.a2(
-    CSSColorPercent l,
-    CSSColorNumber a,
-    CSSColorNumber b,
+    CSSColorNumber b, [
     CSSColorPercent alpha,
-  );
+  ]);
 }
 
 extension CSSLabExtension on CSSLab {
@@ -622,21 +516,13 @@ extension CSSLabExtension on CSSLab {
 
 @JS('CSSLCH')
 @staticInterop
-class CSSLCH extends CSSColorValue {
-  external factory CSSLCH();
-
-  external factory CSSLCH.a1(
+class CSSLCH implements CSSColorValue {
+  external factory CSSLCH(
     CSSColorPercent l,
     CSSColorPercent c,
-    CSSColorAngle h,
-  );
-
-  external factory CSSLCH.a2(
-    CSSColorPercent l,
-    CSSColorPercent c,
-    CSSColorAngle h,
+    CSSColorAngle h, [
     CSSColorPercent alpha,
-  );
+  ]);
 }
 
 extension CSSLCHExtension on CSSLCH {
@@ -652,21 +538,13 @@ extension CSSLCHExtension on CSSLCH {
 
 @JS('CSSOKLab')
 @staticInterop
-class CSSOKLab extends CSSColorValue {
-  external factory CSSOKLab();
-
-  external factory CSSOKLab.a1(
+class CSSOKLab implements CSSColorValue {
+  external factory CSSOKLab(
     CSSColorPercent l,
     CSSColorNumber a,
-    CSSColorNumber b,
-  );
-
-  external factory CSSOKLab.a2(
-    CSSColorPercent l,
-    CSSColorNumber a,
-    CSSColorNumber b,
+    CSSColorNumber b, [
     CSSColorPercent alpha,
-  );
+  ]);
 }
 
 extension CSSOKLabExtension on CSSOKLab {
@@ -682,21 +560,13 @@ extension CSSOKLabExtension on CSSOKLab {
 
 @JS('CSSOKLCH')
 @staticInterop
-class CSSOKLCH extends CSSColorValue {
-  external factory CSSOKLCH();
-
-  external factory CSSOKLCH.a1(
+class CSSOKLCH implements CSSColorValue {
+  external factory CSSOKLCH(
     CSSColorPercent l,
     CSSColorPercent c,
-    CSSColorAngle h,
-  );
-
-  external factory CSSOKLCH.a2(
-    CSSColorPercent l,
-    CSSColorPercent c,
-    CSSColorAngle h,
+    CSSColorAngle h, [
     CSSColorPercent alpha,
-  );
+  ]);
 }
 
 extension CSSOKLCHExtension on CSSOKLCH {
@@ -712,19 +582,12 @@ extension CSSOKLCHExtension on CSSOKLCH {
 
 @JS('CSSColor')
 @staticInterop
-class CSSColor extends CSSColorValue {
-  external factory CSSColor();
-
-  external factory CSSColor.a1(
+class CSSColor implements CSSColorValue {
+  external factory CSSColor(
     CSSKeywordish colorSpace,
-    JSArray channels,
-  );
-
-  external factory CSSColor.a2(
-    CSSKeywordish colorSpace,
-    JSArray channels,
+    JSArray channels, [
     CSSNumberish alpha,
-  );
+  ]);
 }
 
 extension CSSColorExtension on CSSColor {

--- a/lib/src/dom/css_view_transitions.dart
+++ b/lib/src/dom/css_view_transitions.dart
@@ -12,13 +12,11 @@ typedef UpdateCallback = JSFunction;
 
 @JS('ViewTransition')
 @staticInterop
-class ViewTransition {
-  external factory ViewTransition();
-}
+class ViewTransition {}
 
 extension ViewTransitionExtension on ViewTransition {
+  external JSVoid skipTransition();
   external JSPromise get updateCallbackDone;
   external JSPromise get ready;
   external JSPromise get finished;
-  external JSVoid skipTransition();
 }

--- a/lib/src/dom/cssom.dart
+++ b/lib/src/dom/cssom.dart
@@ -16,24 +16,20 @@ import 'html.dart';
 
 @JS('MediaList')
 @staticInterop
-class MediaList {
-  external factory MediaList();
-}
+class MediaList {}
 
 extension MediaListExtension on MediaList {
-  external set mediaText(JSString value);
-  external JSString get mediaText;
-  external JSNumber get length;
   external JSString? item(JSNumber index);
   external JSVoid appendMedium(JSString medium);
   external JSVoid deleteMedium(JSString medium);
+  external set mediaText(JSString value);
+  external JSString get mediaText;
+  external JSNumber get length;
 }
 
 @JS('StyleSheet')
 @staticInterop
-class StyleSheet {
-  external factory StyleSheet();
-}
+class StyleSheet {}
 
 extension StyleSheetExtension on StyleSheet {
   external JSString get type;
@@ -48,39 +44,27 @@ extension StyleSheetExtension on StyleSheet {
 
 @JS('CSSStyleSheet')
 @staticInterop
-class CSSStyleSheet extends StyleSheet {
-  external factory CSSStyleSheet();
-
-  external factory CSSStyleSheet.a1();
-
-  external factory CSSStyleSheet.a2(CSSStyleSheetInit options);
+class CSSStyleSheet implements StyleSheet {
+  external factory CSSStyleSheet([CSSStyleSheetInit options]);
 }
 
 extension CSSStyleSheetExtension on CSSStyleSheet {
-  external CSSRule? get ownerRule;
-  external CSSRuleList get cssRules;
-  external JSNumber insertRule(JSString rule);
-  external JSNumber insertRule1(
-    JSString rule,
+  external JSNumber insertRule(
+    JSString rule, [
     JSNumber index,
-  );
+  ]);
   external JSVoid deleteRule(JSNumber index);
   external JSPromise replace(JSString text);
   external JSVoid replaceSync(JSString text);
-  external CSSRuleList get rules;
-  external JSNumber addRule();
-  external JSNumber addRule1(JSString selector);
-  external JSNumber addRule2(
-    JSString selector,
-    JSString style,
-  );
-  external JSNumber addRule3(
+  external JSNumber addRule([
     JSString selector,
     JSString style,
     JSNumber index,
-  );
-  external JSVoid removeRule();
-  external JSVoid removeRule1(JSNumber index);
+  ]);
+  external JSVoid removeRule([JSNumber index]);
+  external CSSRule? get ownerRule;
+  external CSSRuleList get cssRules;
+  external CSSRuleList get rules;
 }
 
 @JS()
@@ -105,9 +89,7 @@ extension CSSStyleSheetInitExtension on CSSStyleSheetInit {
 
 @JS('StyleSheetList')
 @staticInterop
-class StyleSheetList {
-  external factory StyleSheetList();
-}
+class StyleSheetList {}
 
 extension StyleSheetListExtension on StyleSheetList {
   external CSSStyleSheet? item(JSNumber index);
@@ -116,9 +98,7 @@ extension StyleSheetListExtension on StyleSheetList {
 
 @JS('LinkStyle')
 @staticInterop
-class LinkStyle {
-  external factory LinkStyle();
-}
+class LinkStyle {}
 
 extension LinkStyleExtension on LinkStyle {
   external CSSStyleSheet? get sheet;
@@ -126,9 +106,7 @@ extension LinkStyleExtension on LinkStyle {
 
 @JS('CSSRuleList')
 @staticInterop
-class CSSRuleList {
-  external factory CSSRuleList();
-}
+class CSSRuleList {}
 
 extension CSSRuleListExtension on CSSRuleList {
   external CSSRule? item(JSNumber index);
@@ -138,8 +116,6 @@ extension CSSRuleListExtension on CSSRuleList {
 @JS('CSSRule')
 @staticInterop
 class CSSRule {
-  external factory CSSRule();
-
   external static JSNumber get KEYFRAMES_RULE;
   external static JSNumber get KEYFRAME_RULE;
   external static JSNumber get SUPPORTS_RULE;
@@ -165,18 +141,15 @@ extension CSSRuleExtension on CSSRule {
 
 @JS('CSSStyleRule')
 @staticInterop
-class CSSStyleRule extends CSSRule {
-  external factory CSSStyleRule();
-}
+class CSSStyleRule implements CSSRule {}
 
 extension CSSStyleRuleExtension on CSSStyleRule {
-  external CSSRuleList get cssRules;
-  external JSNumber insertRule(JSString rule);
-  external JSNumber insertRule1(
-    JSString rule,
+  external JSNumber insertRule(
+    JSString rule, [
     JSNumber index,
-  );
+  ]);
   external JSVoid deleteRule(JSNumber index);
+  external CSSRuleList get cssRules;
   external StylePropertyMap get styleMap;
   external set selectorText(JSString value);
   external JSString get selectorText;
@@ -185,9 +158,7 @@ extension CSSStyleRuleExtension on CSSStyleRule {
 
 @JS('CSSImportRule')
 @staticInterop
-class CSSImportRule extends CSSRule {
-  external factory CSSImportRule();
-}
+class CSSImportRule implements CSSRule {}
 
 extension CSSImportRuleExtension on CSSImportRule {
   external JSString? get layerName;
@@ -198,25 +169,20 @@ extension CSSImportRuleExtension on CSSImportRule {
 
 @JS('CSSGroupingRule')
 @staticInterop
-class CSSGroupingRule extends CSSRule {
-  external factory CSSGroupingRule();
-}
+class CSSGroupingRule implements CSSRule {}
 
 extension CSSGroupingRuleExtension on CSSGroupingRule {
-  external CSSRuleList get cssRules;
-  external JSNumber insertRule(JSString rule);
-  external JSNumber insertRule1(
-    JSString rule,
+  external JSNumber insertRule(
+    JSString rule, [
     JSNumber index,
-  );
+  ]);
   external JSVoid deleteRule(JSNumber index);
+  external CSSRuleList get cssRules;
 }
 
 @JS('CSSPageRule')
 @staticInterop
-class CSSPageRule extends CSSGroupingRule {
-  external factory CSSPageRule();
-}
+class CSSPageRule implements CSSGroupingRule {}
 
 extension CSSPageRuleExtension on CSSPageRule {
   external set selectorText(JSString value);
@@ -226,9 +192,7 @@ extension CSSPageRuleExtension on CSSPageRule {
 
 @JS('CSSMarginRule')
 @staticInterop
-class CSSMarginRule extends CSSRule {
-  external factory CSSMarginRule();
-}
+class CSSMarginRule implements CSSRule {}
 
 extension CSSMarginRuleExtension on CSSMarginRule {
   external JSString get name;
@@ -237,9 +201,7 @@ extension CSSMarginRuleExtension on CSSMarginRule {
 
 @JS('CSSNamespaceRule')
 @staticInterop
-class CSSNamespaceRule extends CSSRule {
-  external factory CSSNamespaceRule();
-}
+class CSSNamespaceRule implements CSSRule {}
 
 extension CSSNamespaceRuleExtension on CSSNamespaceRule {
   external JSString get namespaceURI;
@@ -248,27 +210,21 @@ extension CSSNamespaceRuleExtension on CSSNamespaceRule {
 
 @JS('CSSStyleDeclaration')
 @staticInterop
-class CSSStyleDeclaration {
-  external factory CSSStyleDeclaration();
-}
+class CSSStyleDeclaration {}
 
 extension CSSStyleDeclarationExtension on CSSStyleDeclaration {
-  external set cssText(JSString value);
-  external JSString get cssText;
-  external JSNumber get length;
   external JSString item(JSNumber index);
   external JSString getPropertyValue(JSString property);
   external JSString getPropertyPriority(JSString property);
   external JSVoid setProperty(
     JSString property,
-    JSString value,
-  );
-  external JSVoid setProperty1(
-    JSString property,
-    JSString value,
+    JSString value, [
     JSString priority,
-  );
+  ]);
   external JSString removeProperty(JSString property);
+  external set cssText(JSString value);
+  external JSString get cssText;
+  external JSNumber get length;
   external CSSRule? get parentRule;
   external set cssFloat(JSString value);
   external JSString get cssFloat;
@@ -276,9 +232,7 @@ extension CSSStyleDeclarationExtension on CSSStyleDeclaration {
 
 @JS('ElementCSSInlineStyle')
 @staticInterop
-class ElementCSSInlineStyle {
-  external factory ElementCSSInlineStyle();
-}
+class ElementCSSInlineStyle {}
 
 extension ElementCSSInlineStyleExtension on ElementCSSInlineStyle {
   external StylePropertyMap get attributeStyleMap;
@@ -290,47 +244,33 @@ external $CSS get CSS;
 
 @JS('CSS')
 @staticInterop
-abstract class $CSS {
-  external factory $CSS();
-}
+abstract class $CSS {}
 
 extension $CSSExtension on $CSS {
-  external Worklet get animationWorklet;
   external JSBoolean supports(
-    JSString property,
+    JSString conditionTextOrProperty, [
     JSString value,
-  );
-  @JS('supports')
-  external JSBoolean supports_1_(JSString conditionText);
-  external HighlightRegistry get highlights;
-  external JSAny get elementSources;
-  external Worklet get layoutWorklet;
-  external Worklet get paintWorklet;
-  external JSPromise parseStylesheet(CSSStringSource css);
-  external JSPromise parseStylesheet1(
-    CSSStringSource css,
+  ]);
+  external JSPromise parseStylesheet(
+    CSSStringSource css, [
     CSSParserOptions options,
-  );
-  external JSPromise parseRuleList(CSSStringSource css);
-  external JSPromise parseRuleList1(
-    CSSStringSource css,
+  ]);
+  external JSPromise parseRuleList(
+    CSSStringSource css, [
     CSSParserOptions options,
-  );
-  external JSPromise parseRule(CSSStringSource css);
-  external JSPromise parseRule1(
-    CSSStringSource css,
+  ]);
+  external JSPromise parseRule(
+    CSSStringSource css, [
     CSSParserOptions options,
-  );
-  external JSPromise parseDeclarationList(CSSStringSource css);
-  external JSPromise parseDeclarationList1(
-    CSSStringSource css,
+  ]);
+  external JSPromise parseDeclarationList(
+    CSSStringSource css, [
     CSSParserOptions options,
-  );
-  external CSSParserDeclaration parseDeclaration(JSString css);
-  external CSSParserDeclaration parseDeclaration1(
-    JSString css,
+  ]);
+  external CSSParserDeclaration parseDeclaration(
+    JSString css, [
     CSSParserOptions options,
-  );
+  ]);
   external CSSToken parseValue(JSString css);
   external JSArray parseValueList(JSString css);
   external JSArray parseCommaValueList(JSString css);
@@ -378,7 +318,7 @@ extension $CSSExtension on $CSS {
   external CSSUnitValue mm(JSNumber value);
   external CSSUnitValue Q(JSNumber value);
   @JS('in')
-  external CSSUnitValue in_0_(JSNumber value);
+  external CSSUnitValue in_(JSNumber value);
   external CSSUnitValue pt(JSNumber value);
   external CSSUnitValue pc(JSNumber value);
   external CSSUnitValue px(JSNumber value);
@@ -395,4 +335,9 @@ extension $CSSExtension on $CSS {
   external CSSUnitValue dppx(JSNumber value);
   external CSSUnitValue fr(JSNumber value);
   external JSString escape(JSString ident);
+  external Worklet get animationWorklet;
+  external HighlightRegistry get highlights;
+  external JSAny get elementSources;
+  external Worklet get layoutWorklet;
+  external Worklet get paintWorklet;
 }

--- a/lib/src/dom/cssom_view.dart
+++ b/lib/src/dom/cssom_view.dart
@@ -33,7 +33,7 @@ extension ScrollOptionsExtension on ScrollOptions {
 @JS()
 @staticInterop
 @anonymous
-class ScrollToOptions extends ScrollOptions {
+class ScrollToOptions implements ScrollOptions {
   external factory ScrollToOptions({
     JSNumber left,
     JSNumber top,
@@ -49,30 +49,24 @@ extension ScrollToOptionsExtension on ScrollToOptions {
 
 @JS('MediaQueryList')
 @staticInterop
-class MediaQueryList extends EventTarget {
-  external factory MediaQueryList();
-}
+class MediaQueryList implements EventTarget {}
 
 extension MediaQueryListExtension on MediaQueryList {
-  external JSString get media;
-  external JSBoolean get matches;
   external JSVoid addListener(EventListener? callback);
   external JSVoid removeListener(EventListener? callback);
+  external JSString get media;
+  external JSBoolean get matches;
   external set onchange(EventHandler value);
   external EventHandler get onchange;
 }
 
 @JS('MediaQueryListEvent')
 @staticInterop
-class MediaQueryListEvent extends Event {
-  external factory MediaQueryListEvent();
-
-  external factory MediaQueryListEvent.a1(JSString type);
-
-  external factory MediaQueryListEvent.a2(
-    JSString type,
+class MediaQueryListEvent implements Event {
+  external factory MediaQueryListEvent(
+    JSString type, [
     MediaQueryListEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension MediaQueryListEventExtension on MediaQueryListEvent {
@@ -83,7 +77,7 @@ extension MediaQueryListEventExtension on MediaQueryListEvent {
 @JS()
 @staticInterop
 @anonymous
-class MediaQueryListEventInit extends EventInit {
+class MediaQueryListEventInit implements EventInit {
   external factory MediaQueryListEventInit({
     JSString media = '',
     JSBoolean matches = false,
@@ -99,9 +93,7 @@ extension MediaQueryListEventInitExtension on MediaQueryListEventInit {
 
 @JS('Screen')
 @staticInterop
-class Screen {
-  external factory Screen();
-}
+class Screen {}
 
 extension ScreenExtension on Screen {
   external JSNumber get availWidth;
@@ -118,20 +110,18 @@ extension ScreenExtension on Screen {
 
 @JS('CaretPosition')
 @staticInterop
-class CaretPosition {
-  external factory CaretPosition();
-}
+class CaretPosition {}
 
 extension CaretPositionExtension on CaretPosition {
+  external DOMRect? getClientRect();
   external Node get offsetNode;
   external JSNumber get offset;
-  external DOMRect? getClientRect();
 }
 
 @JS()
 @staticInterop
 @anonymous
-class ScrollIntoViewOptions extends ScrollOptions {
+class ScrollIntoViewOptions implements ScrollOptions {
   external factory ScrollIntoViewOptions({
     ScrollLogicalPosition block = 'start',
     ScrollLogicalPosition inline = 'nearest',
@@ -198,47 +188,30 @@ extension ConvertCoordinateOptionsExtension on ConvertCoordinateOptions {
 
 @JS('GeometryUtils')
 @staticInterop
-class GeometryUtils {
-  external factory GeometryUtils();
-}
+class GeometryUtils {}
 
 extension GeometryUtilsExtension on GeometryUtils {
-  external JSArray getBoxQuads();
-  external JSArray getBoxQuads1(BoxQuadOptions options);
+  external JSArray getBoxQuads([BoxQuadOptions options]);
   external DOMQuad convertQuadFromNode(
     DOMQuadInit quad,
-    GeometryNode from,
-  );
-  external DOMQuad convertQuadFromNode1(
-    DOMQuadInit quad,
-    GeometryNode from,
+    GeometryNode from, [
     ConvertCoordinateOptions options,
-  );
+  ]);
   external DOMQuad convertRectFromNode(
     DOMRectReadOnly rect,
-    GeometryNode from,
-  );
-  external DOMQuad convertRectFromNode1(
-    DOMRectReadOnly rect,
-    GeometryNode from,
+    GeometryNode from, [
     ConvertCoordinateOptions options,
-  );
+  ]);
   external DOMPoint convertPointFromNode(
     DOMPointInit point,
-    GeometryNode from,
-  );
-  external DOMPoint convertPointFromNode1(
-    DOMPointInit point,
-    GeometryNode from,
+    GeometryNode from, [
     ConvertCoordinateOptions options,
-  );
+  ]);
 }
 
 @JS('VisualViewport')
 @staticInterop
-class VisualViewport extends EventTarget {
-  external factory VisualViewport();
-}
+class VisualViewport implements EventTarget {}
 
 extension VisualViewportExtension on VisualViewport {
   external JSNumber get offsetLeft;

--- a/lib/src/dom/custom_state_pseudo_class.dart
+++ b/lib/src/dom/custom_state_pseudo_class.dart
@@ -10,9 +10,7 @@ import 'package:js/js.dart' hide JS;
 
 @JS('CustomStateSet')
 @staticInterop
-class CustomStateSet {
-  external factory CustomStateSet();
-}
+class CustomStateSet {}
 
 extension CustomStateSetExtension on CustomStateSet {
   external JSVoid add(JSString value);

--- a/lib/src/dom/datacue.dart
+++ b/lib/src/dom/datacue.dart
@@ -12,21 +12,13 @@ import 'html.dart';
 
 @JS('DataCue')
 @staticInterop
-class DataCue extends TextTrackCue {
-  external factory DataCue();
-
-  external factory DataCue.a1(
+class DataCue implements TextTrackCue {
+  external factory DataCue(
     JSNumber startTime,
     JSNumber endTime,
-    JSAny value,
-  );
-
-  external factory DataCue.a2(
-    JSNumber startTime,
-    JSNumber endTime,
-    JSAny value,
+    JSAny value, [
     JSString type,
-  );
+  ]);
 }
 
 extension DataCueExtension on DataCue {

--- a/lib/src/dom/deprecation_reporting.dart
+++ b/lib/src/dom/deprecation_reporting.dart
@@ -12,9 +12,7 @@ import 'reporting.dart';
 
 @JS('DeprecationReportBody')
 @staticInterop
-class DeprecationReportBody extends ReportBody {
-  external factory DeprecationReportBody();
-}
+class DeprecationReportBody implements ReportBody {}
 
 extension DeprecationReportBodyExtension on DeprecationReportBody {
   external JSObject toJSON();

--- a/lib/src/dom/device_memory.dart
+++ b/lib/src/dom/device_memory.dart
@@ -10,9 +10,7 @@ import 'package:js/js.dart' hide JS;
 
 @JS('NavigatorDeviceMemory')
 @staticInterop
-class NavigatorDeviceMemory {
-  external factory NavigatorDeviceMemory();
-}
+class NavigatorDeviceMemory {}
 
 extension NavigatorDeviceMemoryExtension on NavigatorDeviceMemory {
   external JSNumber get deviceMemory;

--- a/lib/src/dom/device_posture.dart
+++ b/lib/src/dom/device_posture.dart
@@ -15,9 +15,7 @@ typedef DevicePostureType = JSString;
 
 @JS('DevicePosture')
 @staticInterop
-class DevicePosture extends EventTarget {
-  external factory DevicePosture();
-}
+class DevicePosture implements EventTarget {}
 
 extension DevicePostureExtension on DevicePosture {
   external DevicePostureType get type;

--- a/lib/src/dom/digital_goods.dart
+++ b/lib/src/dom/digital_goods.dart
@@ -14,9 +14,7 @@ typedef ItemType = JSString;
 
 @JS('DigitalGoodsService')
 @staticInterop
-class DigitalGoodsService {
-  external factory DigitalGoodsService();
-}
+class DigitalGoodsService {}
 
 extension DigitalGoodsServiceExtension on DigitalGoodsService {
   external JSPromise getDetails(JSArray itemIds);

--- a/lib/src/dom/dom.dart
+++ b/lib/src/dom/dom.dart
@@ -41,14 +41,10 @@ typedef SlotAssignmentMode = JSString;
 @JS('Event')
 @staticInterop
 class Event {
-  external factory Event();
-
-  external factory Event.a1(JSString type);
-
-  external factory Event.a2(
-    JSString type,
+  external factory Event(
+    JSString type, [
     EventInit eventInitDict,
-  );
+  ]);
 
   external static JSNumber get NONE;
   external static JSNumber get CAPTURING_PHASE;
@@ -57,35 +53,30 @@ class Event {
 }
 
 extension EventExtension on Event {
+  external JSArray composedPath();
+  external JSVoid stopPropagation();
+  external JSVoid stopImmediatePropagation();
+  external JSVoid preventDefault();
+  external JSVoid initEvent(
+    JSString type, [
+    JSBoolean bubbles,
+    JSBoolean cancelable,
+  ]);
   external JSString get type;
   external EventTarget? get target;
   external EventTarget? get srcElement;
   external EventTarget? get currentTarget;
-  external JSArray composedPath();
   external JSNumber get eventPhase;
-  external JSVoid stopPropagation();
   external set cancelBubble(JSBoolean value);
   external JSBoolean get cancelBubble;
-  external JSVoid stopImmediatePropagation();
   external JSBoolean get bubbles;
   external JSBoolean get cancelable;
   external set returnValue(JSBoolean value);
   external JSBoolean get returnValue;
-  external JSVoid preventDefault();
   external JSBoolean get defaultPrevented;
   external JSBoolean get composed;
   external JSBoolean get isTrusted;
   external DOMHighResTimeStamp get timeStamp;
-  external JSVoid initEvent(JSString type);
-  external JSVoid initEvent1(
-    JSString type,
-    JSBoolean bubbles,
-  );
-  external JSVoid initEvent2(
-    JSString type,
-    JSBoolean bubbles,
-    JSBoolean cancelable,
-  );
 }
 
 @JS()
@@ -110,41 +101,27 @@ extension EventInitExtension on EventInit {
 
 @JS('CustomEvent')
 @staticInterop
-class CustomEvent extends Event {
-  external factory CustomEvent();
-
-  external factory CustomEvent.a1(JSString type);
-
-  external factory CustomEvent.a2(
-    JSString type,
+class CustomEvent implements Event {
+  external factory CustomEvent(
+    JSString type, [
     CustomEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension CustomEventExtension on CustomEvent {
-  external JSAny get detail;
-  external JSVoid initCustomEvent(JSString type);
-  external JSVoid initCustomEvent1(
-    JSString type,
-    JSBoolean bubbles,
-  );
-  external JSVoid initCustomEvent2(
-    JSString type,
-    JSBoolean bubbles,
-    JSBoolean cancelable,
-  );
-  external JSVoid initCustomEvent3(
-    JSString type,
+  external JSVoid initCustomEvent(
+    JSString type, [
     JSBoolean bubbles,
     JSBoolean cancelable,
     JSAny detail,
-  );
+  ]);
+  external JSAny get detail;
 }
 
 @JS()
 @staticInterop
 @anonymous
-class CustomEventInit extends EventInit {
+class CustomEventInit implements EventInit {
   external factory CustomEventInit({JSAny detail});
 }
 
@@ -156,28 +133,20 @@ extension CustomEventInitExtension on CustomEventInit {
 @JS('EventTarget')
 @staticInterop
 class EventTarget {
-  external factory EventTarget.a0();
+  external factory EventTarget();
 }
 
 extension EventTargetExtension on EventTarget {
   external JSVoid addEventListener(
     JSString type,
-    EventListener? callback,
-  );
-  external JSVoid addEventListener1(
-    JSString type,
-    EventListener? callback,
+    EventListener? callback, [
     JSAny options,
-  );
+  ]);
   external JSVoid removeEventListener(
     JSString type,
-    EventListener? callback,
-  );
-  external JSVoid removeEventListener1(
-    JSString type,
-    EventListener? callback,
+    EventListener? callback, [
     JSAny options,
-  );
+  ]);
   external JSBoolean dispatchEvent(Event event);
 }
 
@@ -196,7 +165,7 @@ extension EventListenerOptionsExtension on EventListenerOptions {
 @JS()
 @staticInterop
 @anonymous
-class AddEventListenerOptions extends EventListenerOptions {
+class AddEventListenerOptions implements EventListenerOptions {
   external factory AddEventListenerOptions({
     JSBoolean passive,
     JSBoolean once = false,
@@ -216,38 +185,32 @@ extension AddEventListenerOptionsExtension on AddEventListenerOptions {
 @JS('AbortController')
 @staticInterop
 class AbortController {
-  external factory AbortController.a0();
+  external factory AbortController();
 }
 
 extension AbortControllerExtension on AbortController {
+  external JSVoid abort([JSAny reason]);
   external AbortSignal get signal;
-  external JSVoid abort();
-  external JSVoid abort1(JSAny reason);
 }
 
 @JS('AbortSignal')
 @staticInterop
-class AbortSignal extends EventTarget {
-  external factory AbortSignal();
-
-  external static AbortSignal abort();
-  external static AbortSignal abort1(JSAny reason);
+class AbortSignal implements EventTarget {
+  external static AbortSignal abort([JSAny reason]);
   external static AbortSignal timeout(JSNumber milliseconds);
 }
 
 extension AbortSignalExtension on AbortSignal {
+  external JSVoid throwIfAborted();
   external JSBoolean get aborted;
   external JSAny get reason;
-  external JSVoid throwIfAborted();
   external set onabort(EventHandler value);
   external EventHandler get onabort;
 }
 
 @JS('NonElementParentNode')
 @staticInterop
-class NonElementParentNode {
-  external factory NonElementParentNode();
-}
+class NonElementParentNode {}
 
 extension NonElementParentNodeExtension on NonElementParentNode {
   external Element? getElementById(JSString elementId);
@@ -255,11 +218,10 @@ extension NonElementParentNodeExtension on NonElementParentNode {
 
 @JS('DocumentOrShadowRoot')
 @staticInterop
-class DocumentOrShadowRoot {
-  external factory DocumentOrShadowRoot();
-}
+class DocumentOrShadowRoot {}
 
 extension DocumentOrShadowRootExtension on DocumentOrShadowRoot {
+  external JSArray getAnimations();
   external StyleSheetList get styleSheets;
   external set adoptedStyleSheets(JSArray value);
   external JSArray get adoptedStyleSheets;
@@ -267,32 +229,27 @@ extension DocumentOrShadowRootExtension on DocumentOrShadowRoot {
   external Element? get activeElement;
   external Element? get pictureInPictureElement;
   external Element? get pointerLockElement;
-  external JSArray getAnimations();
 }
 
 @JS('ParentNode')
 @staticInterop
-class ParentNode {
-  external factory ParentNode();
-}
+class ParentNode {}
 
 extension ParentNodeExtension on ParentNode {
-  external HTMLCollection get children;
-  external Element? get firstElementChild;
-  external Element? get lastElementChild;
-  external JSNumber get childElementCount;
   external JSVoid prepend(JSAny nodes);
   external JSVoid append(JSAny nodes);
   external JSVoid replaceChildren(JSAny nodes);
   external Element? querySelector(JSString selectors);
   external NodeList querySelectorAll(JSString selectors);
+  external HTMLCollection get children;
+  external Element? get firstElementChild;
+  external Element? get lastElementChild;
+  external JSNumber get childElementCount;
 }
 
 @JS('NonDocumentTypeChildNode')
 @staticInterop
-class NonDocumentTypeChildNode {
-  external factory NonDocumentTypeChildNode();
-}
+class NonDocumentTypeChildNode {}
 
 extension NonDocumentTypeChildNodeExtension on NonDocumentTypeChildNode {
   external Element? get previousElementSibling;
@@ -301,9 +258,7 @@ extension NonDocumentTypeChildNodeExtension on NonDocumentTypeChildNode {
 
 @JS('ChildNode')
 @staticInterop
-class ChildNode {
-  external factory ChildNode();
-}
+class ChildNode {}
 
 extension ChildNodeExtension on ChildNode {
   external JSVoid before(JSAny nodes);
@@ -314,9 +269,7 @@ extension ChildNodeExtension on ChildNode {
 
 @JS('Slottable')
 @staticInterop
-class Slottable {
-  external factory Slottable();
-}
+class Slottable {}
 
 extension SlottableExtension on Slottable {
   external HTMLSlotElement? get assignedSlot;
@@ -324,9 +277,7 @@ extension SlottableExtension on Slottable {
 
 @JS('NodeList')
 @staticInterop
-class NodeList {
-  external factory NodeList();
-}
+class NodeList {}
 
 extension NodeListExtension on NodeList {
   external Node? item(JSNumber index);
@@ -335,30 +286,25 @@ extension NodeListExtension on NodeList {
 
 @JS('HTMLCollection')
 @staticInterop
-class HTMLCollection {
-  external factory HTMLCollection();
-}
+class HTMLCollection {}
 
 extension HTMLCollectionExtension on HTMLCollection {
-  external JSNumber get length;
   external Element? item(JSNumber index);
   external Element? namedItem(JSString name);
+  external JSNumber get length;
 }
 
 @JS('MutationObserver')
 @staticInterop
 class MutationObserver {
-  external factory MutationObserver();
-
-  external factory MutationObserver.a1(MutationCallback callback);
+  external factory MutationObserver(MutationCallback callback);
 }
 
 extension MutationObserverExtension on MutationObserver {
-  external JSVoid observe(Node target);
-  external JSVoid observe1(
-    Node target,
+  external JSVoid observe(
+    Node target, [
     MutationObserverInit options,
-  );
+  ]);
   external JSVoid disconnect();
   external JSArray takeRecords();
 }
@@ -397,9 +343,7 @@ extension MutationObserverInitExtension on MutationObserverInit {
 
 @JS('MutationRecord')
 @staticInterop
-class MutationRecord {
-  external factory MutationRecord();
-}
+class MutationRecord {}
 
 extension MutationRecordExtension on MutationRecord {
   external JSString get type;
@@ -415,9 +359,7 @@ extension MutationRecordExtension on MutationRecord {
 
 @JS('Node')
 @staticInterop
-class Node extends EventTarget {
-  external factory Node();
-
+class Node implements EventTarget {
   external static JSNumber get ELEMENT_NODE;
   external static JSNumber get ATTRIBUTE_NODE;
   external static JSNumber get TEXT_NODE;
@@ -439,28 +381,10 @@ class Node extends EventTarget {
 }
 
 extension NodeExtension on Node {
-  external JSNumber get nodeType;
-  external JSString get nodeName;
-  external JSString get baseURI;
-  external JSBoolean get isConnected;
-  external Document? get ownerDocument;
-  external Node getRootNode();
-  external Node getRootNode1(GetRootNodeOptions options);
-  external Node? get parentNode;
-  external Element? get parentElement;
+  external Node getRootNode([GetRootNodeOptions options]);
   external JSBoolean hasChildNodes();
-  external NodeList get childNodes;
-  external Node? get firstChild;
-  external Node? get lastChild;
-  external Node? get previousSibling;
-  external Node? get nextSibling;
-  external set nodeValue(JSString? value);
-  external JSString? get nodeValue;
-  external set textContent(JSString? value);
-  external JSString? get textContent;
   external JSVoid normalize();
-  external Node cloneNode();
-  external Node cloneNode1(JSBoolean deep);
+  external Node cloneNode([JSBoolean deep]);
   external JSBoolean isEqualNode(Node? otherNode);
   external JSBoolean isSameNode(Node? otherNode);
   external JSNumber compareDocumentPosition(Node other);
@@ -478,6 +402,22 @@ extension NodeExtension on Node {
     Node child,
   );
   external Node removeChild(Node child);
+  external JSNumber get nodeType;
+  external JSString get nodeName;
+  external JSString get baseURI;
+  external JSBoolean get isConnected;
+  external Document? get ownerDocument;
+  external Node? get parentNode;
+  external Element? get parentElement;
+  external NodeList get childNodes;
+  external Node? get firstChild;
+  external Node? get lastChild;
+  external Node? get previousSibling;
+  external Node? get nextSibling;
+  external set nodeValue(JSString? value);
+  external JSString? get nodeValue;
+  external set textContent(JSString? value);
+  external JSString? get textContent;
 }
 
 @JS()
@@ -497,8 +437,9 @@ external Document get document;
 
 @JS('Document')
 @staticInterop
-class Document extends Node
+class Document
     implements
+        Node,
         FontFaceSource,
         GeometryUtils,
         NonElementParentNode,
@@ -506,14 +447,11 @@ class Document extends Node
         ParentNode,
         XPathEvaluatorBase,
         GlobalEventHandlers {
-  external factory Document.a0();
+  external factory Document();
 }
 
 extension DocumentExtension on Document {
-  external SVGSVGElement? get rootElement;
-  external NamedFlowMap get namedFlows;
-  external ViewTransition startViewTransition();
-  external ViewTransition startViewTransition1(UpdateCallback? updateCallback);
+  external ViewTransition startViewTransition([UpdateCallback? updateCallback]);
   external Element? elementFromPoint(
     JSNumber x,
     JSNumber y,
@@ -526,6 +464,88 @@ extension DocumentExtension on Document {
     JSNumber x,
     JSNumber y,
   );
+  external HTMLCollection getElementsByTagName(JSString qualifiedName);
+  external HTMLCollection getElementsByTagNameNS(
+    JSString? namespace,
+    JSString localName,
+  );
+  external HTMLCollection getElementsByClassName(JSString classNames);
+  external Element createElement(
+    JSString localName, [
+    JSAny options,
+  ]);
+  external Element createElementNS(
+    JSString? namespace,
+    JSString qualifiedName, [
+    JSAny options,
+  ]);
+  external DocumentFragment createDocumentFragment();
+  external Text createTextNode(JSString data);
+  external CDATASection createCDATASection(JSString data);
+  external Comment createComment(JSString data);
+  external ProcessingInstruction createProcessingInstruction(
+    JSString target,
+    JSString data,
+  );
+  external Node importNode(
+    Node node, [
+    JSBoolean deep,
+  ]);
+  external Node adoptNode(Node node);
+  external Attr createAttribute(JSString localName);
+  external Attr createAttributeNS(
+    JSString? namespace,
+    JSString qualifiedName,
+  );
+  external Event createEvent(JSString interface);
+  external Range createRange();
+  external NodeIterator createNodeIterator(
+    Node root, [
+    JSNumber whatToShow,
+    NodeFilter? filter,
+  ]);
+  external TreeWalker createTreeWalker(
+    Node root, [
+    JSNumber whatToShow,
+    NodeFilter? filter,
+  ]);
+  external FontMetrics measureElement(Element element);
+  external FontMetrics measureText(
+    JSString text,
+    StylePropertyMapReadOnly styleMap,
+  );
+  external JSPromise exitFullscreen();
+  external NodeList getElementsByName(JSString elementName);
+  external JSAny? open([
+    JSString unused1OrUrl,
+    JSString nameOrUnused2,
+    JSString features,
+  ]);
+  external JSVoid close();
+  external JSVoid write(JSString text);
+  external JSVoid writeln(JSString text);
+  external JSBoolean hasFocus();
+  external JSBoolean execCommand(
+    JSString commandId, [
+    JSBoolean showUI,
+    JSString value,
+  ]);
+  external JSBoolean queryCommandEnabled(JSString commandId);
+  external JSBoolean queryCommandIndeterm(JSString commandId);
+  external JSBoolean queryCommandState(JSString commandId);
+  external JSBoolean queryCommandSupported(JSString commandId);
+  external JSString queryCommandValue(JSString commandId);
+  external JSVoid clear();
+  external JSVoid captureEvents();
+  external JSVoid releaseEvents();
+  external JSPromise exitPictureInPicture();
+  external JSVoid exitPointerLock();
+  external JSPromise requestStorageAccessForOrigin(JSString origin);
+  external Selection? getSelection();
+  external JSPromise hasStorageAccess();
+  external JSPromise requestStorageAccess();
+  external SVGSVGElement? get rootElement;
+  external NamedFlowMap get namedFlows;
   external Element? get scrollingElement;
   external DOMImplementation get implementation;
   external JSString get URL;
@@ -537,75 +557,8 @@ extension DocumentExtension on Document {
   external JSString get contentType;
   external DocumentType? get doctype;
   external Element? get documentElement;
-  external HTMLCollection getElementsByTagName(JSString qualifiedName);
-  external HTMLCollection getElementsByTagNameNS(
-    JSString? namespace,
-    JSString localName,
-  );
-  external HTMLCollection getElementsByClassName(JSString classNames);
-  external Element createElement(JSString localName);
-  external Element createElement1(
-    JSString localName,
-    JSAny options,
-  );
-  external Element createElementNS(
-    JSString? namespace,
-    JSString qualifiedName,
-  );
-  external Element createElementNS1(
-    JSString? namespace,
-    JSString qualifiedName,
-    JSAny options,
-  );
-  external DocumentFragment createDocumentFragment();
-  external Text createTextNode(JSString data);
-  external CDATASection createCDATASection(JSString data);
-  external Comment createComment(JSString data);
-  external ProcessingInstruction createProcessingInstruction(
-    JSString target,
-    JSString data,
-  );
-  external Node importNode(Node node);
-  external Node importNode1(
-    Node node,
-    JSBoolean deep,
-  );
-  external Node adoptNode(Node node);
-  external Attr createAttribute(JSString localName);
-  external Attr createAttributeNS(
-    JSString? namespace,
-    JSString qualifiedName,
-  );
-  external Event createEvent(JSString interface);
-  external Range createRange();
-  external NodeIterator createNodeIterator(Node root);
-  external NodeIterator createNodeIterator1(
-    Node root,
-    JSNumber whatToShow,
-  );
-  external NodeIterator createNodeIterator2(
-    Node root,
-    JSNumber whatToShow,
-    NodeFilter? filter,
-  );
-  external TreeWalker createTreeWalker(Node root);
-  external TreeWalker createTreeWalker1(
-    Node root,
-    JSNumber whatToShow,
-  );
-  external TreeWalker createTreeWalker2(
-    Node root,
-    JSNumber whatToShow,
-    NodeFilter? filter,
-  );
-  external FontMetrics measureElement(Element element);
-  external FontMetrics measureText(
-    JSString text,
-    StylePropertyMapReadOnly styleMap,
-  );
   external JSBoolean get fullscreenEnabled;
   external JSBoolean get fullscreen;
-  external JSPromise exitFullscreen();
   external set onfullscreenchange(EventHandler value);
   external EventHandler get onfullscreenchange;
   external set onfullscreenerror(EventHandler value);
@@ -631,42 +584,10 @@ extension DocumentExtension on Document {
   external HTMLCollection get links;
   external HTMLCollection get forms;
   external HTMLCollection get scripts;
-  external NodeList getElementsByName(JSString elementName);
   external HTMLOrSVGScriptElement? get currentScript;
-  external Document open();
-  external Document open1(JSString unused1);
-  external Document open2(
-    JSString unused1,
-    JSString unused2,
-  );
-  @JS('open')
-  external Window? open_1_(
-    JSString url,
-    JSString name,
-    JSString features,
-  );
-  external JSVoid close();
-  external JSVoid write(JSString text);
-  external JSVoid writeln(JSString text);
   external Window? get defaultView;
-  external JSBoolean hasFocus();
   external set designMode(JSString value);
   external JSString get designMode;
-  external JSBoolean execCommand(JSString commandId);
-  external JSBoolean execCommand1(
-    JSString commandId,
-    JSBoolean showUI,
-  );
-  external JSBoolean execCommand2(
-    JSString commandId,
-    JSBoolean showUI,
-    JSString value,
-  );
-  external JSBoolean queryCommandEnabled(JSString commandId);
-  external JSBoolean queryCommandIndeterm(JSString commandId);
-  external JSBoolean queryCommandState(JSString commandId);
-  external JSBoolean queryCommandSupported(JSString commandId);
-  external JSString queryCommandValue(JSString commandId);
   external JSBoolean get hidden;
   external DocumentVisibilityState get visibilityState;
   external set onreadystatechange(EventHandler value);
@@ -685,9 +606,6 @@ extension DocumentExtension on Document {
   external JSString get bgColor;
   external HTMLCollection get anchors;
   external HTMLCollection get applets;
-  external JSVoid clear();
-  external JSVoid captureEvents();
-  external JSVoid releaseEvents();
   external HTMLAllCollection get all;
   external set onfreeze(EventHandler value);
   external EventHandler get onfreeze;
@@ -696,28 +614,20 @@ extension DocumentExtension on Document {
   external JSBoolean get wasDiscarded;
   external PermissionsPolicy get permissionsPolicy;
   external JSBoolean get pictureInPictureEnabled;
-  external JSPromise exitPictureInPicture();
   external set onpointerlockchange(EventHandler value);
   external EventHandler get onpointerlockchange;
   external set onpointerlockerror(EventHandler value);
   external EventHandler get onpointerlockerror;
-  external JSVoid exitPointerLock();
   external JSBoolean get prerendering;
   external set onprerenderingchange(EventHandler value);
   external EventHandler get onprerenderingchange;
-  external JSPromise requestStorageAccessForOrigin(JSString origin);
   external FragmentDirective get fragmentDirective;
-  external Selection? getSelection();
-  external JSPromise hasStorageAccess();
-  external JSPromise requestStorageAccess();
   external DocumentTimeline get timeline;
 }
 
 @JS('XMLDocument')
 @staticInterop
-class XMLDocument extends Document {
-  external factory XMLDocument();
-}
+class XMLDocument implements Document {}
 
 @JS()
 @staticInterop
@@ -728,16 +638,14 @@ class ElementCreationOptions {
 
 extension ElementCreationOptionsExtension on ElementCreationOptions {
   @JS('is')
-  external set is_0_(JSString value);
+  external set is_(JSString value);
   @JS('is')
-  external JSString get is_0_;
+  external JSString get is_;
 }
 
 @JS('DOMImplementation')
 @staticInterop
-class DOMImplementation {
-  external factory DOMImplementation();
-}
+class DOMImplementation {}
 
 extension DOMImplementationExtension on DOMImplementation {
   external DocumentType createDocumentType(
@@ -747,23 +655,16 @@ extension DOMImplementationExtension on DOMImplementation {
   );
   external XMLDocument createDocument(
     JSString? namespace,
-    JSString qualifiedName,
-  );
-  external XMLDocument createDocument1(
-    JSString? namespace,
-    JSString qualifiedName,
+    JSString qualifiedName, [
     DocumentType? doctype,
-  );
-  external Document createHTMLDocument();
-  external Document createHTMLDocument1(JSString title);
+  ]);
+  external Document createHTMLDocument([JSString title]);
   external JSBoolean hasFeature();
 }
 
 @JS('DocumentType')
 @staticInterop
-class DocumentType extends Node implements ChildNode {
-  external factory DocumentType();
-}
+class DocumentType implements Node, ChildNode {}
 
 extension DocumentTypeExtension on DocumentType {
   external JSString get name;
@@ -773,17 +674,13 @@ extension DocumentTypeExtension on DocumentType {
 
 @JS('DocumentFragment')
 @staticInterop
-class DocumentFragment extends Node
-    implements NonElementParentNode, ParentNode {
-  external factory DocumentFragment.a0();
+class DocumentFragment implements Node, NonElementParentNode, ParentNode {
+  external factory DocumentFragment();
 }
 
 @JS('ShadowRoot')
 @staticInterop
-class ShadowRoot extends DocumentFragment
-    implements InnerHTML, DocumentOrShadowRoot {
-  external factory ShadowRoot();
-}
+class ShadowRoot implements DocumentFragment, InnerHTML, DocumentOrShadowRoot {}
 
 extension ShadowRootExtension on ShadowRoot {
   external ShadowRootMode get mode;
@@ -796,8 +693,9 @@ extension ShadowRootExtension on ShadowRoot {
 
 @JS('Element')
 @staticInterop
-class Element extends Node
+class Element
     implements
+        Node,
         InnerHTML,
         Region,
         GeometryUtils,
@@ -806,55 +704,105 @@ class Element extends Node
         ChildNode,
         Slottable,
         ARIAMixin,
-        Animatable {
-  external factory Element();
-}
+        Animatable {}
 
 extension ElementExtension on Element {
-  external set outerHTML(JSString value);
-  external JSString get outerHTML;
   external JSVoid insertAdjacentHTML(
     JSString position,
     JSString text,
   );
   external Node getSpatialNavigationContainer();
-  external JSArray focusableAreas();
-  external JSArray focusableAreas1(FocusableAreasOption option);
-  external Node? spatialNavigationSearch(SpatialNavigationDirection dir);
-  external Node? spatialNavigationSearch1(
-    SpatialNavigationDirection dir,
+  external JSArray focusableAreas([FocusableAreasOption option]);
+  external Node? spatialNavigationSearch(
+    SpatialNavigationDirection dir, [
     SpatialNavigationSearchOptions options,
-  );
+  ]);
   external CSSPseudoElement? pseudo(JSString type);
-  external DOMTokenList get part;
   external StylePropertyMapReadOnly computedStyleMap();
   external DOMRectList getClientRects();
   external DOMRect getBoundingClientRect();
-  external JSBoolean checkVisibility();
-  external JSBoolean checkVisibility1(CheckVisibilityOptions options);
-  external JSVoid scrollIntoView();
-  external JSVoid scrollIntoView1(JSAny arg);
-  external JSVoid scroll();
-  external JSVoid scroll1(ScrollToOptions options);
-  @JS('scroll')
-  external JSVoid scroll_1_(
-    JSNumber x,
+  external JSBoolean checkVisibility([CheckVisibilityOptions options]);
+  external JSVoid scrollIntoView([JSAny arg]);
+  external JSVoid scroll([
+    JSAny optionsOrX,
     JSNumber y,
-  );
-  external JSVoid scrollTo();
-  external JSVoid scrollTo1(ScrollToOptions options);
-  @JS('scrollTo')
-  external JSVoid scrollTo_1_(
-    JSNumber x,
+  ]);
+  external JSVoid scrollTo([
+    JSAny optionsOrX,
     JSNumber y,
-  );
-  external JSVoid scrollBy();
-  external JSVoid scrollBy1(ScrollToOptions options);
-  @JS('scrollBy')
-  external JSVoid scrollBy_1_(
-    JSNumber x,
+  ]);
+  external JSVoid scrollBy([
+    JSAny optionsOrX,
     JSNumber y,
+  ]);
+  external JSBoolean hasAttributes();
+  external JSArray getAttributeNames();
+  external JSString? getAttribute(JSString qualifiedName);
+  external JSString? getAttributeNS(
+    JSString? namespace,
+    JSString localName,
   );
+  external JSVoid setAttribute(
+    JSString qualifiedName,
+    JSString value,
+  );
+  external JSVoid setAttributeNS(
+    JSString? namespace,
+    JSString qualifiedName,
+    JSString value,
+  );
+  external JSVoid removeAttribute(JSString qualifiedName);
+  external JSVoid removeAttributeNS(
+    JSString? namespace,
+    JSString localName,
+  );
+  external JSBoolean toggleAttribute(
+    JSString qualifiedName, [
+    JSBoolean force,
+  ]);
+  external JSBoolean hasAttribute(JSString qualifiedName);
+  external JSBoolean hasAttributeNS(
+    JSString? namespace,
+    JSString localName,
+  );
+  external Attr? getAttributeNode(JSString qualifiedName);
+  external Attr? getAttributeNodeNS(
+    JSString? namespace,
+    JSString localName,
+  );
+  external Attr? setAttributeNode(Attr attr);
+  external Attr? setAttributeNodeNS(Attr attr);
+  external Attr removeAttributeNode(Attr attr);
+  external ShadowRoot attachShadow(ShadowRootInit init);
+  external Element? closest(JSString selectors);
+  external JSBoolean matches(JSString selectors);
+  external JSBoolean webkitMatchesSelector(JSString selectors);
+  external HTMLCollection getElementsByTagName(JSString qualifiedName);
+  external HTMLCollection getElementsByTagNameNS(
+    JSString? namespace,
+    JSString localName,
+  );
+  external HTMLCollection getElementsByClassName(JSString classNames);
+  external Element? insertAdjacentElement(
+    JSString where,
+    Element element,
+  );
+  external JSVoid insertAdjacentText(
+    JSString where,
+    JSString data,
+  );
+  external JSPromise requestFullscreen([FullscreenOptions options]);
+  external JSVoid setPointerCapture(JSNumber pointerId);
+  external JSVoid releasePointerCapture(JSNumber pointerId);
+  external JSBoolean hasPointerCapture(JSNumber pointerId);
+  external JSVoid requestPointerLock();
+  external JSVoid setHTML(
+    JSString input, [
+    SetHTMLOptions options,
+  ]);
+  external set outerHTML(JSString value);
+  external JSString get outerHTML;
+  external DOMTokenList get part;
   external set scrollTop(JSNumber value);
   external JSNumber get scrollTop;
   external set scrollLeft(JSNumber value);
@@ -876,84 +824,16 @@ extension ElementExtension on Element {
   external DOMTokenList get classList;
   external set slot(JSString value);
   external JSString get slot;
-  external JSBoolean hasAttributes();
   external NamedNodeMap get attributes;
-  external JSArray getAttributeNames();
-  external JSString? getAttribute(JSString qualifiedName);
-  external JSString? getAttributeNS(
-    JSString? namespace,
-    JSString localName,
-  );
-  external JSVoid setAttribute(
-    JSString qualifiedName,
-    JSString value,
-  );
-  external JSVoid setAttributeNS(
-    JSString? namespace,
-    JSString qualifiedName,
-    JSString value,
-  );
-  external JSVoid removeAttribute(JSString qualifiedName);
-  external JSVoid removeAttributeNS(
-    JSString? namespace,
-    JSString localName,
-  );
-  external JSBoolean toggleAttribute(JSString qualifiedName);
-  external JSBoolean toggleAttribute1(
-    JSString qualifiedName,
-    JSBoolean force,
-  );
-  external JSBoolean hasAttribute(JSString qualifiedName);
-  external JSBoolean hasAttributeNS(
-    JSString? namespace,
-    JSString localName,
-  );
-  external Attr? getAttributeNode(JSString qualifiedName);
-  external Attr? getAttributeNodeNS(
-    JSString? namespace,
-    JSString localName,
-  );
-  external Attr? setAttributeNode(Attr attr);
-  external Attr? setAttributeNodeNS(Attr attr);
-  external Attr removeAttributeNode(Attr attr);
-  external ShadowRoot attachShadow(ShadowRootInit init);
   external ShadowRoot? get shadowRoot;
-  external Element? closest(JSString selectors);
-  external JSBoolean matches(JSString selectors);
-  external JSBoolean webkitMatchesSelector(JSString selectors);
-  external HTMLCollection getElementsByTagName(JSString qualifiedName);
-  external HTMLCollection getElementsByTagNameNS(
-    JSString? namespace,
-    JSString localName,
-  );
-  external HTMLCollection getElementsByClassName(JSString classNames);
-  external Element? insertAdjacentElement(
-    JSString where,
-    Element element,
-  );
-  external JSVoid insertAdjacentText(
-    JSString where,
-    JSString data,
-  );
   external set editContext(EditContext? value);
   external EditContext? get editContext;
   external set elementTiming(JSString value);
   external JSString get elementTiming;
-  external JSPromise requestFullscreen();
-  external JSPromise requestFullscreen1(FullscreenOptions options);
   external set onfullscreenchange(EventHandler value);
   external EventHandler get onfullscreenchange;
   external set onfullscreenerror(EventHandler value);
   external EventHandler get onfullscreenerror;
-  external JSVoid setPointerCapture(JSNumber pointerId);
-  external JSVoid releasePointerCapture(JSNumber pointerId);
-  external JSBoolean hasPointerCapture(JSNumber pointerId);
-  external JSVoid requestPointerLock();
-  external JSVoid setHTML(JSString input);
-  external JSVoid setHTML1(
-    JSString input,
-    SetHTMLOptions options,
-  );
 }
 
 @JS()
@@ -978,12 +858,9 @@ extension ShadowRootInitExtension on ShadowRootInit {
 
 @JS('NamedNodeMap')
 @staticInterop
-class NamedNodeMap {
-  external factory NamedNodeMap();
-}
+class NamedNodeMap {}
 
 extension NamedNodeMapExtension on NamedNodeMap {
-  external JSNumber get length;
   external Attr? item(JSNumber index);
   external Attr? getNamedItem(JSString qualifiedName);
   external Attr? getNamedItemNS(
@@ -997,13 +874,12 @@ extension NamedNodeMapExtension on NamedNodeMap {
     JSString? namespace,
     JSString localName,
   );
+  external JSNumber get length;
 }
 
 @JS('Attr')
 @staticInterop
-class Attr extends Node {
-  external factory Attr();
-}
+class Attr implements Node {}
 
 extension AttrExtension on Attr {
   external JSString? get namespaceURI;
@@ -1018,15 +894,9 @@ extension AttrExtension on Attr {
 
 @JS('CharacterData')
 @staticInterop
-class CharacterData extends Node
-    implements NonDocumentTypeChildNode, ChildNode {
-  external factory CharacterData();
-}
+class CharacterData implements Node, NonDocumentTypeChildNode, ChildNode {}
 
 extension CharacterDataExtension on CharacterData {
-  external set data(JSString value);
-  external JSString get data;
-  external JSNumber get length;
   external JSString substringData(
     JSNumber offset,
     JSNumber count,
@@ -1045,16 +915,15 @@ extension CharacterDataExtension on CharacterData {
     JSNumber count,
     JSString data,
   );
+  external set data(JSString value);
+  external JSString get data;
+  external JSNumber get length;
 }
 
 @JS('Text')
 @staticInterop
-class Text extends CharacterData implements GeometryUtils, Slottable {
-  external factory Text();
-
-  external factory Text.a1();
-
-  external factory Text.a2(JSString data);
+class Text implements CharacterData, GeometryUtils, Slottable {
+  external factory Text([JSString data]);
 }
 
 extension TextExtension on Text {
@@ -1064,15 +933,11 @@ extension TextExtension on Text {
 
 @JS('CDATASection')
 @staticInterop
-class CDATASection extends Text {
-  external factory CDATASection();
-}
+class CDATASection implements Text {}
 
 @JS('ProcessingInstruction')
 @staticInterop
-class ProcessingInstruction extends CharacterData implements LinkStyle {
-  external factory ProcessingInstruction();
-}
+class ProcessingInstruction implements CharacterData, LinkStyle {}
 
 extension ProcessingInstructionExtension on ProcessingInstruction {
   external JSString get target;
@@ -1080,19 +945,13 @@ extension ProcessingInstructionExtension on ProcessingInstruction {
 
 @JS('Comment')
 @staticInterop
-class Comment extends CharacterData {
-  external factory Comment();
-
-  external factory Comment.a1();
-
-  external factory Comment.a2(JSString data);
+class Comment implements CharacterData {
+  external factory Comment([JSString data]);
 }
 
 @JS('AbstractRange')
 @staticInterop
-class AbstractRange {
-  external factory AbstractRange();
-}
+class AbstractRange {}
 
 extension AbstractRangeExtension on AbstractRange {
   external Node get startContainer;
@@ -1127,16 +986,14 @@ extension StaticRangeInitExtension on StaticRangeInit {
 
 @JS('StaticRange')
 @staticInterop
-class StaticRange extends AbstractRange {
-  external factory StaticRange();
-
-  external factory StaticRange.a1(StaticRangeInit init);
+class StaticRange implements AbstractRange {
+  external factory StaticRange(StaticRangeInit init);
 }
 
 @JS('Range')
 @staticInterop
-class Range extends AbstractRange {
-  external factory Range.a0();
+class Range implements AbstractRange {
+  external factory Range();
 
   external static JSNumber get START_TO_START;
   external static JSNumber get START_TO_END;
@@ -1148,7 +1005,6 @@ extension RangeExtension on Range {
   external DocumentFragment createContextualFragment(JSString fragment);
   external DOMRectList getClientRects();
   external DOMRect getBoundingClientRect();
-  external Node get commonAncestorContainer;
   external JSVoid setStart(
     Node node,
     JSNumber offset,
@@ -1161,8 +1017,7 @@ extension RangeExtension on Range {
   external JSVoid setStartAfter(Node node);
   external JSVoid setEndBefore(Node node);
   external JSVoid setEndAfter(Node node);
-  external JSVoid collapse();
-  external JSVoid collapse1(JSBoolean toStart);
+  external JSVoid collapse([JSBoolean toStart]);
   external JSVoid selectNode(Node node);
   external JSVoid selectNodeContents(Node node);
   external JSNumber compareBoundaryPoints(
@@ -1185,37 +1040,29 @@ extension RangeExtension on Range {
     JSNumber offset,
   );
   external JSBoolean intersectsNode(Node node);
+  external Node get commonAncestorContainer;
 }
 
 @JS('NodeIterator')
 @staticInterop
-class NodeIterator {
-  external factory NodeIterator();
-}
+class NodeIterator {}
 
 extension NodeIteratorExtension on NodeIterator {
+  external Node? nextNode();
+  external Node? previousNode();
+  external JSVoid detach();
   external Node get root;
   external Node get referenceNode;
   external JSBoolean get pointerBeforeReferenceNode;
   external JSNumber get whatToShow;
   external NodeFilter? get filter;
-  external Node? nextNode();
-  external Node? previousNode();
-  external JSVoid detach();
 }
 
 @JS('TreeWalker')
 @staticInterop
-class TreeWalker {
-  external factory TreeWalker();
-}
+class TreeWalker {}
 
 extension TreeWalkerExtension on TreeWalker {
-  external Node get root;
-  external JSNumber get whatToShow;
-  external NodeFilter? get filter;
-  external set currentNode(Node value);
-  external Node get currentNode;
   external Node? parentNode();
   external Node? firstChild();
   external Node? lastChild();
@@ -1223,30 +1070,32 @@ extension TreeWalkerExtension on TreeWalker {
   external Node? nextSibling();
   external Node? previousNode();
   external Node? nextNode();
+  external Node get root;
+  external JSNumber get whatToShow;
+  external NodeFilter? get filter;
+  external set currentNode(Node value);
+  external Node get currentNode;
 }
 
 @JS('DOMTokenList')
 @staticInterop
-class DOMTokenList {
-  external factory DOMTokenList();
-}
+class DOMTokenList {}
 
 extension DOMTokenListExtension on DOMTokenList {
-  external JSNumber get length;
   external JSString? item(JSNumber index);
   external JSBoolean contains(JSString token);
   external JSVoid add(JSString tokens);
   external JSVoid remove(JSString tokens);
-  external JSBoolean toggle(JSString token);
-  external JSBoolean toggle1(
-    JSString token,
+  external JSBoolean toggle(
+    JSString token, [
     JSBoolean force,
-  );
+  ]);
   external JSBoolean replace(
     JSString token,
     JSString newToken,
   );
   external JSBoolean supports(JSString token);
+  external JSNumber get length;
   external set value(JSString value);
   external JSString get value;
 }
@@ -1254,8 +1103,6 @@ extension DOMTokenListExtension on DOMTokenList {
 @JS('XPathResult')
 @staticInterop
 class XPathResult {
-  external factory XPathResult();
-
   external static JSNumber get ANY_TYPE;
   external static JSNumber get NUMBER_TYPE;
   external static JSNumber get STRING_TYPE;
@@ -1269,6 +1116,8 @@ class XPathResult {
 }
 
 extension XPathResultExtension on XPathResult {
+  external Node? iterateNext();
+  external Node? snapshotItem(JSNumber index);
   external JSNumber get resultType;
   external JSNumber get numberValue;
   external JSString get stringValue;
@@ -1276,76 +1125,49 @@ extension XPathResultExtension on XPathResult {
   external Node? get singleNodeValue;
   external JSBoolean get invalidIteratorState;
   external JSNumber get snapshotLength;
-  external Node? iterateNext();
-  external Node? snapshotItem(JSNumber index);
 }
 
 @JS('XPathExpression')
 @staticInterop
-class XPathExpression {
-  external factory XPathExpression();
-}
+class XPathExpression {}
 
 extension XPathExpressionExtension on XPathExpression {
-  external XPathResult evaluate(Node contextNode);
-  external XPathResult evaluate1(
-    Node contextNode,
-    JSNumber type,
-  );
-  external XPathResult evaluate2(
-    Node contextNode,
+  external XPathResult evaluate(
+    Node contextNode, [
     JSNumber type,
     XPathResult? result,
-  );
+  ]);
 }
 
 @JS('XPathEvaluatorBase')
 @staticInterop
-class XPathEvaluatorBase {
-  external factory XPathEvaluatorBase();
-}
+class XPathEvaluatorBase {}
 
 extension XPathEvaluatorBaseExtension on XPathEvaluatorBase {
-  external XPathExpression createExpression(JSString expression);
-  external XPathExpression createExpression1(
-    JSString expression,
+  external XPathExpression createExpression(
+    JSString expression, [
     XPathNSResolver? resolver,
-  );
+  ]);
   external XPathNSResolver createNSResolver(Node nodeResolver);
   external XPathResult evaluate(
     JSString expression,
-    Node contextNode,
-  );
-  external XPathResult evaluate1(
-    JSString expression,
-    Node contextNode,
-    XPathNSResolver? resolver,
-  );
-  external XPathResult evaluate2(
-    JSString expression,
-    Node contextNode,
-    XPathNSResolver? resolver,
-    JSNumber type,
-  );
-  external XPathResult evaluate3(
-    JSString expression,
-    Node contextNode,
+    Node contextNode, [
     XPathNSResolver? resolver,
     JSNumber type,
     XPathResult? result,
-  );
+  ]);
 }
 
 @JS('XPathEvaluator')
 @staticInterop
 class XPathEvaluator implements XPathEvaluatorBase {
-  external factory XPathEvaluator.a0();
+  external factory XPathEvaluator();
 }
 
 @JS('XSLTProcessor')
 @staticInterop
 class XSLTProcessor {
-  external factory XSLTProcessor.a0();
+  external factory XSLTProcessor();
 }
 
 extension XSLTProcessorExtension on XSLTProcessor {

--- a/lib/src/dom/dom_parsing.dart
+++ b/lib/src/dom/dom_parsing.dart
@@ -13,7 +13,7 @@ import 'dom.dart';
 @JS('XMLSerializer')
 @staticInterop
 class XMLSerializer {
-  external factory XMLSerializer.a0();
+  external factory XMLSerializer();
 }
 
 extension XMLSerializerExtension on XMLSerializer {
@@ -22,9 +22,7 @@ extension XMLSerializerExtension on XMLSerializer {
 
 @JS('InnerHTML')
 @staticInterop
-class InnerHTML {
-  external factory InnerHTML();
-}
+class InnerHTML {}
 
 extension InnerHTMLExtension on InnerHTML {
   external set innerHTML(JSString value);

--- a/lib/src/dom/edit_context.dart
+++ b/lib/src/dom/edit_context.dart
@@ -34,12 +34,8 @@ extension EditContextInitExtension on EditContextInit {
 
 @JS('EditContext')
 @staticInterop
-class EditContext extends EventTarget {
-  external factory EditContext();
-
-  external factory EditContext.a1();
-
-  external factory EditContext.a2(EditContextInit options);
+class EditContext implements EventTarget {
+  external factory EditContext([EditContextInit options]);
 }
 
 extension EditContextExtension on EditContext {
@@ -59,6 +55,7 @@ extension EditContextExtension on EditContext {
     JSArray characterBounds,
   );
   external JSArray attachedElements();
+  external JSArray characterBounds();
   external JSString get text;
   external JSNumber get selectionStart;
   external JSNumber get selectionEnd;
@@ -68,7 +65,6 @@ extension EditContextExtension on EditContext {
   external DOMRect get controlBound;
   external DOMRect get selectionBound;
   external JSNumber get characterBoundsRangeStart;
-  external JSArray characterBounds();
   external set ontextupdate(EventHandler value);
   external EventHandler get ontextupdate;
   external set ontextformatupdate(EventHandler value);
@@ -115,12 +111,8 @@ extension TextUpdateEventInitExtension on TextUpdateEventInit {
 
 @JS('TextUpdateEvent')
 @staticInterop
-class TextUpdateEvent extends Event {
-  external factory TextUpdateEvent();
-
-  external factory TextUpdateEvent.a1();
-
-  external factory TextUpdateEvent.a2(TextUpdateEventInit options);
+class TextUpdateEvent implements Event {
+  external factory TextUpdateEvent([TextUpdateEventInit options]);
 }
 
 extension TextUpdateEventExtension on TextUpdateEvent {
@@ -168,11 +160,7 @@ extension TextFormatInitExtension on TextFormatInit {
 @JS('TextFormat')
 @staticInterop
 class TextFormat {
-  external factory TextFormat();
-
-  external factory TextFormat.a1();
-
-  external factory TextFormat.a2(TextFormatInit options);
+  external factory TextFormat([TextFormatInit options]);
 }
 
 extension TextFormatExtension on TextFormat {
@@ -206,12 +194,8 @@ extension TextFormatUpdateEventInitExtension on TextFormatUpdateEventInit {
 
 @JS('TextFormatUpdateEvent')
 @staticInterop
-class TextFormatUpdateEvent extends Event {
-  external factory TextFormatUpdateEvent();
-
-  external factory TextFormatUpdateEvent.a1();
-
-  external factory TextFormatUpdateEvent.a2(TextFormatUpdateEventInit options);
+class TextFormatUpdateEvent implements Event {
+  external factory TextFormatUpdateEvent([TextFormatUpdateEventInit options]);
 }
 
 extension TextFormatUpdateEventExtension on TextFormatUpdateEvent {
@@ -238,13 +222,9 @@ extension CharacterBoundsUpdateEventInitExtension
 
 @JS('CharacterBoundsUpdateEvent')
 @staticInterop
-class CharacterBoundsUpdateEvent extends Event {
-  external factory CharacterBoundsUpdateEvent();
-
-  external factory CharacterBoundsUpdateEvent.a1();
-
-  external factory CharacterBoundsUpdateEvent.a2(
-      CharacterBoundsUpdateEventInit options);
+class CharacterBoundsUpdateEvent implements Event {
+  external factory CharacterBoundsUpdateEvent(
+      [CharacterBoundsUpdateEventInit options]);
 }
 
 extension CharacterBoundsUpdateEventExtension on CharacterBoundsUpdateEvent {

--- a/lib/src/dom/element_timing.dart
+++ b/lib/src/dom/element_timing.dart
@@ -15,11 +15,10 @@ import 'performance_timeline.dart';
 
 @JS('PerformanceElementTiming')
 @staticInterop
-class PerformanceElementTiming extends PerformanceEntry {
-  external factory PerformanceElementTiming();
-}
+class PerformanceElementTiming implements PerformanceEntry {}
 
 extension PerformanceElementTimingExtension on PerformanceElementTiming {
+  external JSObject toJSON();
   external DOMHighResTimeStamp get renderTime;
   external DOMHighResTimeStamp get loadTime;
   external DOMRectReadOnly get intersectionRect;
@@ -29,5 +28,4 @@ extension PerformanceElementTimingExtension on PerformanceElementTiming {
   external JSString get id;
   external Element? get element;
   external JSString get url;
-  external JSObject toJSON();
 }

--- a/lib/src/dom/encoding.dart
+++ b/lib/src/dom/encoding.dart
@@ -13,9 +13,7 @@ import 'webidl.dart';
 
 @JS('TextDecoderCommon')
 @staticInterop
-class TextDecoderCommon {
-  external factory TextDecoderCommon();
-}
+class TextDecoderCommon {}
 
 extension TextDecoderCommonExtension on TextDecoderCommon {
   external JSString get encoding;
@@ -55,32 +53,22 @@ extension TextDecodeOptionsExtension on TextDecodeOptions {
 @JS('TextDecoder')
 @staticInterop
 class TextDecoder implements TextDecoderCommon {
-  external factory TextDecoder();
-
-  external factory TextDecoder.a1();
-
-  external factory TextDecoder.a2(JSString label);
-
-  external factory TextDecoder.a3(
+  external factory TextDecoder([
     JSString label,
     TextDecoderOptions options,
-  );
+  ]);
 }
 
 extension TextDecoderExtension on TextDecoder {
-  external JSString decode();
-  external JSString decode1(BufferSource input);
-  external JSString decode2(
+  external JSString decode([
     BufferSource input,
     TextDecodeOptions options,
-  );
+  ]);
 }
 
 @JS('TextEncoderCommon')
 @staticInterop
-class TextEncoderCommon {
-  external factory TextEncoderCommon();
-}
+class TextEncoderCommon {}
 
 extension TextEncoderCommonExtension on TextEncoderCommon {
   external JSString get encoding;
@@ -106,12 +94,11 @@ extension TextEncoderEncodeIntoResultExtension on TextEncoderEncodeIntoResult {
 @JS('TextEncoder')
 @staticInterop
 class TextEncoder implements TextEncoderCommon {
-  external factory TextEncoder.a0();
+  external factory TextEncoder();
 }
 
 extension TextEncoderExtension on TextEncoder {
-  external JSUint8Array encode();
-  external JSUint8Array encode1(JSString input);
+  external JSUint8Array encode([JSString input]);
   external TextEncoderEncodeIntoResult encodeInto(
     JSString source,
     JSUint8Array destination,
@@ -121,20 +108,14 @@ extension TextEncoderExtension on TextEncoder {
 @JS('TextDecoderStream')
 @staticInterop
 class TextDecoderStream implements TextDecoderCommon, GenericTransformStream {
-  external factory TextDecoderStream();
-
-  external factory TextDecoderStream.a1();
-
-  external factory TextDecoderStream.a2(JSString label);
-
-  external factory TextDecoderStream.a3(
+  external factory TextDecoderStream([
     JSString label,
     TextDecoderOptions options,
-  );
+  ]);
 }
 
 @JS('TextEncoderStream')
 @staticInterop
 class TextEncoderStream implements TextEncoderCommon, GenericTransformStream {
-  external factory TextEncoderStream.a0();
+  external factory TextEncoderStream();
 }

--- a/lib/src/dom/encrypted_media.dart
+++ b/lib/src/dom/encrypted_media.dart
@@ -73,43 +73,28 @@ extension MediaKeySystemMediaCapabilityExtension
 
 @JS('MediaKeySystemAccess')
 @staticInterop
-class MediaKeySystemAccess {
-  external factory MediaKeySystemAccess();
-}
+class MediaKeySystemAccess {}
 
 extension MediaKeySystemAccessExtension on MediaKeySystemAccess {
-  external JSString get keySystem;
   external MediaKeySystemConfiguration getConfiguration();
   external JSPromise createMediaKeys();
+  external JSString get keySystem;
 }
 
 @JS('MediaKeys')
 @staticInterop
-class MediaKeys {
-  external factory MediaKeys();
-}
+class MediaKeys {}
 
 extension MediaKeysExtension on MediaKeys {
-  external MediaKeySession createSession();
-  external MediaKeySession createSession1(MediaKeySessionType sessionType);
+  external MediaKeySession createSession([MediaKeySessionType sessionType]);
   external JSPromise setServerCertificate(BufferSource serverCertificate);
 }
 
 @JS('MediaKeySession')
 @staticInterop
-class MediaKeySession extends EventTarget {
-  external factory MediaKeySession();
-}
+class MediaKeySession implements EventTarget {}
 
 extension MediaKeySessionExtension on MediaKeySession {
-  external JSString get sessionId;
-  external JSNumber get expiration;
-  external JSPromise get closed;
-  external MediaKeyStatusMap get keyStatuses;
-  external set onkeystatuseschange(EventHandler value);
-  external EventHandler get onkeystatuseschange;
-  external set onmessage(EventHandler value);
-  external EventHandler get onmessage;
   external JSPromise generateRequest(
     JSString initDataType,
     BufferSource initData,
@@ -118,26 +103,30 @@ extension MediaKeySessionExtension on MediaKeySession {
   external JSPromise update(BufferSource response);
   external JSPromise close();
   external JSPromise remove();
+  external JSString get sessionId;
+  external JSNumber get expiration;
+  external JSPromise get closed;
+  external MediaKeyStatusMap get keyStatuses;
+  external set onkeystatuseschange(EventHandler value);
+  external EventHandler get onkeystatuseschange;
+  external set onmessage(EventHandler value);
+  external EventHandler get onmessage;
 }
 
 @JS('MediaKeyStatusMap')
 @staticInterop
-class MediaKeyStatusMap {
-  external factory MediaKeyStatusMap();
-}
+class MediaKeyStatusMap {}
 
 extension MediaKeyStatusMapExtension on MediaKeyStatusMap {
-  external JSNumber get size;
   external JSBoolean has(BufferSource keyId);
   external JSAny get(BufferSource keyId);
+  external JSNumber get size;
 }
 
 @JS('MediaKeyMessageEvent')
 @staticInterop
-class MediaKeyMessageEvent extends Event {
-  external factory MediaKeyMessageEvent();
-
-  external factory MediaKeyMessageEvent.a1(
+class MediaKeyMessageEvent implements Event {
+  external factory MediaKeyMessageEvent(
     JSString type,
     MediaKeyMessageEventInit eventInitDict,
   );
@@ -151,7 +140,7 @@ extension MediaKeyMessageEventExtension on MediaKeyMessageEvent {
 @JS()
 @staticInterop
 @anonymous
-class MediaKeyMessageEventInit extends EventInit {
+class MediaKeyMessageEventInit implements EventInit {
   external factory MediaKeyMessageEventInit({
     required MediaKeyMessageType messageType,
     required JSArrayBuffer message,
@@ -167,15 +156,11 @@ extension MediaKeyMessageEventInitExtension on MediaKeyMessageEventInit {
 
 @JS('MediaEncryptedEvent')
 @staticInterop
-class MediaEncryptedEvent extends Event {
-  external factory MediaEncryptedEvent();
-
-  external factory MediaEncryptedEvent.a1(JSString type);
-
-  external factory MediaEncryptedEvent.a2(
-    JSString type,
+class MediaEncryptedEvent implements Event {
+  external factory MediaEncryptedEvent(
+    JSString type, [
     MediaEncryptedEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension MediaEncryptedEventExtension on MediaEncryptedEvent {
@@ -186,7 +171,7 @@ extension MediaEncryptedEventExtension on MediaEncryptedEvent {
 @JS()
 @staticInterop
 @anonymous
-class MediaEncryptedEventInit extends EventInit {
+class MediaEncryptedEventInit implements EventInit {
   external factory MediaEncryptedEventInit({
     JSString initDataType = '',
     JSArrayBuffer? initData,

--- a/lib/src/dom/entries_api.dart
+++ b/lib/src/dom/entries_api.dart
@@ -15,66 +15,38 @@ typedef FileCallback = JSFunction;
 
 @JS('FileSystemEntry')
 @staticInterop
-class FileSystemEntry {
-  external factory FileSystemEntry();
-}
+class FileSystemEntry {}
 
 extension FileSystemEntryExtension on FileSystemEntry {
+  external JSVoid getParent([
+    FileSystemEntryCallback successCallback,
+    ErrorCallback errorCallback,
+  ]);
   external JSBoolean get isFile;
   external JSBoolean get isDirectory;
   external JSString get name;
   external JSString get fullPath;
   external FileSystem get filesystem;
-  external JSVoid getParent();
-  external JSVoid getParent1(FileSystemEntryCallback successCallback);
-  external JSVoid getParent2(
-    FileSystemEntryCallback successCallback,
-    ErrorCallback errorCallback,
-  );
 }
 
 @JS('FileSystemDirectoryEntry')
 @staticInterop
-class FileSystemDirectoryEntry extends FileSystemEntry {
-  external factory FileSystemDirectoryEntry();
-}
+class FileSystemDirectoryEntry implements FileSystemEntry {}
 
 extension FileSystemDirectoryEntryExtension on FileSystemDirectoryEntry {
   external FileSystemDirectoryReader createReader();
-  external JSVoid getFile();
-  external JSVoid getFile1(JSString? path);
-  external JSVoid getFile2(
-    JSString? path,
-    FileSystemFlags options,
-  );
-  external JSVoid getFile3(
-    JSString? path,
-    FileSystemFlags options,
-    FileSystemEntryCallback successCallback,
-  );
-  external JSVoid getFile4(
+  external JSVoid getFile([
     JSString? path,
     FileSystemFlags options,
     FileSystemEntryCallback successCallback,
     ErrorCallback errorCallback,
-  );
-  external JSVoid getDirectory();
-  external JSVoid getDirectory1(JSString? path);
-  external JSVoid getDirectory2(
-    JSString? path,
-    FileSystemFlags options,
-  );
-  external JSVoid getDirectory3(
-    JSString? path,
-    FileSystemFlags options,
-    FileSystemEntryCallback successCallback,
-  );
-  external JSVoid getDirectory4(
+  ]);
+  external JSVoid getDirectory([
     JSString? path,
     FileSystemFlags options,
     FileSystemEntryCallback successCallback,
     ErrorCallback errorCallback,
-  );
+  ]);
 }
 
 @JS()
@@ -96,37 +68,29 @@ extension FileSystemFlagsExtension on FileSystemFlags {
 
 @JS('FileSystemDirectoryReader')
 @staticInterop
-class FileSystemDirectoryReader {
-  external factory FileSystemDirectoryReader();
-}
+class FileSystemDirectoryReader {}
 
 extension FileSystemDirectoryReaderExtension on FileSystemDirectoryReader {
-  external JSVoid readEntries(FileSystemEntriesCallback successCallback);
-  external JSVoid readEntries1(
-    FileSystemEntriesCallback successCallback,
+  external JSVoid readEntries(
+    FileSystemEntriesCallback successCallback, [
     ErrorCallback errorCallback,
-  );
+  ]);
 }
 
 @JS('FileSystemFileEntry')
 @staticInterop
-class FileSystemFileEntry extends FileSystemEntry {
-  external factory FileSystemFileEntry();
-}
+class FileSystemFileEntry implements FileSystemEntry {}
 
 extension FileSystemFileEntryExtension on FileSystemFileEntry {
-  external JSVoid file(FileCallback successCallback);
-  external JSVoid file1(
-    FileCallback successCallback,
+  external JSVoid file(
+    FileCallback successCallback, [
     ErrorCallback errorCallback,
-  );
+  ]);
 }
 
 @JS('FileSystem')
 @staticInterop
-class FileSystem {
-  external factory FileSystem();
-}
+class FileSystem {}
 
 extension FileSystemExtension on FileSystem {
   external JSString get name;

--- a/lib/src/dom/event_timing.dart
+++ b/lib/src/dom/event_timing.dart
@@ -14,23 +14,19 @@ import 'performance_timeline.dart';
 
 @JS('PerformanceEventTiming')
 @staticInterop
-class PerformanceEventTiming extends PerformanceEntry {
-  external factory PerformanceEventTiming();
-}
+class PerformanceEventTiming implements PerformanceEntry {}
 
 extension PerformanceEventTimingExtension on PerformanceEventTiming {
+  external JSObject toJSON();
   external DOMHighResTimeStamp get processingStart;
   external DOMHighResTimeStamp get processingEnd;
   external JSBoolean get cancelable;
   external Node? get target;
   external JSNumber get interactionId;
-  external JSObject toJSON();
 }
 
 @JS('EventCounts')
 @staticInterop
-class EventCounts {
-  external factory EventCounts();
-}
+class EventCounts {}
 
 extension EventCountsExtension on EventCounts {}

--- a/lib/src/dom/ext_blend_minmax.dart
+++ b/lib/src/dom/ext_blend_minmax.dart
@@ -13,8 +13,6 @@ import 'webgl1.dart';
 @JS('EXT_blend_minmax')
 @staticInterop
 class EXT_blend_minmax {
-  external factory EXT_blend_minmax();
-
   external static GLenum get MIN_EXT;
   external static GLenum get MAX_EXT;
 }

--- a/lib/src/dom/ext_color_buffer_float.dart
+++ b/lib/src/dom/ext_color_buffer_float.dart
@@ -10,6 +10,4 @@ import 'package:js/js.dart' hide JS;
 
 @JS('EXT_color_buffer_float')
 @staticInterop
-class EXT_color_buffer_float {
-  external factory EXT_color_buffer_float();
-}
+class EXT_color_buffer_float {}

--- a/lib/src/dom/ext_color_buffer_half_float.dart
+++ b/lib/src/dom/ext_color_buffer_half_float.dart
@@ -13,8 +13,6 @@ import 'webgl1.dart';
 @JS('EXT_color_buffer_half_float')
 @staticInterop
 class EXT_color_buffer_half_float {
-  external factory EXT_color_buffer_half_float();
-
   external static GLenum get RGBA16F_EXT;
   external static GLenum get RGB16F_EXT;
   external static GLenum get FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT;

--- a/lib/src/dom/ext_disjoint_timer_query.dart
+++ b/lib/src/dom/ext_disjoint_timer_query.dart
@@ -14,15 +14,11 @@ typedef GLuint64EXT = JSNumber;
 
 @JS('WebGLTimerQueryEXT')
 @staticInterop
-class WebGLTimerQueryEXT extends WebGLObject {
-  external factory WebGLTimerQueryEXT();
-}
+class WebGLTimerQueryEXT implements WebGLObject {}
 
 @JS('EXT_disjoint_timer_query')
 @staticInterop
 class EXT_disjoint_timer_query {
-  external factory EXT_disjoint_timer_query();
-
   external static GLenum get QUERY_COUNTER_BITS_EXT;
   external static GLenum get CURRENT_QUERY_EXT;
   external static GLenum get QUERY_RESULT_EXT;

--- a/lib/src/dom/ext_disjoint_timer_query_webgl2.dart
+++ b/lib/src/dom/ext_disjoint_timer_query_webgl2.dart
@@ -14,8 +14,6 @@ import 'webgl2.dart';
 @JS('EXT_disjoint_timer_query_webgl2')
 @staticInterop
 class EXT_disjoint_timer_query_webgl2 {
-  external factory EXT_disjoint_timer_query_webgl2();
-
   external static GLenum get QUERY_COUNTER_BITS_EXT;
   external static GLenum get TIME_ELAPSED_EXT;
   external static GLenum get TIMESTAMP_EXT;

--- a/lib/src/dom/ext_float_blend.dart
+++ b/lib/src/dom/ext_float_blend.dart
@@ -10,6 +10,4 @@ import 'package:js/js.dart' hide JS;
 
 @JS('EXT_float_blend')
 @staticInterop
-class EXT_float_blend {
-  external factory EXT_float_blend();
-}
+class EXT_float_blend {}

--- a/lib/src/dom/ext_frag_depth.dart
+++ b/lib/src/dom/ext_frag_depth.dart
@@ -10,6 +10,4 @@ import 'package:js/js.dart' hide JS;
 
 @JS('EXT_frag_depth')
 @staticInterop
-class EXT_frag_depth {
-  external factory EXT_frag_depth();
-}
+class EXT_frag_depth {}

--- a/lib/src/dom/ext_shader_texture_lod.dart
+++ b/lib/src/dom/ext_shader_texture_lod.dart
@@ -10,6 +10,4 @@ import 'package:js/js.dart' hide JS;
 
 @JS('EXT_shader_texture_lod')
 @staticInterop
-class EXT_shader_texture_lod {
-  external factory EXT_shader_texture_lod();
-}
+class EXT_shader_texture_lod {}

--- a/lib/src/dom/ext_srgb.dart
+++ b/lib/src/dom/ext_srgb.dart
@@ -13,8 +13,6 @@ import 'webgl1.dart';
 @JS('EXT_sRGB')
 @staticInterop
 class EXT_sRGB {
-  external factory EXT_sRGB();
-
   external static GLenum get SRGB_EXT;
   external static GLenum get SRGB_ALPHA_EXT;
   external static GLenum get SRGB8_ALPHA8_EXT;

--- a/lib/src/dom/ext_texture_compression_bptc.dart
+++ b/lib/src/dom/ext_texture_compression_bptc.dart
@@ -13,8 +13,6 @@ import 'webgl1.dart';
 @JS('EXT_texture_compression_bptc')
 @staticInterop
 class EXT_texture_compression_bptc {
-  external factory EXT_texture_compression_bptc();
-
   external static GLenum get COMPRESSED_RGBA_BPTC_UNORM_EXT;
   external static GLenum get COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT;
   external static GLenum get COMPRESSED_RGB_BPTC_SIGNED_FLOAT_EXT;

--- a/lib/src/dom/ext_texture_compression_rgtc.dart
+++ b/lib/src/dom/ext_texture_compression_rgtc.dart
@@ -13,8 +13,6 @@ import 'webgl1.dart';
 @JS('EXT_texture_compression_rgtc')
 @staticInterop
 class EXT_texture_compression_rgtc {
-  external factory EXT_texture_compression_rgtc();
-
   external static GLenum get COMPRESSED_RED_RGTC1_EXT;
   external static GLenum get COMPRESSED_SIGNED_RED_RGTC1_EXT;
   external static GLenum get COMPRESSED_RED_GREEN_RGTC2_EXT;

--- a/lib/src/dom/ext_texture_filter_anisotropic.dart
+++ b/lib/src/dom/ext_texture_filter_anisotropic.dart
@@ -13,8 +13,6 @@ import 'webgl1.dart';
 @JS('EXT_texture_filter_anisotropic')
 @staticInterop
 class EXT_texture_filter_anisotropic {
-  external factory EXT_texture_filter_anisotropic();
-
   external static GLenum get TEXTURE_MAX_ANISOTROPY_EXT;
   external static GLenum get MAX_TEXTURE_MAX_ANISOTROPY_EXT;
 }

--- a/lib/src/dom/ext_texture_norm16.dart
+++ b/lib/src/dom/ext_texture_norm16.dart
@@ -13,8 +13,6 @@ import 'webgl1.dart';
 @JS('EXT_texture_norm16')
 @staticInterop
 class EXT_texture_norm16 {
-  external factory EXT_texture_norm16();
-
   external static GLenum get R16_EXT;
   external static GLenum get RG16_EXT;
   external static GLenum get RGB16_EXT;

--- a/lib/src/dom/eyedropper_api.dart
+++ b/lib/src/dom/eyedropper_api.dart
@@ -37,10 +37,9 @@ extension ColorSelectionOptionsExtension on ColorSelectionOptions {
 @JS('EyeDropper')
 @staticInterop
 class EyeDropper {
-  external factory EyeDropper.a0();
+  external factory EyeDropper();
 }
 
 extension EyeDropperExtension on EyeDropper {
-  external JSPromise open();
-  external JSPromise open1(ColorSelectionOptions options);
+  external JSPromise open([ColorSelectionOptions options]);
 }

--- a/lib/src/dom/fedcm.dart
+++ b/lib/src/dom/fedcm.dart
@@ -155,9 +155,7 @@ extension IdentityProviderTokenExtension on IdentityProviderToken {
 
 @JS('IdentityCredential')
 @staticInterop
-class IdentityCredential extends Credential {
-  external factory IdentityCredential();
-
+class IdentityCredential implements Credential {
   external static JSPromise logoutRPs(JSArray logoutRequests);
 }
 
@@ -219,8 +217,6 @@ extension IdentityCredentialLogoutRPsRequestExtension
 @JS('IdentityProvider')
 @staticInterop
 class IdentityProvider {
-  external factory IdentityProvider();
-
   external static JSVoid login();
   external static JSVoid logout();
 }

--- a/lib/src/dom/fetch.dart
+++ b/lib/src/dom/fetch.dart
@@ -28,11 +28,7 @@ typedef ResponseType = JSString;
 @JS('Headers')
 @staticInterop
 class Headers {
-  external factory Headers();
-
-  external factory Headers.a1();
-
-  external factory Headers.a2(HeadersInit init);
+  external factory Headers([HeadersInit init]);
 }
 
 extension HeadersExtension on Headers {
@@ -51,34 +47,29 @@ extension HeadersExtension on Headers {
 
 @JS('Body')
 @staticInterop
-class Body {
-  external factory Body();
-}
+class Body {}
 
 extension BodyExtension on Body {
-  external ReadableStream? get body;
-  external JSBoolean get bodyUsed;
   external JSPromise arrayBuffer();
   external JSPromise blob();
   external JSPromise formData();
   external JSPromise json();
   external JSPromise text();
+  external ReadableStream? get body;
+  external JSBoolean get bodyUsed;
 }
 
 @JS('Request')
 @staticInterop
 class Request implements Body {
-  external factory Request();
-
-  external factory Request.a1(RequestInfo input);
-
-  external factory Request.a2(
-    RequestInfo input,
+  external factory Request(
+    RequestInfo input, [
     RequestInit init,
-  );
+  ]);
 }
 
 extension RequestExtension on Request {
+  external Request clone();
   external JSString get method;
   external JSString get url;
   external Headers get headers;
@@ -95,7 +86,6 @@ extension RequestExtension on Request {
   external JSBoolean get isHistoryNavigation;
   external AbortSignal get signal;
   external RequestDuplex get duplex;
-  external Request clone();
 }
 
 @JS()
@@ -157,31 +147,24 @@ extension RequestInitExtension on RequestInit {
 @JS('Response')
 @staticInterop
 class Response implements Body {
-  external factory Response();
-
-  external factory Response.a1();
-
-  external factory Response.a2(BodyInit? body);
-
-  external factory Response.a3(
+  external factory Response([
     BodyInit? body,
     ResponseInit init,
-  );
+  ]);
 
   external static Response error();
-  external static Response redirect(JSString url);
-  external static Response redirect1(
-    JSString url,
+  external static Response redirect(
+    JSString url, [
     JSNumber status,
-  );
-  external static Response json(JSAny data);
-  external static Response json1(
-    JSAny data,
+  ]);
+  external static Response json(
+    JSAny data, [
     ResponseInit init,
-  );
+  ]);
 }
 
 extension ResponseExtension on Response {
+  external Response clone();
   external ResponseType get type;
   external JSString get url;
   external JSBoolean get redirected;
@@ -189,7 +172,6 @@ extension ResponseExtension on Response {
   external JSBoolean get ok;
   external JSString get statusText;
   external Headers get headers;
-  external Response clone();
 }
 
 @JS()

--- a/lib/src/dom/file_system_access.dart
+++ b/lib/src/dom/file_system_access.dart
@@ -18,7 +18,7 @@ typedef WellKnownDirectory = JSString;
 @JS()
 @staticInterop
 @anonymous
-class FileSystemPermissionDescriptor extends PermissionDescriptor {
+class FileSystemPermissionDescriptor implements PermissionDescriptor {
   external factory FileSystemPermissionDescriptor({
     required FileSystemHandle handle,
     FileSystemPermissionMode mode = 'read',
@@ -90,7 +90,7 @@ extension FilePickerOptionsExtension on FilePickerOptions {
 @JS()
 @staticInterop
 @anonymous
-class OpenFilePickerOptions extends FilePickerOptions {
+class OpenFilePickerOptions implements FilePickerOptions {
   external factory OpenFilePickerOptions({JSBoolean multiple = false});
 }
 
@@ -102,7 +102,7 @@ extension OpenFilePickerOptionsExtension on OpenFilePickerOptions {
 @JS()
 @staticInterop
 @anonymous
-class SaveFilePickerOptions extends FilePickerOptions {
+class SaveFilePickerOptions implements FilePickerOptions {
   external factory SaveFilePickerOptions({JSString? suggestedName});
 }
 

--- a/lib/src/dom/fileapi.dart
+++ b/lib/src/dom/fileapi.dart
@@ -19,35 +19,23 @@ typedef EndingType = JSString;
 @JS('Blob')
 @staticInterop
 class Blob {
-  external factory Blob();
-
-  external factory Blob.a1();
-
-  external factory Blob.a2(JSArray blobParts);
-
-  external factory Blob.a3(
+  external factory Blob([
     JSArray blobParts,
     BlobPropertyBag options,
-  );
+  ]);
 }
 
 extension BlobExtension on Blob {
-  external JSNumber get size;
-  external JSString get type;
-  external Blob slice();
-  external Blob slice1(JSNumber start);
-  external Blob slice2(
-    JSNumber start,
-    JSNumber end,
-  );
-  external Blob slice3(
+  external Blob slice([
     JSNumber start,
     JSNumber end,
     JSString contentType,
-  );
+  ]);
   external ReadableStream stream();
   external JSPromise text();
   external JSPromise arrayBuffer();
+  external JSNumber get size;
+  external JSString get type;
 }
 
 @JS()
@@ -69,19 +57,12 @@ extension BlobPropertyBagExtension on BlobPropertyBag {
 
 @JS('File')
 @staticInterop
-class File extends Blob {
-  external factory File();
-
-  external factory File.a1(
+class File implements Blob {
+  external factory File(
     JSArray fileBits,
-    JSString fileName,
-  );
-
-  external factory File.a2(
-    JSArray fileBits,
-    JSString fileName,
+    JSString fileName, [
     FilePropertyBag options,
-  );
+  ]);
 }
 
 extension FileExtension on File {
@@ -93,7 +74,7 @@ extension FileExtension on File {
 @JS()
 @staticInterop
 @anonymous
-class FilePropertyBag extends BlobPropertyBag {
+class FilePropertyBag implements BlobPropertyBag {
   external factory FilePropertyBag({JSNumber lastModified});
 }
 
@@ -104,9 +85,7 @@ extension FilePropertyBagExtension on FilePropertyBag {
 
 @JS('FileList')
 @staticInterop
-class FileList {
-  external factory FileList();
-}
+class FileList {}
 
 extension FileListExtension on FileList {
   external File? item(JSNumber index);
@@ -115,8 +94,8 @@ extension FileListExtension on FileList {
 
 @JS('FileReader')
 @staticInterop
-class FileReader extends EventTarget {
-  external factory FileReader.a0();
+class FileReader implements EventTarget {
+  external factory FileReader();
 
   external static JSNumber get EMPTY;
   external static JSNumber get LOADING;
@@ -126,11 +105,10 @@ class FileReader extends EventTarget {
 extension FileReaderExtension on FileReader {
   external JSVoid readAsArrayBuffer(Blob blob);
   external JSVoid readAsBinaryString(Blob blob);
-  external JSVoid readAsText(Blob blob);
-  external JSVoid readAsText1(
-    Blob blob,
+  external JSVoid readAsText(
+    Blob blob, [
     JSString encoding,
-  );
+  ]);
   external JSVoid readAsDataURL(Blob blob);
   external JSVoid abort();
   external JSNumber get readyState;
@@ -153,16 +131,15 @@ extension FileReaderExtension on FileReader {
 @JS('FileReaderSync')
 @staticInterop
 class FileReaderSync {
-  external factory FileReaderSync.a0();
+  external factory FileReaderSync();
 }
 
 extension FileReaderSyncExtension on FileReaderSync {
   external JSArrayBuffer readAsArrayBuffer(Blob blob);
   external JSString readAsBinaryString(Blob blob);
-  external JSString readAsText(Blob blob);
-  external JSString readAsText1(
-    Blob blob,
+  external JSString readAsText(
+    Blob blob, [
     JSString encoding,
-  );
+  ]);
   external JSString readAsDataURL(Blob blob);
 }

--- a/lib/src/dom/filter_effects.dart
+++ b/lib/src/dom/filter_effects.dart
@@ -12,9 +12,7 @@ import 'svg.dart';
 
 @JS('SVGFilterElement')
 @staticInterop
-class SVGFilterElement extends SVGElement implements SVGURIReference {
-  external factory SVGFilterElement();
-}
+class SVGFilterElement implements SVGElement, SVGURIReference {}
 
 extension SVGFilterElementExtension on SVGFilterElement {
   external SVGAnimatedEnumeration get filterUnits;
@@ -27,9 +25,7 @@ extension SVGFilterElementExtension on SVGFilterElement {
 
 @JS('SVGFilterPrimitiveStandardAttributes')
 @staticInterop
-class SVGFilterPrimitiveStandardAttributes {
-  external factory SVGFilterPrimitiveStandardAttributes();
-}
+class SVGFilterPrimitiveStandardAttributes {}
 
 extension SVGFilterPrimitiveStandardAttributesExtension
     on SVGFilterPrimitiveStandardAttributes {
@@ -42,10 +38,8 @@ extension SVGFilterPrimitiveStandardAttributesExtension
 
 @JS('SVGFEBlendElement')
 @staticInterop
-class SVGFEBlendElement extends SVGElement
-    implements SVGFilterPrimitiveStandardAttributes {
-  external factory SVGFEBlendElement();
-
+class SVGFEBlendElement
+    implements SVGElement, SVGFilterPrimitiveStandardAttributes {
   external static JSNumber get SVG_FEBLEND_MODE_UNKNOWN;
   external static JSNumber get SVG_FEBLEND_MODE_NORMAL;
   external static JSNumber get SVG_FEBLEND_MODE_MULTIPLY;
@@ -73,10 +67,8 @@ extension SVGFEBlendElementExtension on SVGFEBlendElement {
 
 @JS('SVGFEColorMatrixElement')
 @staticInterop
-class SVGFEColorMatrixElement extends SVGElement
-    implements SVGFilterPrimitiveStandardAttributes {
-  external factory SVGFEColorMatrixElement();
-
+class SVGFEColorMatrixElement
+    implements SVGElement, SVGFilterPrimitiveStandardAttributes {
   external static JSNumber get SVG_FECOLORMATRIX_TYPE_UNKNOWN;
   external static JSNumber get SVG_FECOLORMATRIX_TYPE_MATRIX;
   external static JSNumber get SVG_FECOLORMATRIX_TYPE_SATURATE;
@@ -92,10 +84,8 @@ extension SVGFEColorMatrixElementExtension on SVGFEColorMatrixElement {
 
 @JS('SVGFEComponentTransferElement')
 @staticInterop
-class SVGFEComponentTransferElement extends SVGElement
-    implements SVGFilterPrimitiveStandardAttributes {
-  external factory SVGFEComponentTransferElement();
-}
+class SVGFEComponentTransferElement
+    implements SVGElement, SVGFilterPrimitiveStandardAttributes {}
 
 extension SVGFEComponentTransferElementExtension
     on SVGFEComponentTransferElement {
@@ -104,9 +94,7 @@ extension SVGFEComponentTransferElementExtension
 
 @JS('SVGComponentTransferFunctionElement')
 @staticInterop
-class SVGComponentTransferFunctionElement extends SVGElement {
-  external factory SVGComponentTransferFunctionElement();
-
+class SVGComponentTransferFunctionElement implements SVGElement {
   external static JSNumber get SVG_FECOMPONENTTRANSFER_TYPE_UNKNOWN;
   external static JSNumber get SVG_FECOMPONENTTRANSFER_TYPE_IDENTITY;
   external static JSNumber get SVG_FECOMPONENTTRANSFER_TYPE_TABLE;
@@ -128,34 +116,24 @@ extension SVGComponentTransferFunctionElementExtension
 
 @JS('SVGFEFuncRElement')
 @staticInterop
-class SVGFEFuncRElement extends SVGComponentTransferFunctionElement {
-  external factory SVGFEFuncRElement();
-}
+class SVGFEFuncRElement implements SVGComponentTransferFunctionElement {}
 
 @JS('SVGFEFuncGElement')
 @staticInterop
-class SVGFEFuncGElement extends SVGComponentTransferFunctionElement {
-  external factory SVGFEFuncGElement();
-}
+class SVGFEFuncGElement implements SVGComponentTransferFunctionElement {}
 
 @JS('SVGFEFuncBElement')
 @staticInterop
-class SVGFEFuncBElement extends SVGComponentTransferFunctionElement {
-  external factory SVGFEFuncBElement();
-}
+class SVGFEFuncBElement implements SVGComponentTransferFunctionElement {}
 
 @JS('SVGFEFuncAElement')
 @staticInterop
-class SVGFEFuncAElement extends SVGComponentTransferFunctionElement {
-  external factory SVGFEFuncAElement();
-}
+class SVGFEFuncAElement implements SVGComponentTransferFunctionElement {}
 
 @JS('SVGFECompositeElement')
 @staticInterop
-class SVGFECompositeElement extends SVGElement
-    implements SVGFilterPrimitiveStandardAttributes {
-  external factory SVGFECompositeElement();
-
+class SVGFECompositeElement
+    implements SVGElement, SVGFilterPrimitiveStandardAttributes {
   external static JSNumber get SVG_FECOMPOSITE_OPERATOR_UNKNOWN;
   external static JSNumber get SVG_FECOMPOSITE_OPERATOR_OVER;
   external static JSNumber get SVG_FECOMPOSITE_OPERATOR_IN;
@@ -177,10 +155,8 @@ extension SVGFECompositeElementExtension on SVGFECompositeElement {
 
 @JS('SVGFEConvolveMatrixElement')
 @staticInterop
-class SVGFEConvolveMatrixElement extends SVGElement
-    implements SVGFilterPrimitiveStandardAttributes {
-  external factory SVGFEConvolveMatrixElement();
-
+class SVGFEConvolveMatrixElement
+    implements SVGElement, SVGFilterPrimitiveStandardAttributes {
   external static JSNumber get SVG_EDGEMODE_UNKNOWN;
   external static JSNumber get SVG_EDGEMODE_DUPLICATE;
   external static JSNumber get SVG_EDGEMODE_WRAP;
@@ -204,10 +180,8 @@ extension SVGFEConvolveMatrixElementExtension on SVGFEConvolveMatrixElement {
 
 @JS('SVGFEDiffuseLightingElement')
 @staticInterop
-class SVGFEDiffuseLightingElement extends SVGElement
-    implements SVGFilterPrimitiveStandardAttributes {
-  external factory SVGFEDiffuseLightingElement();
-}
+class SVGFEDiffuseLightingElement
+    implements SVGElement, SVGFilterPrimitiveStandardAttributes {}
 
 extension SVGFEDiffuseLightingElementExtension on SVGFEDiffuseLightingElement {
   external SVGAnimatedString get in1;
@@ -219,9 +193,7 @@ extension SVGFEDiffuseLightingElementExtension on SVGFEDiffuseLightingElement {
 
 @JS('SVGFEDistantLightElement')
 @staticInterop
-class SVGFEDistantLightElement extends SVGElement {
-  external factory SVGFEDistantLightElement();
-}
+class SVGFEDistantLightElement implements SVGElement {}
 
 extension SVGFEDistantLightElementExtension on SVGFEDistantLightElement {
   external SVGAnimatedNumber get azimuth;
@@ -230,9 +202,7 @@ extension SVGFEDistantLightElementExtension on SVGFEDistantLightElement {
 
 @JS('SVGFEPointLightElement')
 @staticInterop
-class SVGFEPointLightElement extends SVGElement {
-  external factory SVGFEPointLightElement();
-}
+class SVGFEPointLightElement implements SVGElement {}
 
 extension SVGFEPointLightElementExtension on SVGFEPointLightElement {
   external SVGAnimatedNumber get x;
@@ -242,9 +212,7 @@ extension SVGFEPointLightElementExtension on SVGFEPointLightElement {
 
 @JS('SVGFESpotLightElement')
 @staticInterop
-class SVGFESpotLightElement extends SVGElement {
-  external factory SVGFESpotLightElement();
-}
+class SVGFESpotLightElement implements SVGElement {}
 
 extension SVGFESpotLightElementExtension on SVGFESpotLightElement {
   external SVGAnimatedNumber get x;
@@ -259,10 +227,8 @@ extension SVGFESpotLightElementExtension on SVGFESpotLightElement {
 
 @JS('SVGFEDisplacementMapElement')
 @staticInterop
-class SVGFEDisplacementMapElement extends SVGElement
-    implements SVGFilterPrimitiveStandardAttributes {
-  external factory SVGFEDisplacementMapElement();
-
+class SVGFEDisplacementMapElement
+    implements SVGElement, SVGFilterPrimitiveStandardAttributes {
   external static JSNumber get SVG_CHANNEL_UNKNOWN;
   external static JSNumber get SVG_CHANNEL_R;
   external static JSNumber get SVG_CHANNEL_G;
@@ -280,36 +246,30 @@ extension SVGFEDisplacementMapElementExtension on SVGFEDisplacementMapElement {
 
 @JS('SVGFEDropShadowElement')
 @staticInterop
-class SVGFEDropShadowElement extends SVGElement
-    implements SVGFilterPrimitiveStandardAttributes {
-  external factory SVGFEDropShadowElement();
-}
+class SVGFEDropShadowElement
+    implements SVGElement, SVGFilterPrimitiveStandardAttributes {}
 
 extension SVGFEDropShadowElementExtension on SVGFEDropShadowElement {
+  external JSVoid setStdDeviation(
+    JSNumber stdDeviationX,
+    JSNumber stdDeviationY,
+  );
   external SVGAnimatedString get in1;
   external SVGAnimatedNumber get dx;
   external SVGAnimatedNumber get dy;
   external SVGAnimatedNumber get stdDeviationX;
   external SVGAnimatedNumber get stdDeviationY;
-  external JSVoid setStdDeviation(
-    JSNumber stdDeviationX,
-    JSNumber stdDeviationY,
-  );
 }
 
 @JS('SVGFEFloodElement')
 @staticInterop
-class SVGFEFloodElement extends SVGElement
-    implements SVGFilterPrimitiveStandardAttributes {
-  external factory SVGFEFloodElement();
-}
+class SVGFEFloodElement
+    implements SVGElement, SVGFilterPrimitiveStandardAttributes {}
 
 @JS('SVGFEGaussianBlurElement')
 @staticInterop
-class SVGFEGaussianBlurElement extends SVGElement
-    implements SVGFilterPrimitiveStandardAttributes {
-  external factory SVGFEGaussianBlurElement();
-
+class SVGFEGaussianBlurElement
+    implements SVGElement, SVGFilterPrimitiveStandardAttributes {
   external static JSNumber get SVG_EDGEMODE_UNKNOWN;
   external static JSNumber get SVG_EDGEMODE_DUPLICATE;
   external static JSNumber get SVG_EDGEMODE_WRAP;
@@ -317,22 +277,23 @@ class SVGFEGaussianBlurElement extends SVGElement
 }
 
 extension SVGFEGaussianBlurElementExtension on SVGFEGaussianBlurElement {
-  external SVGAnimatedString get in1;
-  external SVGAnimatedNumber get stdDeviationX;
-  external SVGAnimatedNumber get stdDeviationY;
-  external SVGAnimatedEnumeration get edgeMode;
   external JSVoid setStdDeviation(
     JSNumber stdDeviationX,
     JSNumber stdDeviationY,
   );
+  external SVGAnimatedString get in1;
+  external SVGAnimatedNumber get stdDeviationX;
+  external SVGAnimatedNumber get stdDeviationY;
+  external SVGAnimatedEnumeration get edgeMode;
 }
 
 @JS('SVGFEImageElement')
 @staticInterop
-class SVGFEImageElement extends SVGElement
-    implements SVGFilterPrimitiveStandardAttributes, SVGURIReference {
-  external factory SVGFEImageElement();
-}
+class SVGFEImageElement
+    implements
+        SVGElement,
+        SVGFilterPrimitiveStandardAttributes,
+        SVGURIReference {}
 
 extension SVGFEImageElementExtension on SVGFEImageElement {
   external SVGAnimatedPreserveAspectRatio get preserveAspectRatio;
@@ -341,16 +302,12 @@ extension SVGFEImageElementExtension on SVGFEImageElement {
 
 @JS('SVGFEMergeElement')
 @staticInterop
-class SVGFEMergeElement extends SVGElement
-    implements SVGFilterPrimitiveStandardAttributes {
-  external factory SVGFEMergeElement();
-}
+class SVGFEMergeElement
+    implements SVGElement, SVGFilterPrimitiveStandardAttributes {}
 
 @JS('SVGFEMergeNodeElement')
 @staticInterop
-class SVGFEMergeNodeElement extends SVGElement {
-  external factory SVGFEMergeNodeElement();
-}
+class SVGFEMergeNodeElement implements SVGElement {}
 
 extension SVGFEMergeNodeElementExtension on SVGFEMergeNodeElement {
   external SVGAnimatedString get in1;
@@ -358,10 +315,8 @@ extension SVGFEMergeNodeElementExtension on SVGFEMergeNodeElement {
 
 @JS('SVGFEMorphologyElement')
 @staticInterop
-class SVGFEMorphologyElement extends SVGElement
-    implements SVGFilterPrimitiveStandardAttributes {
-  external factory SVGFEMorphologyElement();
-
+class SVGFEMorphologyElement
+    implements SVGElement, SVGFilterPrimitiveStandardAttributes {
   external static JSNumber get SVG_MORPHOLOGY_OPERATOR_UNKNOWN;
   external static JSNumber get SVG_MORPHOLOGY_OPERATOR_ERODE;
   external static JSNumber get SVG_MORPHOLOGY_OPERATOR_DILATE;
@@ -376,10 +331,8 @@ extension SVGFEMorphologyElementExtension on SVGFEMorphologyElement {
 
 @JS('SVGFEOffsetElement')
 @staticInterop
-class SVGFEOffsetElement extends SVGElement
-    implements SVGFilterPrimitiveStandardAttributes {
-  external factory SVGFEOffsetElement();
-}
+class SVGFEOffsetElement
+    implements SVGElement, SVGFilterPrimitiveStandardAttributes {}
 
 extension SVGFEOffsetElementExtension on SVGFEOffsetElement {
   external SVGAnimatedString get in1;
@@ -389,10 +342,8 @@ extension SVGFEOffsetElementExtension on SVGFEOffsetElement {
 
 @JS('SVGFESpecularLightingElement')
 @staticInterop
-class SVGFESpecularLightingElement extends SVGElement
-    implements SVGFilterPrimitiveStandardAttributes {
-  external factory SVGFESpecularLightingElement();
-}
+class SVGFESpecularLightingElement
+    implements SVGElement, SVGFilterPrimitiveStandardAttributes {}
 
 extension SVGFESpecularLightingElementExtension
     on SVGFESpecularLightingElement {
@@ -406,10 +357,8 @@ extension SVGFESpecularLightingElementExtension
 
 @JS('SVGFETileElement')
 @staticInterop
-class SVGFETileElement extends SVGElement
-    implements SVGFilterPrimitiveStandardAttributes {
-  external factory SVGFETileElement();
-}
+class SVGFETileElement
+    implements SVGElement, SVGFilterPrimitiveStandardAttributes {}
 
 extension SVGFETileElementExtension on SVGFETileElement {
   external SVGAnimatedString get in1;
@@ -417,10 +366,8 @@ extension SVGFETileElementExtension on SVGFETileElement {
 
 @JS('SVGFETurbulenceElement')
 @staticInterop
-class SVGFETurbulenceElement extends SVGElement
-    implements SVGFilterPrimitiveStandardAttributes {
-  external factory SVGFETurbulenceElement();
-
+class SVGFETurbulenceElement
+    implements SVGElement, SVGFilterPrimitiveStandardAttributes {
   external static JSNumber get SVG_TURBULENCE_TYPE_UNKNOWN;
   external static JSNumber get SVG_TURBULENCE_TYPE_FRACTALNOISE;
   external static JSNumber get SVG_TURBULENCE_TYPE_TURBULENCE;

--- a/lib/src/dom/font_metrics_api.dart
+++ b/lib/src/dom/font_metrics_api.dart
@@ -10,9 +10,7 @@ import 'package:js/js.dart' hide JS;
 
 @JS('FontMetrics')
 @staticInterop
-class FontMetrics {
-  external factory FontMetrics();
-}
+class FontMetrics {}
 
 extension FontMetricsExtension on FontMetrics {
   external JSNumber get width;
@@ -33,9 +31,7 @@ extension FontMetricsExtension on FontMetrics {
 
 @JS('Baseline')
 @staticInterop
-class Baseline {
-  external factory Baseline();
-}
+class Baseline {}
 
 extension BaselineExtension on Baseline {
   external JSString get name;
@@ -44,9 +40,7 @@ extension BaselineExtension on Baseline {
 
 @JS('Font')
 @staticInterop
-class Font {
-  external factory Font();
-}
+class Font {}
 
 extension FontExtension on Font {
   external JSString get name;

--- a/lib/src/dom/fs.dart
+++ b/lib/src/dom/fs.dart
@@ -18,20 +18,16 @@ typedef WriteCommandType = JSString;
 
 @JS('FileSystemHandle')
 @staticInterop
-class FileSystemHandle {
-  external factory FileSystemHandle();
-}
+class FileSystemHandle {}
 
 extension FileSystemHandleExtension on FileSystemHandle {
-  external JSPromise queryPermission();
-  external JSPromise queryPermission1(
-      FileSystemHandlePermissionDescriptor descriptor);
-  external JSPromise requestPermission();
-  external JSPromise requestPermission1(
-      FileSystemHandlePermissionDescriptor descriptor);
+  external JSPromise queryPermission(
+      [FileSystemHandlePermissionDescriptor descriptor]);
+  external JSPromise requestPermission(
+      [FileSystemHandlePermissionDescriptor descriptor]);
+  external JSPromise isSameEntry(FileSystemHandle other);
   external FileSystemHandleKind get kind;
   external JSString get name;
-  external JSPromise isSameEntry(FileSystemHandle other);
 }
 
 @JS()
@@ -50,14 +46,11 @@ extension FileSystemCreateWritableOptionsExtension
 
 @JS('FileSystemFileHandle')
 @staticInterop
-class FileSystemFileHandle extends FileSystemHandle {
-  external factory FileSystemFileHandle();
-}
+class FileSystemFileHandle implements FileSystemHandle {}
 
 extension FileSystemFileHandleExtension on FileSystemFileHandle {
   external JSPromise getFile();
-  external JSPromise createWritable();
-  external JSPromise createWritable1(FileSystemCreateWritableOptions options);
+  external JSPromise createWritable([FileSystemCreateWritableOptions options]);
   external JSPromise createSyncAccessHandle();
 }
 
@@ -100,26 +93,21 @@ extension FileSystemRemoveOptionsExtension on FileSystemRemoveOptions {
 
 @JS('FileSystemDirectoryHandle')
 @staticInterop
-class FileSystemDirectoryHandle extends FileSystemHandle {
-  external factory FileSystemDirectoryHandle();
-}
+class FileSystemDirectoryHandle implements FileSystemHandle {}
 
 extension FileSystemDirectoryHandleExtension on FileSystemDirectoryHandle {
-  external JSPromise getFileHandle(JSString name);
-  external JSPromise getFileHandle1(
-    JSString name,
+  external JSPromise getFileHandle(
+    JSString name, [
     FileSystemGetFileOptions options,
-  );
-  external JSPromise getDirectoryHandle(JSString name);
-  external JSPromise getDirectoryHandle1(
-    JSString name,
+  ]);
+  external JSPromise getDirectoryHandle(
+    JSString name, [
     FileSystemGetDirectoryOptions options,
-  );
-  external JSPromise removeEntry(JSString name);
-  external JSPromise removeEntry1(
-    JSString name,
+  ]);
+  external JSPromise removeEntry(
+    JSString name, [
     FileSystemRemoveOptions options,
-  );
+  ]);
   external JSPromise resolve(FileSystemHandle possibleDescendant);
 }
 
@@ -148,9 +136,7 @@ extension WriteParamsExtension on WriteParams {
 
 @JS('FileSystemWritableFileStream')
 @staticInterop
-class FileSystemWritableFileStream extends WritableStream {
-  external factory FileSystemWritableFileStream();
-}
+class FileSystemWritableFileStream implements WritableStream {}
 
 extension FileSystemWritableFileStreamExtension
     on FileSystemWritableFileStream {
@@ -173,21 +159,17 @@ extension FileSystemReadWriteOptionsExtension on FileSystemReadWriteOptions {
 
 @JS('FileSystemSyncAccessHandle')
 @staticInterop
-class FileSystemSyncAccessHandle {
-  external factory FileSystemSyncAccessHandle();
-}
+class FileSystemSyncAccessHandle {}
 
 extension FileSystemSyncAccessHandleExtension on FileSystemSyncAccessHandle {
-  external JSNumber read(BufferSource buffer);
-  external JSNumber read1(
-    BufferSource buffer,
+  external JSNumber read(
+    BufferSource buffer, [
     FileSystemReadWriteOptions options,
-  );
-  external JSNumber write(BufferSource buffer);
-  external JSNumber write1(
-    BufferSource buffer,
+  ]);
+  external JSNumber write(
+    BufferSource buffer, [
     FileSystemReadWriteOptions options,
-  );
+  ]);
   external JSVoid truncate(JSNumber newSize);
   external JSNumber getSize();
   external JSVoid flush();

--- a/lib/src/dom/gamepad.dart
+++ b/lib/src/dom/gamepad.dart
@@ -16,9 +16,7 @@ typedef GamepadMappingType = JSString;
 
 @JS('Gamepad')
 @staticInterop
-class Gamepad {
-  external factory Gamepad();
-}
+class Gamepad {}
 
 extension GamepadExtension on Gamepad {
   external GamepadHand get hand;
@@ -37,9 +35,7 @@ extension GamepadExtension on Gamepad {
 
 @JS('GamepadButton')
 @staticInterop
-class GamepadButton {
-  external factory GamepadButton();
-}
+class GamepadButton {}
 
 extension GamepadButtonExtension on GamepadButton {
   external JSBoolean get pressed;
@@ -49,10 +45,8 @@ extension GamepadButtonExtension on GamepadButton {
 
 @JS('GamepadEvent')
 @staticInterop
-class GamepadEvent extends Event {
-  external factory GamepadEvent();
-
-  external factory GamepadEvent.a1(
+class GamepadEvent implements Event {
+  external factory GamepadEvent(
     JSString type,
     GamepadEventInit eventInitDict,
   );
@@ -65,7 +59,7 @@ extension GamepadEventExtension on GamepadEvent {
 @JS()
 @staticInterop
 @anonymous
-class GamepadEventInit extends EventInit {
+class GamepadEventInit implements EventInit {
   external factory GamepadEventInit({required Gamepad gamepad});
 }
 

--- a/lib/src/dom/gamepad_extensions.dart
+++ b/lib/src/dom/gamepad_extensions.dart
@@ -15,23 +15,20 @@ typedef GamepadHapticEffectType = JSString;
 
 @JS('GamepadHapticActuator')
 @staticInterop
-class GamepadHapticActuator {
-  external factory GamepadHapticActuator();
-}
+class GamepadHapticActuator {}
 
 extension GamepadHapticActuatorExtension on GamepadHapticActuator {
-  external GamepadHapticActuatorType get type;
   external JSBoolean canPlayEffectType(GamepadHapticEffectType type);
-  external JSPromise playEffect(GamepadHapticEffectType type);
-  external JSPromise playEffect1(
-    GamepadHapticEffectType type,
+  external JSPromise playEffect(
+    GamepadHapticEffectType type, [
     GamepadEffectParameters params,
-  );
+  ]);
   external JSPromise pulse(
     JSNumber value,
     JSNumber duration,
   );
   external JSPromise reset();
+  external GamepadHapticActuatorType get type;
 }
 
 @JS()
@@ -59,9 +56,7 @@ extension GamepadEffectParametersExtension on GamepadEffectParameters {
 
 @JS('GamepadPose')
 @staticInterop
-class GamepadPose {
-  external factory GamepadPose();
-}
+class GamepadPose {}
 
 extension GamepadPoseExtension on GamepadPose {
   external JSBoolean get hasOrientation;
@@ -76,9 +71,7 @@ extension GamepadPoseExtension on GamepadPose {
 
 @JS('GamepadTouch')
 @staticInterop
-class GamepadTouch {
-  external factory GamepadTouch();
-}
+class GamepadTouch {}
 
 extension GamepadTouchExtension on GamepadTouch {
   external JSNumber get touchId;

--- a/lib/src/dom/generic_sensor.dart
+++ b/lib/src/dom/generic_sensor.dart
@@ -17,16 +17,14 @@ typedef MockSensorType = JSString;
 
 @JS('Sensor')
 @staticInterop
-class Sensor extends EventTarget {
-  external factory Sensor();
-}
+class Sensor implements EventTarget {}
 
 extension SensorExtension on Sensor {
+  external JSVoid start();
+  external JSVoid stop();
   external JSBoolean get activated;
   external JSBoolean get hasReading;
   external DOMHighResTimeStamp? get timestamp;
-  external JSVoid start();
-  external JSVoid stop();
   external set onreading(EventHandler value);
   external EventHandler get onreading;
   external set onactivate(EventHandler value);
@@ -49,10 +47,8 @@ extension SensorOptionsExtension on SensorOptions {
 
 @JS('SensorErrorEvent')
 @staticInterop
-class SensorErrorEvent extends Event {
-  external factory SensorErrorEvent();
-
-  external factory SensorErrorEvent.a1(
+class SensorErrorEvent implements Event {
+  external factory SensorErrorEvent(
     JSString type,
     SensorErrorEventInit errorEventInitDict,
   );
@@ -65,7 +61,7 @@ extension SensorErrorEventExtension on SensorErrorEvent {
 @JS()
 @staticInterop
 @anonymous
-class SensorErrorEventInit extends EventInit {
+class SensorErrorEventInit implements EventInit {
   external factory SensorErrorEventInit({required DOMException error});
 }
 

--- a/lib/src/dom/geolocation.dart
+++ b/lib/src/dom/geolocation.dart
@@ -15,31 +15,19 @@ typedef PositionErrorCallback = JSFunction;
 
 @JS('Geolocation')
 @staticInterop
-class Geolocation {
-  external factory Geolocation();
-}
+class Geolocation {}
 
 extension GeolocationExtension on Geolocation {
-  external JSVoid getCurrentPosition(PositionCallback successCallback);
-  external JSVoid getCurrentPosition1(
-    PositionCallback successCallback,
-    PositionErrorCallback? errorCallback,
-  );
-  external JSVoid getCurrentPosition2(
-    PositionCallback successCallback,
+  external JSVoid getCurrentPosition(
+    PositionCallback successCallback, [
     PositionErrorCallback? errorCallback,
     PositionOptions options,
-  );
-  external JSNumber watchPosition(PositionCallback successCallback);
-  external JSNumber watchPosition1(
-    PositionCallback successCallback,
-    PositionErrorCallback? errorCallback,
-  );
-  external JSNumber watchPosition2(
-    PositionCallback successCallback,
+  ]);
+  external JSNumber watchPosition(
+    PositionCallback successCallback, [
     PositionErrorCallback? errorCallback,
     PositionOptions options,
-  );
+  ]);
   external JSVoid clearWatch(JSNumber watchId);
 }
 
@@ -65,9 +53,7 @@ extension PositionOptionsExtension on PositionOptions {
 
 @JS('GeolocationPosition')
 @staticInterop
-class GeolocationPosition {
-  external factory GeolocationPosition();
-}
+class GeolocationPosition {}
 
 extension GeolocationPositionExtension on GeolocationPosition {
   external GeolocationCoordinates get coords;
@@ -76,9 +62,7 @@ extension GeolocationPositionExtension on GeolocationPosition {
 
 @JS('GeolocationCoordinates')
 @staticInterop
-class GeolocationCoordinates {
-  external factory GeolocationCoordinates();
-}
+class GeolocationCoordinates {}
 
 extension GeolocationCoordinatesExtension on GeolocationCoordinates {
   external JSNumber get accuracy;
@@ -93,8 +77,6 @@ extension GeolocationCoordinatesExtension on GeolocationCoordinates {
 @JS('GeolocationPositionError')
 @staticInterop
 class GeolocationPositionError {
-  external factory GeolocationPositionError();
-
   external static JSNumber get PERMISSION_DENIED;
   external static JSNumber get POSITION_UNAVAILABLE;
   external static JSNumber get TIMEOUT;

--- a/lib/src/dom/geolocation_sensor.dart
+++ b/lib/src/dom/geolocation_sensor.dart
@@ -14,15 +14,10 @@ import 'hr_time.dart';
 
 @JS('GeolocationSensor')
 @staticInterop
-class GeolocationSensor extends Sensor {
-  external factory GeolocationSensor();
+class GeolocationSensor implements Sensor {
+  external factory GeolocationSensor([GeolocationSensorOptions options]);
 
-  external factory GeolocationSensor.a1();
-
-  external factory GeolocationSensor.a2(GeolocationSensorOptions options);
-
-  external static JSPromise read();
-  external static JSPromise read1(ReadOptions readOptions);
+  external static JSPromise read([ReadOptions readOptions]);
 }
 
 extension GeolocationSensorExtension on GeolocationSensor {
@@ -38,14 +33,14 @@ extension GeolocationSensorExtension on GeolocationSensor {
 @JS()
 @staticInterop
 @anonymous
-class GeolocationSensorOptions extends SensorOptions {
+class GeolocationSensorOptions implements SensorOptions {
   external factory GeolocationSensorOptions();
 }
 
 @JS()
 @staticInterop
 @anonymous
-class ReadOptions extends GeolocationSensorOptions {
+class ReadOptions implements GeolocationSensorOptions {
   external factory ReadOptions({AbortSignal? signal});
 }
 

--- a/lib/src/dom/geometry.dart
+++ b/lib/src/dom/geometry.dart
@@ -11,73 +11,36 @@ import 'package:js/js.dart' hide JS;
 @JS('DOMPointReadOnly')
 @staticInterop
 class DOMPointReadOnly {
-  external factory DOMPointReadOnly();
-
-  external factory DOMPointReadOnly.a1();
-
-  external factory DOMPointReadOnly.a2(JSNumber x);
-
-  external factory DOMPointReadOnly.a3(
-    JSNumber x,
-    JSNumber y,
-  );
-
-  external factory DOMPointReadOnly.a4(
-    JSNumber x,
-    JSNumber y,
-    JSNumber z,
-  );
-
-  external factory DOMPointReadOnly.a5(
+  external factory DOMPointReadOnly([
     JSNumber x,
     JSNumber y,
     JSNumber z,
     JSNumber w,
-  );
+  ]);
 
-  external static DOMPointReadOnly fromPoint();
-  external static DOMPointReadOnly fromPoint1(DOMPointInit other);
+  external static DOMPointReadOnly fromPoint([DOMPointInit other]);
 }
 
 extension DOMPointReadOnlyExtension on DOMPointReadOnly {
+  external DOMPoint matrixTransform([DOMMatrixInit matrix]);
+  external JSObject toJSON();
   external JSNumber get x;
   external JSNumber get y;
   external JSNumber get z;
   external JSNumber get w;
-  external DOMPoint matrixTransform();
-  external DOMPoint matrixTransform1(DOMMatrixInit matrix);
-  external JSObject toJSON();
 }
 
 @JS('DOMPoint')
 @staticInterop
-class DOMPoint extends DOMPointReadOnly {
-  external factory DOMPoint();
-
-  external factory DOMPoint.a1();
-
-  external factory DOMPoint.a2(JSNumber x);
-
-  external factory DOMPoint.a3(
-    JSNumber x,
-    JSNumber y,
-  );
-
-  external factory DOMPoint.a4(
-    JSNumber x,
-    JSNumber y,
-    JSNumber z,
-  );
-
-  external factory DOMPoint.a5(
+class DOMPoint implements DOMPointReadOnly {
+  external factory DOMPoint([
     JSNumber x,
     JSNumber y,
     JSNumber z,
     JSNumber w,
-  );
+  ]);
 
-  external static DOMPoint fromPoint();
-  external static DOMPoint fromPoint1(DOMPointInit other);
+  external static DOMPoint fromPoint([DOMPointInit other]);
 }
 
 extension DOMPointExtension on DOMPoint {
@@ -117,35 +80,18 @@ extension DOMPointInitExtension on DOMPointInit {
 @JS('DOMRectReadOnly')
 @staticInterop
 class DOMRectReadOnly {
-  external factory DOMRectReadOnly();
-
-  external factory DOMRectReadOnly.a1();
-
-  external factory DOMRectReadOnly.a2(JSNumber x);
-
-  external factory DOMRectReadOnly.a3(
-    JSNumber x,
-    JSNumber y,
-  );
-
-  external factory DOMRectReadOnly.a4(
-    JSNumber x,
-    JSNumber y,
-    JSNumber width,
-  );
-
-  external factory DOMRectReadOnly.a5(
+  external factory DOMRectReadOnly([
     JSNumber x,
     JSNumber y,
     JSNumber width,
     JSNumber height,
-  );
+  ]);
 
-  external static DOMRectReadOnly fromRect();
-  external static DOMRectReadOnly fromRect1(DOMRectInit other);
+  external static DOMRectReadOnly fromRect([DOMRectInit other]);
 }
 
 extension DOMRectReadOnlyExtension on DOMRectReadOnly {
+  external JSObject toJSON();
   external JSNumber get x;
   external JSNumber get y;
   external JSNumber get width;
@@ -154,38 +100,19 @@ extension DOMRectReadOnlyExtension on DOMRectReadOnly {
   external JSNumber get right;
   external JSNumber get bottom;
   external JSNumber get left;
-  external JSObject toJSON();
 }
 
 @JS('DOMRect')
 @staticInterop
-class DOMRect extends DOMRectReadOnly {
-  external factory DOMRect();
-
-  external factory DOMRect.a1();
-
-  external factory DOMRect.a2(JSNumber x);
-
-  external factory DOMRect.a3(
-    JSNumber x,
-    JSNumber y,
-  );
-
-  external factory DOMRect.a4(
-    JSNumber x,
-    JSNumber y,
-    JSNumber width,
-  );
-
-  external factory DOMRect.a5(
+class DOMRect implements DOMRectReadOnly {
+  external factory DOMRect([
     JSNumber x,
     JSNumber y,
     JSNumber width,
     JSNumber height,
-  );
+  ]);
 
-  external static DOMRect fromRect();
-  external static DOMRect fromRect1(DOMRectInit other);
+  external static DOMRect fromRect([DOMRectInit other]);
 }
 
 extension DOMRectExtension on DOMRect {
@@ -224,55 +151,34 @@ extension DOMRectInitExtension on DOMRectInit {
 
 @JS('DOMRectList')
 @staticInterop
-class DOMRectList {
-  external factory DOMRectList();
-}
+class DOMRectList {}
 
 extension DOMRectListExtension on DOMRectList {
-  external JSNumber get length;
   external DOMRect? item(JSNumber index);
+  external JSNumber get length;
 }
 
 @JS('DOMQuad')
 @staticInterop
 class DOMQuad {
-  external factory DOMQuad();
-
-  external factory DOMQuad.a1();
-
-  external factory DOMQuad.a2(DOMPointInit p1);
-
-  external factory DOMQuad.a3(
-    DOMPointInit p1,
-    DOMPointInit p2,
-  );
-
-  external factory DOMQuad.a4(
-    DOMPointInit p1,
-    DOMPointInit p2,
-    DOMPointInit p3,
-  );
-
-  external factory DOMQuad.a5(
+  external factory DOMQuad([
     DOMPointInit p1,
     DOMPointInit p2,
     DOMPointInit p3,
     DOMPointInit p4,
-  );
+  ]);
 
-  external static DOMQuad fromRect();
-  external static DOMQuad fromRect1(DOMRectInit other);
-  external static DOMQuad fromQuad();
-  external static DOMQuad fromQuad1(DOMQuadInit other);
+  external static DOMQuad fromRect([DOMRectInit other]);
+  external static DOMQuad fromQuad([DOMQuadInit other]);
 }
 
 extension DOMQuadExtension on DOMQuad {
+  external DOMRect getBounds();
+  external JSObject toJSON();
   external DOMPoint get p1;
   external DOMPoint get p2;
   external DOMPoint get p3;
   external DOMPoint get p4;
-  external DOMRect getBounds();
-  external JSObject toJSON();
 }
 
 @JS()
@@ -301,19 +207,62 @@ extension DOMQuadInitExtension on DOMQuadInit {
 @JS('DOMMatrixReadOnly')
 @staticInterop
 class DOMMatrixReadOnly {
-  external factory DOMMatrixReadOnly();
+  external factory DOMMatrixReadOnly([JSAny init]);
 
-  external factory DOMMatrixReadOnly.a1();
-
-  external factory DOMMatrixReadOnly.a2(JSAny init);
-
-  external static DOMMatrixReadOnly fromMatrix();
-  external static DOMMatrixReadOnly fromMatrix1(DOMMatrixInit other);
+  external static DOMMatrixReadOnly fromMatrix([DOMMatrixInit other]);
   external static DOMMatrixReadOnly fromFloat32Array(JSFloat32Array array32);
   external static DOMMatrixReadOnly fromFloat64Array(JSFloat64Array array64);
 }
 
 extension DOMMatrixReadOnlyExtension on DOMMatrixReadOnly {
+  external DOMMatrix translate([
+    JSNumber tx,
+    JSNumber ty,
+    JSNumber tz,
+  ]);
+  external DOMMatrix scale([
+    JSNumber scaleX,
+    JSNumber scaleY,
+    JSNumber scaleZ,
+    JSNumber originX,
+    JSNumber originY,
+    JSNumber originZ,
+  ]);
+  external DOMMatrix scaleNonUniform([
+    JSNumber scaleX,
+    JSNumber scaleY,
+  ]);
+  external DOMMatrix scale3d([
+    JSNumber scale,
+    JSNumber originX,
+    JSNumber originY,
+    JSNumber originZ,
+  ]);
+  external DOMMatrix rotate([
+    JSNumber rotX,
+    JSNumber rotY,
+    JSNumber rotZ,
+  ]);
+  external DOMMatrix rotateFromVector([
+    JSNumber x,
+    JSNumber y,
+  ]);
+  external DOMMatrix rotateAxisAngle([
+    JSNumber x,
+    JSNumber y,
+    JSNumber z,
+    JSNumber angle,
+  ]);
+  external DOMMatrix skewX([JSNumber sx]);
+  external DOMMatrix skewY([JSNumber sy]);
+  external DOMMatrix multiply([DOMMatrixInit other]);
+  external DOMMatrix flipX();
+  external DOMMatrix flipY();
+  external DOMMatrix inverse();
+  external DOMPoint transformPoint([DOMPointInit point]);
+  external JSFloat32Array toFloat32Array();
+  external JSFloat64Array toFloat64Array();
+  external JSObject toJSON();
   external JSNumber get a;
   external JSNumber get b;
   external JSNumber get c;
@@ -338,138 +287,59 @@ extension DOMMatrixReadOnlyExtension on DOMMatrixReadOnly {
   external JSNumber get m44;
   external JSBoolean get is2D;
   external JSBoolean get isIdentity;
-  external DOMMatrix translate();
-  external DOMMatrix translate1(JSNumber tx);
-  external DOMMatrix translate2(
-    JSNumber tx,
-    JSNumber ty,
-  );
-  external DOMMatrix translate3(
-    JSNumber tx,
-    JSNumber ty,
-    JSNumber tz,
-  );
-  external DOMMatrix scale();
-  external DOMMatrix scale1(JSNumber scaleX);
-  external DOMMatrix scale2(
-    JSNumber scaleX,
-    JSNumber scaleY,
-  );
-  external DOMMatrix scale3(
-    JSNumber scaleX,
-    JSNumber scaleY,
-    JSNumber scaleZ,
-  );
-  external DOMMatrix scale4(
-    JSNumber scaleX,
-    JSNumber scaleY,
-    JSNumber scaleZ,
-    JSNumber originX,
-  );
-  external DOMMatrix scale5(
-    JSNumber scaleX,
-    JSNumber scaleY,
-    JSNumber scaleZ,
-    JSNumber originX,
-    JSNumber originY,
-  );
-  external DOMMatrix scale6(
-    JSNumber scaleX,
-    JSNumber scaleY,
-    JSNumber scaleZ,
-    JSNumber originX,
-    JSNumber originY,
-    JSNumber originZ,
-  );
-  external DOMMatrix scaleNonUniform();
-  external DOMMatrix scaleNonUniform1(JSNumber scaleX);
-  external DOMMatrix scaleNonUniform2(
-    JSNumber scaleX,
-    JSNumber scaleY,
-  );
-  external DOMMatrix scale3d();
-  external DOMMatrix scale3d1(JSNumber scale);
-  external DOMMatrix scale3d2(
-    JSNumber scale,
-    JSNumber originX,
-  );
-  external DOMMatrix scale3d3(
-    JSNumber scale,
-    JSNumber originX,
-    JSNumber originY,
-  );
-  external DOMMatrix scale3d4(
-    JSNumber scale,
-    JSNumber originX,
-    JSNumber originY,
-    JSNumber originZ,
-  );
-  external DOMMatrix rotate();
-  external DOMMatrix rotate1(JSNumber rotX);
-  external DOMMatrix rotate2(
-    JSNumber rotX,
-    JSNumber rotY,
-  );
-  external DOMMatrix rotate3(
-    JSNumber rotX,
-    JSNumber rotY,
-    JSNumber rotZ,
-  );
-  external DOMMatrix rotateFromVector();
-  external DOMMatrix rotateFromVector1(JSNumber x);
-  external DOMMatrix rotateFromVector2(
-    JSNumber x,
-    JSNumber y,
-  );
-  external DOMMatrix rotateAxisAngle();
-  external DOMMatrix rotateAxisAngle1(JSNumber x);
-  external DOMMatrix rotateAxisAngle2(
-    JSNumber x,
-    JSNumber y,
-  );
-  external DOMMatrix rotateAxisAngle3(
-    JSNumber x,
-    JSNumber y,
-    JSNumber z,
-  );
-  external DOMMatrix rotateAxisAngle4(
-    JSNumber x,
-    JSNumber y,
-    JSNumber z,
-    JSNumber angle,
-  );
-  external DOMMatrix skewX();
-  external DOMMatrix skewX1(JSNumber sx);
-  external DOMMatrix skewY();
-  external DOMMatrix skewY1(JSNumber sy);
-  external DOMMatrix multiply();
-  external DOMMatrix multiply1(DOMMatrixInit other);
-  external DOMMatrix flipX();
-  external DOMMatrix flipY();
-  external DOMMatrix inverse();
-  external DOMPoint transformPoint();
-  external DOMPoint transformPoint1(DOMPointInit point);
-  external JSFloat32Array toFloat32Array();
-  external JSFloat64Array toFloat64Array();
-  external JSObject toJSON();
 }
 
 @JS('DOMMatrix')
 @staticInterop
-class DOMMatrix extends DOMMatrixReadOnly {
-  external factory DOMMatrix();
+class DOMMatrix implements DOMMatrixReadOnly {
+  external factory DOMMatrix([JSAny init]);
 
-  external factory DOMMatrix.a1();
-
-  external factory DOMMatrix.a2(JSAny init);
-
-  external static DOMMatrix fromMatrix();
-  external static DOMMatrix fromMatrix1(DOMMatrixInit other);
+  external static DOMMatrix fromMatrix([DOMMatrixInit other]);
   external static DOMMatrix fromFloat32Array(JSFloat32Array array32);
   external static DOMMatrix fromFloat64Array(JSFloat64Array array64);
 }
 
 extension DOMMatrixExtension on DOMMatrix {
+  external DOMMatrix multiplySelf([DOMMatrixInit other]);
+  external DOMMatrix preMultiplySelf([DOMMatrixInit other]);
+  external DOMMatrix translateSelf([
+    JSNumber tx,
+    JSNumber ty,
+    JSNumber tz,
+  ]);
+  external DOMMatrix scaleSelf([
+    JSNumber scaleX,
+    JSNumber scaleY,
+    JSNumber scaleZ,
+    JSNumber originX,
+    JSNumber originY,
+    JSNumber originZ,
+  ]);
+  external DOMMatrix scale3dSelf([
+    JSNumber scale,
+    JSNumber originX,
+    JSNumber originY,
+    JSNumber originZ,
+  ]);
+  external DOMMatrix rotateSelf([
+    JSNumber rotX,
+    JSNumber rotY,
+    JSNumber rotZ,
+  ]);
+  external DOMMatrix rotateFromVectorSelf([
+    JSNumber x,
+    JSNumber y,
+  ]);
+  external DOMMatrix rotateAxisAngleSelf([
+    JSNumber x,
+    JSNumber y,
+    JSNumber z,
+    JSNumber angle,
+  ]);
+  external DOMMatrix skewXSelf([JSNumber sx]);
+  external DOMMatrix skewYSelf([JSNumber sy]);
+  external DOMMatrix invertSelf();
+  external DOMMatrix setMatrixValue(JSString transformList);
   external set a(JSNumber value);
   external JSNumber get a;
   external set b(JSNumber value);
@@ -514,110 +384,6 @@ extension DOMMatrixExtension on DOMMatrix {
   external JSNumber get m43;
   external set m44(JSNumber value);
   external JSNumber get m44;
-  external DOMMatrix multiplySelf();
-  external DOMMatrix multiplySelf1(DOMMatrixInit other);
-  external DOMMatrix preMultiplySelf();
-  external DOMMatrix preMultiplySelf1(DOMMatrixInit other);
-  external DOMMatrix translateSelf();
-  external DOMMatrix translateSelf1(JSNumber tx);
-  external DOMMatrix translateSelf2(
-    JSNumber tx,
-    JSNumber ty,
-  );
-  external DOMMatrix translateSelf3(
-    JSNumber tx,
-    JSNumber ty,
-    JSNumber tz,
-  );
-  external DOMMatrix scaleSelf();
-  external DOMMatrix scaleSelf1(JSNumber scaleX);
-  external DOMMatrix scaleSelf2(
-    JSNumber scaleX,
-    JSNumber scaleY,
-  );
-  external DOMMatrix scaleSelf3(
-    JSNumber scaleX,
-    JSNumber scaleY,
-    JSNumber scaleZ,
-  );
-  external DOMMatrix scaleSelf4(
-    JSNumber scaleX,
-    JSNumber scaleY,
-    JSNumber scaleZ,
-    JSNumber originX,
-  );
-  external DOMMatrix scaleSelf5(
-    JSNumber scaleX,
-    JSNumber scaleY,
-    JSNumber scaleZ,
-    JSNumber originX,
-    JSNumber originY,
-  );
-  external DOMMatrix scaleSelf6(
-    JSNumber scaleX,
-    JSNumber scaleY,
-    JSNumber scaleZ,
-    JSNumber originX,
-    JSNumber originY,
-    JSNumber originZ,
-  );
-  external DOMMatrix scale3dSelf();
-  external DOMMatrix scale3dSelf1(JSNumber scale);
-  external DOMMatrix scale3dSelf2(
-    JSNumber scale,
-    JSNumber originX,
-  );
-  external DOMMatrix scale3dSelf3(
-    JSNumber scale,
-    JSNumber originX,
-    JSNumber originY,
-  );
-  external DOMMatrix scale3dSelf4(
-    JSNumber scale,
-    JSNumber originX,
-    JSNumber originY,
-    JSNumber originZ,
-  );
-  external DOMMatrix rotateSelf();
-  external DOMMatrix rotateSelf1(JSNumber rotX);
-  external DOMMatrix rotateSelf2(
-    JSNumber rotX,
-    JSNumber rotY,
-  );
-  external DOMMatrix rotateSelf3(
-    JSNumber rotX,
-    JSNumber rotY,
-    JSNumber rotZ,
-  );
-  external DOMMatrix rotateFromVectorSelf();
-  external DOMMatrix rotateFromVectorSelf1(JSNumber x);
-  external DOMMatrix rotateFromVectorSelf2(
-    JSNumber x,
-    JSNumber y,
-  );
-  external DOMMatrix rotateAxisAngleSelf();
-  external DOMMatrix rotateAxisAngleSelf1(JSNumber x);
-  external DOMMatrix rotateAxisAngleSelf2(
-    JSNumber x,
-    JSNumber y,
-  );
-  external DOMMatrix rotateAxisAngleSelf3(
-    JSNumber x,
-    JSNumber y,
-    JSNumber z,
-  );
-  external DOMMatrix rotateAxisAngleSelf4(
-    JSNumber x,
-    JSNumber y,
-    JSNumber z,
-    JSNumber angle,
-  );
-  external DOMMatrix skewXSelf();
-  external DOMMatrix skewXSelf1(JSNumber sx);
-  external DOMMatrix skewYSelf();
-  external DOMMatrix skewYSelf1(JSNumber sy);
-  external DOMMatrix invertSelf();
-  external DOMMatrix setMatrixValue(JSString transformList);
 }
 
 @JS()
@@ -670,7 +436,7 @@ extension DOMMatrix2DInitExtension on DOMMatrix2DInit {
 @JS()
 @staticInterop
 @anonymous
-class DOMMatrixInit extends DOMMatrix2DInit {
+class DOMMatrixInit implements DOMMatrix2DInit {
   external factory DOMMatrixInit({
     JSNumber m13 = 0,
     JSNumber m14 = 0,

--- a/lib/src/dom/gpc_spec.dart
+++ b/lib/src/dom/gpc_spec.dart
@@ -10,9 +10,7 @@ import 'package:js/js.dart' hide JS;
 
 @JS('GlobalPrivacyControl')
 @staticInterop
-class GlobalPrivacyControl {
-  external factory GlobalPrivacyControl();
-}
+class GlobalPrivacyControl {}
 
 extension GlobalPrivacyControlExtension on GlobalPrivacyControl {
   external JSBoolean get globalPrivacyControl;

--- a/lib/src/dom/gyroscope.dart
+++ b/lib/src/dom/gyroscope.dart
@@ -14,12 +14,8 @@ typedef GyroscopeLocalCoordinateSystem = JSString;
 
 @JS('Gyroscope')
 @staticInterop
-class Gyroscope extends Sensor {
-  external factory Gyroscope();
-
-  external factory Gyroscope.a1();
-
-  external factory Gyroscope.a2(GyroscopeSensorOptions sensorOptions);
+class Gyroscope implements Sensor {
+  external factory Gyroscope([GyroscopeSensorOptions sensorOptions]);
 }
 
 extension GyroscopeExtension on Gyroscope {
@@ -31,7 +27,7 @@ extension GyroscopeExtension on Gyroscope {
 @JS()
 @staticInterop
 @anonymous
-class GyroscopeSensorOptions extends SensorOptions {
+class GyroscopeSensorOptions implements SensorOptions {
   external factory GyroscopeSensorOptions(
       {GyroscopeLocalCoordinateSystem referenceFrame = 'device'});
 }

--- a/lib/src/dom/hr_time.dart
+++ b/lib/src/dom/hr_time.dart
@@ -20,47 +20,36 @@ typedef EpochTimeStamp = JSNumber;
 
 @JS('Performance')
 @staticInterop
-class Performance extends EventTarget {
-  external factory Performance();
-}
+class Performance implements EventTarget {}
 
 extension PerformanceExtension on Performance {
-  external EventCounts get eventCounts;
-  external JSNumber get interactionCount;
   external DOMHighResTimeStamp now();
-  external DOMHighResTimeStamp get timeOrigin;
   external JSObject toJSON();
-  external PerformanceTiming get timing;
-  external PerformanceNavigation get navigation;
   external JSPromise measureUserAgentSpecificMemory();
   external PerformanceEntryList getEntries();
   external PerformanceEntryList getEntriesByType(JSString type);
-  external PerformanceEntryList getEntriesByName(JSString name);
-  external PerformanceEntryList getEntriesByName1(
-    JSString name,
+  external PerformanceEntryList getEntriesByName(
+    JSString name, [
     JSString type,
-  );
+  ]);
   external JSVoid clearResourceTimings();
   external JSVoid setResourceTimingBufferSize(JSNumber maxSize);
-  external set onresourcetimingbufferfull(EventHandler value);
-  external EventHandler get onresourcetimingbufferfull;
-  external PerformanceMark mark(JSString markName);
-  external PerformanceMark mark1(
-    JSString markName,
+  external PerformanceMark mark(
+    JSString markName, [
     PerformanceMarkOptions markOptions,
-  );
-  external JSVoid clearMarks();
-  external JSVoid clearMarks1(JSString markName);
-  external PerformanceMeasure measure(JSString measureName);
-  external PerformanceMeasure measure1(
-    JSString measureName,
-    JSAny startOrMeasureOptions,
-  );
-  external PerformanceMeasure measure2(
-    JSString measureName,
+  ]);
+  external JSVoid clearMarks([JSString markName]);
+  external PerformanceMeasure measure(
+    JSString measureName, [
     JSAny startOrMeasureOptions,
     JSString endMark,
-  );
-  external JSVoid clearMeasures();
-  external JSVoid clearMeasures1(JSString measureName);
+  ]);
+  external JSVoid clearMeasures([JSString measureName]);
+  external EventCounts get eventCounts;
+  external JSNumber get interactionCount;
+  external DOMHighResTimeStamp get timeOrigin;
+  external PerformanceTiming get timing;
+  external PerformanceNavigation get navigation;
+  external set onresourcetimingbufferfull(EventHandler value);
+  external EventHandler get onresourcetimingbufferfull;
 }

--- a/lib/src/dom/html.dart
+++ b/lib/src/dom/html.dart
@@ -68,7 +68,6 @@ import 'web_app_launch.dart';
 import 'web_bluetooth.dart';
 import 'web_locks.dart';
 import 'web_share.dart';
-import 'webaudio.dart';
 import 'webcryptoapi.dart';
 import 'webdriver.dart';
 import 'webgpu.dart';
@@ -129,22 +128,17 @@ typedef WorkerType = JSString;
 
 @JS('HTMLAllCollection')
 @staticInterop
-class HTMLAllCollection {
-  external factory HTMLAllCollection();
-}
+class HTMLAllCollection {}
 
 extension HTMLAllCollectionExtension on HTMLAllCollection {
-  external JSNumber get length;
   external JSAny? namedItem(JSString name);
-  external JSAny? item();
-  external JSAny? item1(JSString nameOrIndex);
+  external JSAny? item([JSString nameOrIndex]);
+  external JSNumber get length;
 }
 
 @JS('HTMLFormControlsCollection')
 @staticInterop
-class HTMLFormControlsCollection extends HTMLCollection {
-  external factory HTMLFormControlsCollection();
-}
+class HTMLFormControlsCollection implements HTMLCollection {}
 
 extension HTMLFormControlsCollectionExtension on HTMLFormControlsCollection {
   external JSAny? namedItem(JSString name);
@@ -152,9 +146,7 @@ extension HTMLFormControlsCollectionExtension on HTMLFormControlsCollection {
 
 @JS('RadioNodeList')
 @staticInterop
-class RadioNodeList extends NodeList {
-  external factory RadioNodeList();
-}
+class RadioNodeList implements NodeList {}
 
 extension RadioNodeListExtension on RadioNodeList {
   external set value(JSString value);
@@ -163,47 +155,48 @@ extension RadioNodeListExtension on RadioNodeList {
 
 @JS('HTMLOptionsCollection')
 @staticInterop
-class HTMLOptionsCollection extends HTMLCollection {
-  external factory HTMLOptionsCollection();
-}
+class HTMLOptionsCollection implements HTMLCollection {}
 
 extension HTMLOptionsCollectionExtension on HTMLOptionsCollection {
+  external JSVoid add(
+    JSAny element, [
+    JSAny? before,
+  ]);
+  external JSVoid remove(JSNumber index);
   external set length(JSNumber value);
   external JSNumber get length;
-  external JSVoid add(JSAny element);
-  external JSVoid add1(
-    JSAny element,
-    JSAny? before,
-  );
-  external JSVoid remove(JSNumber index);
   external set selectedIndex(JSNumber value);
   external JSNumber get selectedIndex;
 }
 
 @JS('DOMStringList')
 @staticInterop
-class DOMStringList {
-  external factory DOMStringList();
-}
+class DOMStringList {}
 
 extension DOMStringListExtension on DOMStringList {
-  external JSNumber get length;
   external JSString? item(JSNumber index);
   external JSBoolean contains(JSString string);
+  external JSNumber get length;
 }
 
 @JS('HTMLElement')
 @staticInterop
-class HTMLElement extends Element
+class HTMLElement
     implements
+        Element,
         ElementCSSInlineStyle,
         GlobalEventHandlers,
         ElementContentEditable,
         HTMLOrSVGElement {
-  external factory HTMLElement.a0();
+  external factory HTMLElement();
 }
 
 extension HTMLElementExtension on HTMLElement {
+  external JSVoid click();
+  external ElementInternals attachInternals();
+  external JSVoid showPopover();
+  external JSVoid hidePopover();
+  external JSVoid togglePopover([JSBoolean force]);
   external Element? get offsetParent;
   external JSNumber get offsetTop;
   external JSNumber get offsetLeft;
@@ -221,7 +214,6 @@ extension HTMLElementExtension on HTMLElement {
   external JSAny? get hidden;
   external set inert(JSBoolean value);
   external JSBoolean get inert;
-  external JSVoid click();
   external set accessKey(JSString value);
   external JSString get accessKey;
   external JSString get accessKeyLabel;
@@ -235,28 +227,21 @@ extension HTMLElementExtension on HTMLElement {
   external JSString get innerText;
   external set outerText(JSString value);
   external JSString get outerText;
-  external ElementInternals attachInternals();
-  external JSVoid showPopover();
-  external JSVoid hidePopover();
-  external JSVoid togglePopover();
-  external JSVoid togglePopover1(JSBoolean force);
   external set popover(JSString? value);
   external JSString? get popover;
 }
 
 @JS('HTMLUnknownElement')
 @staticInterop
-class HTMLUnknownElement extends HTMLElement {
-  external factory HTMLUnknownElement();
-}
+class HTMLUnknownElement implements HTMLElement {}
 
 @JS('HTMLOrSVGElement')
 @staticInterop
-class HTMLOrSVGElement {
-  external factory HTMLOrSVGElement();
-}
+class HTMLOrSVGElement {}
 
 extension HTMLOrSVGElementExtension on HTMLOrSVGElement {
+  external JSVoid focus([FocusOptions options]);
+  external JSVoid blur();
   external DOMStringMap get dataset;
   external set nonce(JSString value);
   external JSString get nonce;
@@ -264,21 +249,16 @@ extension HTMLOrSVGElementExtension on HTMLOrSVGElement {
   external JSBoolean get autofocus;
   external set tabIndex(JSNumber value);
   external JSNumber get tabIndex;
-  external JSVoid focus();
-  external JSVoid focus1(FocusOptions options);
-  external JSVoid blur();
 }
 
 @JS('DOMStringMap')
 @staticInterop
-class DOMStringMap {
-  external factory DOMStringMap();
-}
+class DOMStringMap {}
 
 @JS('HTMLHtmlElement')
 @staticInterop
-class HTMLHtmlElement extends HTMLElement {
-  external factory HTMLHtmlElement.a0();
+class HTMLHtmlElement implements HTMLElement {
+  external factory HTMLHtmlElement();
 }
 
 extension HTMLHtmlElementExtension on HTMLHtmlElement {
@@ -288,14 +268,14 @@ extension HTMLHtmlElementExtension on HTMLHtmlElement {
 
 @JS('HTMLHeadElement')
 @staticInterop
-class HTMLHeadElement extends HTMLElement {
-  external factory HTMLHeadElement.a0();
+class HTMLHeadElement implements HTMLElement {
+  external factory HTMLHeadElement();
 }
 
 @JS('HTMLTitleElement')
 @staticInterop
-class HTMLTitleElement extends HTMLElement {
-  external factory HTMLTitleElement.a0();
+class HTMLTitleElement implements HTMLElement {
+  external factory HTMLTitleElement();
 }
 
 extension HTMLTitleElementExtension on HTMLTitleElement {
@@ -305,8 +285,8 @@ extension HTMLTitleElementExtension on HTMLTitleElement {
 
 @JS('HTMLBaseElement')
 @staticInterop
-class HTMLBaseElement extends HTMLElement {
-  external factory HTMLBaseElement.a0();
+class HTMLBaseElement implements HTMLElement {
+  external factory HTMLBaseElement();
 }
 
 extension HTMLBaseElementExtension on HTMLBaseElement {
@@ -318,8 +298,8 @@ extension HTMLBaseElementExtension on HTMLBaseElement {
 
 @JS('HTMLLinkElement')
 @staticInterop
-class HTMLLinkElement extends HTMLElement implements LinkStyle {
-  external factory HTMLLinkElement.a0();
+class HTMLLinkElement implements HTMLElement, LinkStyle {
+  external factory HTMLLinkElement();
 }
 
 extension HTMLLinkElementExtension on HTMLLinkElement {
@@ -362,8 +342,8 @@ extension HTMLLinkElementExtension on HTMLLinkElement {
 
 @JS('HTMLMetaElement')
 @staticInterop
-class HTMLMetaElement extends HTMLElement {
-  external factory HTMLMetaElement.a0();
+class HTMLMetaElement implements HTMLElement {
+  external factory HTMLMetaElement();
 }
 
 extension HTMLMetaElementExtension on HTMLMetaElement {
@@ -381,8 +361,8 @@ extension HTMLMetaElementExtension on HTMLMetaElement {
 
 @JS('HTMLStyleElement')
 @staticInterop
-class HTMLStyleElement extends HTMLElement implements LinkStyle {
-  external factory HTMLStyleElement.a0();
+class HTMLStyleElement implements HTMLElement, LinkStyle {
+  external factory HTMLStyleElement();
 }
 
 extension HTMLStyleElementExtension on HTMLStyleElement {
@@ -397,8 +377,8 @@ extension HTMLStyleElementExtension on HTMLStyleElement {
 
 @JS('HTMLBodyElement')
 @staticInterop
-class HTMLBodyElement extends HTMLElement implements WindowEventHandlers {
-  external factory HTMLBodyElement.a0();
+class HTMLBodyElement implements HTMLElement, WindowEventHandlers {
+  external factory HTMLBodyElement();
 }
 
 extension HTMLBodyElementExtension on HTMLBodyElement {
@@ -420,8 +400,8 @@ extension HTMLBodyElementExtension on HTMLBodyElement {
 
 @JS('HTMLHeadingElement')
 @staticInterop
-class HTMLHeadingElement extends HTMLElement {
-  external factory HTMLHeadingElement.a0();
+class HTMLHeadingElement implements HTMLElement {
+  external factory HTMLHeadingElement();
 }
 
 extension HTMLHeadingElementExtension on HTMLHeadingElement {
@@ -431,8 +411,8 @@ extension HTMLHeadingElementExtension on HTMLHeadingElement {
 
 @JS('HTMLParagraphElement')
 @staticInterop
-class HTMLParagraphElement extends HTMLElement {
-  external factory HTMLParagraphElement.a0();
+class HTMLParagraphElement implements HTMLElement {
+  external factory HTMLParagraphElement();
 }
 
 extension HTMLParagraphElementExtension on HTMLParagraphElement {
@@ -442,8 +422,8 @@ extension HTMLParagraphElementExtension on HTMLParagraphElement {
 
 @JS('HTMLHRElement')
 @staticInterop
-class HTMLHRElement extends HTMLElement {
-  external factory HTMLHRElement.a0();
+class HTMLHRElement implements HTMLElement {
+  external factory HTMLHRElement();
 }
 
 extension HTMLHRElementExtension on HTMLHRElement {
@@ -461,8 +441,8 @@ extension HTMLHRElementExtension on HTMLHRElement {
 
 @JS('HTMLPreElement')
 @staticInterop
-class HTMLPreElement extends HTMLElement {
-  external factory HTMLPreElement.a0();
+class HTMLPreElement implements HTMLElement {
+  external factory HTMLPreElement();
 }
 
 extension HTMLPreElementExtension on HTMLPreElement {
@@ -472,8 +452,8 @@ extension HTMLPreElementExtension on HTMLPreElement {
 
 @JS('HTMLQuoteElement')
 @staticInterop
-class HTMLQuoteElement extends HTMLElement {
-  external factory HTMLQuoteElement.a0();
+class HTMLQuoteElement implements HTMLElement {
+  external factory HTMLQuoteElement();
 }
 
 extension HTMLQuoteElementExtension on HTMLQuoteElement {
@@ -483,8 +463,8 @@ extension HTMLQuoteElementExtension on HTMLQuoteElement {
 
 @JS('HTMLOListElement')
 @staticInterop
-class HTMLOListElement extends HTMLElement {
-  external factory HTMLOListElement.a0();
+class HTMLOListElement implements HTMLElement {
+  external factory HTMLOListElement();
 }
 
 extension HTMLOListElementExtension on HTMLOListElement {
@@ -500,8 +480,8 @@ extension HTMLOListElementExtension on HTMLOListElement {
 
 @JS('HTMLUListElement')
 @staticInterop
-class HTMLUListElement extends HTMLElement {
-  external factory HTMLUListElement.a0();
+class HTMLUListElement implements HTMLElement {
+  external factory HTMLUListElement();
 }
 
 extension HTMLUListElementExtension on HTMLUListElement {
@@ -513,8 +493,8 @@ extension HTMLUListElementExtension on HTMLUListElement {
 
 @JS('HTMLMenuElement')
 @staticInterop
-class HTMLMenuElement extends HTMLElement {
-  external factory HTMLMenuElement.a0();
+class HTMLMenuElement implements HTMLElement {
+  external factory HTMLMenuElement();
 }
 
 extension HTMLMenuElementExtension on HTMLMenuElement {
@@ -524,8 +504,8 @@ extension HTMLMenuElementExtension on HTMLMenuElement {
 
 @JS('HTMLLIElement')
 @staticInterop
-class HTMLLIElement extends HTMLElement {
-  external factory HTMLLIElement.a0();
+class HTMLLIElement implements HTMLElement {
+  external factory HTMLLIElement();
 }
 
 extension HTMLLIElementExtension on HTMLLIElement {
@@ -537,8 +517,8 @@ extension HTMLLIElementExtension on HTMLLIElement {
 
 @JS('HTMLDListElement')
 @staticInterop
-class HTMLDListElement extends HTMLElement {
-  external factory HTMLDListElement.a0();
+class HTMLDListElement implements HTMLElement {
+  external factory HTMLDListElement();
 }
 
 extension HTMLDListElementExtension on HTMLDListElement {
@@ -548,8 +528,8 @@ extension HTMLDListElementExtension on HTMLDListElement {
 
 @JS('HTMLDivElement')
 @staticInterop
-class HTMLDivElement extends HTMLElement {
-  external factory HTMLDivElement.a0();
+class HTMLDivElement implements HTMLElement {
+  external factory HTMLDivElement();
 }
 
 extension HTMLDivElementExtension on HTMLDivElement {
@@ -559,9 +539,12 @@ extension HTMLDivElementExtension on HTMLDivElement {
 
 @JS('HTMLAnchorElement')
 @staticInterop
-class HTMLAnchorElement extends HTMLElement
-    implements HTMLAttributionSrcElementUtils, HTMLHyperlinkElementUtils {
-  external factory HTMLAnchorElement.a0();
+class HTMLAnchorElement
+    implements
+        HTMLElement,
+        HTMLAttributionSrcElementUtils,
+        HTMLHyperlinkElementUtils {
+  external factory HTMLAnchorElement();
 }
 
 extension HTMLAnchorElementExtension on HTMLAnchorElement {
@@ -598,8 +581,8 @@ extension HTMLAnchorElementExtension on HTMLAnchorElement {
 
 @JS('HTMLDataElement')
 @staticInterop
-class HTMLDataElement extends HTMLElement {
-  external factory HTMLDataElement.a0();
+class HTMLDataElement implements HTMLElement {
+  external factory HTMLDataElement();
 }
 
 extension HTMLDataElementExtension on HTMLDataElement {
@@ -609,8 +592,8 @@ extension HTMLDataElementExtension on HTMLDataElement {
 
 @JS('HTMLTimeElement')
 @staticInterop
-class HTMLTimeElement extends HTMLElement {
-  external factory HTMLTimeElement.a0();
+class HTMLTimeElement implements HTMLElement {
+  external factory HTMLTimeElement();
 }
 
 extension HTMLTimeElementExtension on HTMLTimeElement {
@@ -620,14 +603,14 @@ extension HTMLTimeElementExtension on HTMLTimeElement {
 
 @JS('HTMLSpanElement')
 @staticInterop
-class HTMLSpanElement extends HTMLElement {
-  external factory HTMLSpanElement.a0();
+class HTMLSpanElement implements HTMLElement {
+  external factory HTMLSpanElement();
 }
 
 @JS('HTMLBRElement')
 @staticInterop
-class HTMLBRElement extends HTMLElement {
-  external factory HTMLBRElement.a0();
+class HTMLBRElement implements HTMLElement {
+  external factory HTMLBRElement();
 }
 
 extension HTMLBRElementExtension on HTMLBRElement {
@@ -637,9 +620,7 @@ extension HTMLBRElementExtension on HTMLBRElement {
 
 @JS('HTMLHyperlinkElementUtils')
 @staticInterop
-class HTMLHyperlinkElementUtils {
-  external factory HTMLHyperlinkElementUtils();
-}
+class HTMLHyperlinkElementUtils {}
 
 extension HTMLHyperlinkElementUtilsExtension on HTMLHyperlinkElementUtils {
   external set href(JSString value);
@@ -667,8 +648,8 @@ extension HTMLHyperlinkElementUtilsExtension on HTMLHyperlinkElementUtils {
 
 @JS('HTMLModElement')
 @staticInterop
-class HTMLModElement extends HTMLElement {
-  external factory HTMLModElement.a0();
+class HTMLModElement implements HTMLElement {
+  external factory HTMLModElement();
 }
 
 extension HTMLModElementExtension on HTMLModElement {
@@ -680,14 +661,14 @@ extension HTMLModElementExtension on HTMLModElement {
 
 @JS('HTMLPictureElement')
 @staticInterop
-class HTMLPictureElement extends HTMLElement {
-  external factory HTMLPictureElement.a0();
+class HTMLPictureElement implements HTMLElement {
+  external factory HTMLPictureElement();
 }
 
 @JS('HTMLSourceElement')
 @staticInterop
-class HTMLSourceElement extends HTMLElement {
-  external factory HTMLSourceElement.a0();
+class HTMLSourceElement implements HTMLElement {
+  external factory HTMLSourceElement();
 }
 
 extension HTMLSourceElementExtension on HTMLSourceElement {
@@ -709,12 +690,12 @@ extension HTMLSourceElementExtension on HTMLSourceElement {
 
 @JS('HTMLImageElement')
 @staticInterop
-class HTMLImageElement extends HTMLElement
-    implements HTMLAttributionSrcElementUtils {
-  external factory HTMLImageElement.a0();
+class HTMLImageElement implements HTMLElement, HTMLAttributionSrcElementUtils {
+  external factory HTMLImageElement();
 }
 
 extension HTMLImageElementExtension on HTMLImageElement {
+  external JSPromise decode();
   external JSNumber get x;
   external JSNumber get y;
   external set alt(JSString value);
@@ -745,7 +726,6 @@ extension HTMLImageElementExtension on HTMLImageElement {
   external JSString get decoding;
   external set loading(JSString value);
   external JSString get loading;
-  external JSPromise decode();
   external set name(JSString value);
   external JSString get name;
   external set lowsrc(JSString value);
@@ -766,11 +746,12 @@ extension HTMLImageElementExtension on HTMLImageElement {
 
 @JS('HTMLIFrameElement')
 @staticInterop
-class HTMLIFrameElement extends HTMLElement {
-  external factory HTMLIFrameElement.a0();
+class HTMLIFrameElement implements HTMLElement {
+  external factory HTMLIFrameElement();
 }
 
 extension HTMLIFrameElementExtension on HTMLIFrameElement {
+  external Document? getSVGDocument();
   external set csp(JSString value);
   external JSString get csp;
   external set src(JSString value);
@@ -794,7 +775,6 @@ extension HTMLIFrameElementExtension on HTMLIFrameElement {
   external JSString get loading;
   external Document? get contentDocument;
   external Window? get contentWindow;
-  external Document? getSVGDocument();
   external set align(JSString value);
   external JSString get align;
   external set scrolling(JSString value);
@@ -814,11 +794,12 @@ extension HTMLIFrameElementExtension on HTMLIFrameElement {
 
 @JS('HTMLEmbedElement')
 @staticInterop
-class HTMLEmbedElement extends HTMLElement {
-  external factory HTMLEmbedElement.a0();
+class HTMLEmbedElement implements HTMLElement {
+  external factory HTMLEmbedElement();
 }
 
 extension HTMLEmbedElementExtension on HTMLEmbedElement {
+  external Document? getSVGDocument();
   external set src(JSString value);
   external JSString get src;
   external set type(JSString value);
@@ -827,7 +808,6 @@ extension HTMLEmbedElementExtension on HTMLEmbedElement {
   external JSString get width;
   external set height(JSString value);
   external JSString get height;
-  external Document? getSVGDocument();
   external set align(JSString value);
   external JSString get align;
   external set name(JSString value);
@@ -836,11 +816,15 @@ extension HTMLEmbedElementExtension on HTMLEmbedElement {
 
 @JS('HTMLObjectElement')
 @staticInterop
-class HTMLObjectElement extends HTMLElement {
-  external factory HTMLObjectElement.a0();
+class HTMLObjectElement implements HTMLElement {
+  external factory HTMLObjectElement();
 }
 
 extension HTMLObjectElementExtension on HTMLObjectElement {
+  external Document? getSVGDocument();
+  external JSBoolean checkValidity();
+  external JSBoolean reportValidity();
+  external JSVoid setCustomValidity(JSString error);
   external set data(JSString value);
   external JSString get data;
   external set type(JSString value);
@@ -854,13 +838,9 @@ extension HTMLObjectElementExtension on HTMLObjectElement {
   external JSString get height;
   external Document? get contentDocument;
   external Window? get contentWindow;
-  external Document? getSVGDocument();
   external JSBoolean get willValidate;
   external ValidityState get validity;
   external JSString get validationMessage;
-  external JSBoolean checkValidity();
-  external JSBoolean reportValidity();
-  external JSVoid setCustomValidity(JSString error);
   external set align(JSString value);
   external JSString get align;
   external set archive(JSString value);
@@ -887,11 +867,16 @@ extension HTMLObjectElementExtension on HTMLObjectElement {
 
 @JS('HTMLVideoElement')
 @staticInterop
-class HTMLVideoElement extends HTMLMediaElement {
-  external factory HTMLVideoElement.a0();
+class HTMLVideoElement implements HTMLMediaElement {
+  external factory HTMLVideoElement();
 }
 
 extension HTMLVideoElementExtension on HTMLVideoElement {
+  external VideoPlaybackQuality getVideoPlaybackQuality();
+  external JSPromise requestPictureInPicture();
+  external JSNumber requestVideoFrameCallback(
+      VideoFrameRequestCallback callback);
+  external JSVoid cancelVideoFrameCallback(JSNumber handle);
   external set width(JSNumber value);
   external JSNumber get width;
   external set height(JSNumber value);
@@ -902,29 +887,24 @@ extension HTMLVideoElementExtension on HTMLVideoElement {
   external JSString get poster;
   external set playsInline(JSBoolean value);
   external JSBoolean get playsInline;
-  external VideoPlaybackQuality getVideoPlaybackQuality();
-  external JSPromise requestPictureInPicture();
   external set onenterpictureinpicture(EventHandler value);
   external EventHandler get onenterpictureinpicture;
   external set onleavepictureinpicture(EventHandler value);
   external EventHandler get onleavepictureinpicture;
   external set disablePictureInPicture(JSBoolean value);
   external JSBoolean get disablePictureInPicture;
-  external JSNumber requestVideoFrameCallback(
-      VideoFrameRequestCallback callback);
-  external JSVoid cancelVideoFrameCallback(JSNumber handle);
 }
 
 @JS('HTMLAudioElement')
 @staticInterop
-class HTMLAudioElement extends HTMLMediaElement {
-  external factory HTMLAudioElement.a0();
+class HTMLAudioElement implements HTMLMediaElement {
+  external factory HTMLAudioElement();
 }
 
 @JS('HTMLTrackElement')
 @staticInterop
-class HTMLTrackElement extends HTMLElement {
-  external factory HTMLTrackElement.a0();
+class HTMLTrackElement implements HTMLElement {
+  external factory HTMLTrackElement();
 
   external static JSNumber get NONE;
   external static JSNumber get LOADING;
@@ -942,18 +922,16 @@ extension HTMLTrackElementExtension on HTMLTrackElement {
   external set label(JSString value);
   external JSString get label;
   @JS('default')
-  external set default_0_(JSBoolean value);
+  external set default_(JSBoolean value);
   @JS('default')
-  external JSBoolean get default_0_;
+  external JSBoolean get default_;
   external JSNumber get readyState;
   external TextTrack get track;
 }
 
 @JS('HTMLMediaElement')
 @staticInterop
-class HTMLMediaElement extends HTMLElement {
-  external factory HTMLMediaElement();
-
+class HTMLMediaElement implements HTMLElement {
   external static JSNumber get NETWORK_EMPTY;
   external static JSNumber get NETWORK_IDLE;
   external static JSNumber get NETWORK_LOADING;
@@ -966,14 +944,26 @@ class HTMLMediaElement extends HTMLElement {
 }
 
 extension HTMLMediaElementExtension on HTMLMediaElement {
-  external JSString get sinkId;
   external JSPromise setSinkId(JSString sinkId);
+  external JSPromise setMediaKeys(MediaKeys? mediaKeys);
+  external JSVoid load();
+  external CanPlayTypeResult canPlayType(JSString type);
+  external JSVoid fastSeek(JSNumber time);
+  external JSObject getStartDate();
+  external JSPromise play();
+  external JSVoid pause();
+  external TextTrack addTextTrack(
+    TextTrackKind kind, [
+    JSString label,
+    JSString language,
+  ]);
+  external MediaStream captureStream();
+  external JSString get sinkId;
   external MediaKeys? get mediaKeys;
   external set onencrypted(EventHandler value);
   external EventHandler get onencrypted;
   external set onwaitingforkey(EventHandler value);
   external EventHandler get onwaitingforkey;
-  external JSPromise setMediaKeys(MediaKeys? mediaKeys);
   external MediaError? get error;
   external set src(JSString value);
   external JSString get src;
@@ -986,15 +976,11 @@ extension HTMLMediaElementExtension on HTMLMediaElement {
   external set preload(JSString value);
   external JSString get preload;
   external TimeRanges get buffered;
-  external JSVoid load();
-  external CanPlayTypeResult canPlayType(JSString type);
   external JSNumber get readyState;
   external JSBoolean get seeking;
   external set currentTime(JSNumber value);
   external JSNumber get currentTime;
-  external JSVoid fastSeek(JSNumber time);
   external JSNumber get duration;
-  external JSObject getStartDate();
   external JSBoolean get paused;
   external set defaultPlaybackRate(JSNumber value);
   external JSNumber get defaultPlaybackRate;
@@ -1009,8 +995,6 @@ extension HTMLMediaElementExtension on HTMLMediaElement {
   external JSBoolean get autoplay;
   external set loop(JSBoolean value);
   external JSBoolean get loop;
-  external JSPromise play();
-  external JSVoid pause();
   external set controls(JSBoolean value);
   external JSBoolean get controls;
   external set volume(JSNumber value);
@@ -1022,17 +1006,6 @@ extension HTMLMediaElementExtension on HTMLMediaElement {
   external AudioTrackList get audioTracks;
   external VideoTrackList get videoTracks;
   external TextTrackList get textTracks;
-  external TextTrack addTextTrack(TextTrackKind kind);
-  external TextTrack addTextTrack1(
-    TextTrackKind kind,
-    JSString label,
-  );
-  external TextTrack addTextTrack2(
-    TextTrackKind kind,
-    JSString label,
-    JSString language,
-  );
-  external MediaStream captureStream();
   external RemotePlayback get remote;
   external set disableRemotePlayback(JSBoolean value);
   external JSBoolean get disableRemotePlayback;
@@ -1041,8 +1014,6 @@ extension HTMLMediaElementExtension on HTMLMediaElement {
 @JS('MediaError')
 @staticInterop
 class MediaError {
-  external factory MediaError();
-
   external static JSNumber get MEDIA_ERR_ABORTED;
   external static JSNumber get MEDIA_ERR_NETWORK;
   external static JSNumber get MEDIA_ERR_DECODE;
@@ -1056,13 +1027,11 @@ extension MediaErrorExtension on MediaError {
 
 @JS('AudioTrackList')
 @staticInterop
-class AudioTrackList extends EventTarget {
-  external factory AudioTrackList();
-}
+class AudioTrackList implements EventTarget {}
 
 extension AudioTrackListExtension on AudioTrackList {
-  external JSNumber get length;
   external AudioTrack? getTrackById(JSString id);
+  external JSNumber get length;
   external set onchange(EventHandler value);
   external EventHandler get onchange;
   external set onaddtrack(EventHandler value);
@@ -1073,9 +1042,7 @@ extension AudioTrackListExtension on AudioTrackList {
 
 @JS('AudioTrack')
 @staticInterop
-class AudioTrack {
-  external factory AudioTrack();
-}
+class AudioTrack {}
 
 extension AudioTrackExtension on AudioTrack {
   external JSString get id;
@@ -1089,13 +1056,11 @@ extension AudioTrackExtension on AudioTrack {
 
 @JS('VideoTrackList')
 @staticInterop
-class VideoTrackList extends EventTarget {
-  external factory VideoTrackList();
-}
+class VideoTrackList implements EventTarget {}
 
 extension VideoTrackListExtension on VideoTrackList {
-  external JSNumber get length;
   external VideoTrack? getTrackById(JSString id);
+  external JSNumber get length;
   external JSNumber get selectedIndex;
   external set onchange(EventHandler value);
   external EventHandler get onchange;
@@ -1107,9 +1072,7 @@ extension VideoTrackListExtension on VideoTrackList {
 
 @JS('VideoTrack')
 @staticInterop
-class VideoTrack {
-  external factory VideoTrack();
-}
+class VideoTrack {}
 
 extension VideoTrackExtension on VideoTrack {
   external JSString get id;
@@ -1123,13 +1086,11 @@ extension VideoTrackExtension on VideoTrack {
 
 @JS('TextTrackList')
 @staticInterop
-class TextTrackList extends EventTarget {
-  external factory TextTrackList();
-}
+class TextTrackList implements EventTarget {}
 
 extension TextTrackListExtension on TextTrackList {
-  external JSNumber get length;
   external TextTrack? getTrackById(JSString id);
+  external JSNumber get length;
   external set onchange(EventHandler value);
   external EventHandler get onchange;
   external set onaddtrack(EventHandler value);
@@ -1140,11 +1101,11 @@ extension TextTrackListExtension on TextTrackList {
 
 @JS('TextTrack')
 @staticInterop
-class TextTrack extends EventTarget {
-  external factory TextTrack();
-}
+class TextTrack implements EventTarget {}
 
 extension TextTrackExtension on TextTrack {
+  external JSVoid addCue(TextTrackCue cue);
+  external JSVoid removeCue(TextTrackCue cue);
   external TextTrackKind get kind;
   external JSString get label;
   external JSString get language;
@@ -1154,8 +1115,6 @@ extension TextTrackExtension on TextTrack {
   external TextTrackMode get mode;
   external TextTrackCueList? get cues;
   external TextTrackCueList? get activeCues;
-  external JSVoid addCue(TextTrackCue cue);
-  external JSVoid removeCue(TextTrackCue cue);
   external set oncuechange(EventHandler value);
   external EventHandler get oncuechange;
   external SourceBuffer? get sourceBuffer;
@@ -1163,20 +1122,16 @@ extension TextTrackExtension on TextTrack {
 
 @JS('TextTrackCueList')
 @staticInterop
-class TextTrackCueList {
-  external factory TextTrackCueList();
-}
+class TextTrackCueList {}
 
 extension TextTrackCueListExtension on TextTrackCueList {
-  external JSNumber get length;
   external TextTrackCue? getCueById(JSString id);
+  external JSNumber get length;
 }
 
 @JS('TextTrackCue')
 @staticInterop
-class TextTrackCue extends EventTarget {
-  external factory TextTrackCue();
-}
+class TextTrackCue implements EventTarget {}
 
 extension TextTrackCueExtension on TextTrackCue {
   external TextTrack? get track;
@@ -1196,27 +1151,21 @@ extension TextTrackCueExtension on TextTrackCue {
 
 @JS('TimeRanges')
 @staticInterop
-class TimeRanges {
-  external factory TimeRanges();
-}
+class TimeRanges {}
 
 extension TimeRangesExtension on TimeRanges {
-  external JSNumber get length;
   external JSNumber start(JSNumber index);
   external JSNumber end(JSNumber index);
+  external JSNumber get length;
 }
 
 @JS('TrackEvent')
 @staticInterop
-class TrackEvent extends Event {
-  external factory TrackEvent();
-
-  external factory TrackEvent.a1(JSString type);
-
-  external factory TrackEvent.a2(
-    JSString type,
+class TrackEvent implements Event {
+  external factory TrackEvent(
+    JSString type, [
     TrackEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension TrackEventExtension on TrackEvent {
@@ -1226,7 +1175,7 @@ extension TrackEventExtension on TrackEvent {
 @JS()
 @staticInterop
 @anonymous
-class TrackEventInit extends EventInit {
+class TrackEventInit implements EventInit {
   external factory TrackEventInit({JSAny? track});
 }
 
@@ -1237,8 +1186,8 @@ extension TrackEventInitExtension on TrackEventInit {
 
 @JS('HTMLMapElement')
 @staticInterop
-class HTMLMapElement extends HTMLElement {
-  external factory HTMLMapElement.a0();
+class HTMLMapElement implements HTMLElement {
+  external factory HTMLMapElement();
 }
 
 extension HTMLMapElementExtension on HTMLMapElement {
@@ -1249,8 +1198,8 @@ extension HTMLMapElementExtension on HTMLMapElement {
 
 @JS('HTMLAreaElement')
 @staticInterop
-class HTMLAreaElement extends HTMLElement implements HTMLHyperlinkElementUtils {
-  external factory HTMLAreaElement.a0();
+class HTMLAreaElement implements HTMLElement, HTMLHyperlinkElementUtils {
+  external factory HTMLAreaElement();
 }
 
 extension HTMLAreaElementExtension on HTMLAreaElement {
@@ -1277,29 +1226,28 @@ extension HTMLAreaElementExtension on HTMLAreaElement {
 
 @JS('HTMLTableElement')
 @staticInterop
-class HTMLTableElement extends HTMLElement {
-  external factory HTMLTableElement.a0();
+class HTMLTableElement implements HTMLElement {
+  external factory HTMLTableElement();
 }
 
 extension HTMLTableElementExtension on HTMLTableElement {
-  external set caption(HTMLTableCaptionElement? value);
-  external HTMLTableCaptionElement? get caption;
   external HTMLTableCaptionElement createCaption();
   external JSVoid deleteCaption();
-  external set tHead(HTMLTableSectionElement? value);
-  external HTMLTableSectionElement? get tHead;
   external HTMLTableSectionElement createTHead();
   external JSVoid deleteTHead();
-  external set tFoot(HTMLTableSectionElement? value);
-  external HTMLTableSectionElement? get tFoot;
   external HTMLTableSectionElement createTFoot();
   external JSVoid deleteTFoot();
-  external HTMLCollection get tBodies;
   external HTMLTableSectionElement createTBody();
-  external HTMLCollection get rows;
-  external HTMLTableRowElement insertRow();
-  external HTMLTableRowElement insertRow1(JSNumber index);
+  external HTMLTableRowElement insertRow([JSNumber index]);
   external JSVoid deleteRow(JSNumber index);
+  external set caption(HTMLTableCaptionElement? value);
+  external HTMLTableCaptionElement? get caption;
+  external set tHead(HTMLTableSectionElement? value);
+  external HTMLTableSectionElement? get tHead;
+  external set tFoot(HTMLTableSectionElement? value);
+  external HTMLTableSectionElement? get tFoot;
+  external HTMLCollection get tBodies;
+  external HTMLCollection get rows;
   external set align(JSString value);
   external JSString get align;
   external set border(JSString value);
@@ -1322,8 +1270,8 @@ extension HTMLTableElementExtension on HTMLTableElement {
 
 @JS('HTMLTableCaptionElement')
 @staticInterop
-class HTMLTableCaptionElement extends HTMLElement {
-  external factory HTMLTableCaptionElement.a0();
+class HTMLTableCaptionElement implements HTMLElement {
+  external factory HTMLTableCaptionElement();
 }
 
 extension HTMLTableCaptionElementExtension on HTMLTableCaptionElement {
@@ -1333,8 +1281,8 @@ extension HTMLTableCaptionElementExtension on HTMLTableCaptionElement {
 
 @JS('HTMLTableColElement')
 @staticInterop
-class HTMLTableColElement extends HTMLElement {
-  external factory HTMLTableColElement.a0();
+class HTMLTableColElement implements HTMLElement {
+  external factory HTMLTableColElement();
 }
 
 extension HTMLTableColElementExtension on HTMLTableColElement {
@@ -1354,15 +1302,14 @@ extension HTMLTableColElementExtension on HTMLTableColElement {
 
 @JS('HTMLTableSectionElement')
 @staticInterop
-class HTMLTableSectionElement extends HTMLElement {
-  external factory HTMLTableSectionElement.a0();
+class HTMLTableSectionElement implements HTMLElement {
+  external factory HTMLTableSectionElement();
 }
 
 extension HTMLTableSectionElementExtension on HTMLTableSectionElement {
-  external HTMLCollection get rows;
-  external HTMLTableRowElement insertRow();
-  external HTMLTableRowElement insertRow1(JSNumber index);
+  external HTMLTableRowElement insertRow([JSNumber index]);
   external JSVoid deleteRow(JSNumber index);
+  external HTMLCollection get rows;
   external set align(JSString value);
   external JSString get align;
   external set ch(JSString value);
@@ -1375,17 +1322,16 @@ extension HTMLTableSectionElementExtension on HTMLTableSectionElement {
 
 @JS('HTMLTableRowElement')
 @staticInterop
-class HTMLTableRowElement extends HTMLElement {
-  external factory HTMLTableRowElement.a0();
+class HTMLTableRowElement implements HTMLElement {
+  external factory HTMLTableRowElement();
 }
 
 extension HTMLTableRowElementExtension on HTMLTableRowElement {
+  external HTMLTableCellElement insertCell([JSNumber index]);
+  external JSVoid deleteCell(JSNumber index);
   external JSNumber get rowIndex;
   external JSNumber get sectionRowIndex;
   external HTMLCollection get cells;
-  external HTMLTableCellElement insertCell();
-  external HTMLTableCellElement insertCell1(JSNumber index);
-  external JSVoid deleteCell(JSNumber index);
   external set align(JSString value);
   external JSString get align;
   external set ch(JSString value);
@@ -1400,8 +1346,8 @@ extension HTMLTableRowElementExtension on HTMLTableRowElement {
 
 @JS('HTMLTableCellElement')
 @staticInterop
-class HTMLTableCellElement extends HTMLElement {
-  external factory HTMLTableCellElement.a0();
+class HTMLTableCellElement implements HTMLElement {
+  external factory HTMLTableCellElement();
 }
 
 extension HTMLTableCellElementExtension on HTMLTableCellElement {
@@ -1438,11 +1384,16 @@ extension HTMLTableCellElementExtension on HTMLTableCellElement {
 
 @JS('HTMLFormElement')
 @staticInterop
-class HTMLFormElement extends HTMLElement {
-  external factory HTMLFormElement.a0();
+class HTMLFormElement implements HTMLElement {
+  external factory HTMLFormElement();
 }
 
 extension HTMLFormElementExtension on HTMLFormElement {
+  external JSVoid submit();
+  external JSVoid requestSubmit([HTMLElement? submitter]);
+  external JSVoid reset();
+  external JSBoolean checkValidity();
+  external JSBoolean reportValidity();
   external set acceptCharset(JSString value);
   external JSString get acceptCharset;
   external set action(JSString value);
@@ -1466,18 +1417,12 @@ extension HTMLFormElementExtension on HTMLFormElement {
   external DOMTokenList get relList;
   external HTMLFormControlsCollection get elements;
   external JSNumber get length;
-  external JSVoid submit();
-  external JSVoid requestSubmit();
-  external JSVoid requestSubmit1(HTMLElement? submitter);
-  external JSVoid reset();
-  external JSBoolean checkValidity();
-  external JSBoolean reportValidity();
 }
 
 @JS('HTMLLabelElement')
 @staticInterop
-class HTMLLabelElement extends HTMLElement {
-  external factory HTMLLabelElement.a0();
+class HTMLLabelElement implements HTMLElement {
+  external factory HTMLLabelElement();
 }
 
 extension HTMLLabelElementExtension on HTMLLabelElement {
@@ -1489,11 +1434,29 @@ extension HTMLLabelElementExtension on HTMLLabelElement {
 
 @JS('HTMLInputElement')
 @staticInterop
-class HTMLInputElement extends HTMLElement implements PopoverTargetElement {
-  external factory HTMLInputElement.a0();
+class HTMLInputElement implements HTMLElement, PopoverTargetElement {
+  external factory HTMLInputElement();
 }
 
 extension HTMLInputElementExtension on HTMLInputElement {
+  external JSVoid stepUp([JSNumber n]);
+  external JSVoid stepDown([JSNumber n]);
+  external JSBoolean checkValidity();
+  external JSBoolean reportValidity();
+  external JSVoid setCustomValidity(JSString error);
+  external JSVoid select();
+  external JSVoid setRangeText(
+    JSString replacement, [
+    JSNumber start,
+    JSNumber end,
+    SelectionMode selectionMode,
+  ]);
+  external JSVoid setSelectionRange(
+    JSNumber start,
+    JSNumber end, [
+    JSString direction,
+  ]);
+  external JSVoid showPicker();
   external set webkitdirectory(JSBoolean value);
   external JSBoolean get webkitdirectory;
   external JSArray get webkitEntries;
@@ -1569,48 +1532,16 @@ extension HTMLInputElementExtension on HTMLInputElement {
   external JSNumber get valueAsNumber;
   external set width(JSNumber value);
   external JSNumber get width;
-  external JSVoid stepUp();
-  external JSVoid stepUp1(JSNumber n);
-  external JSVoid stepDown();
-  external JSVoid stepDown1(JSNumber n);
   external JSBoolean get willValidate;
   external ValidityState get validity;
   external JSString get validationMessage;
-  external JSBoolean checkValidity();
-  external JSBoolean reportValidity();
-  external JSVoid setCustomValidity(JSString error);
   external NodeList? get labels;
-  external JSVoid select();
   external set selectionStart(JSNumber? value);
   external JSNumber? get selectionStart;
   external set selectionEnd(JSNumber? value);
   external JSNumber? get selectionEnd;
   external set selectionDirection(JSString? value);
   external JSString? get selectionDirection;
-  external JSVoid setRangeText(JSString replacement);
-  @JS('setRangeText')
-  external JSVoid setRangeText_1_(
-    JSString replacement,
-    JSNumber start,
-    JSNumber end,
-  );
-  @JS('setRangeText')
-  external JSVoid setRangeText_1_1(
-    JSString replacement,
-    JSNumber start,
-    JSNumber end,
-    SelectionMode selectionMode,
-  );
-  external JSVoid setSelectionRange(
-    JSNumber start,
-    JSNumber end,
-  );
-  external JSVoid setSelectionRange1(
-    JSNumber start,
-    JSNumber end,
-    JSString direction,
-  );
-  external JSVoid showPicker();
   external set align(JSString value);
   external JSString get align;
   external set useMap(JSString value);
@@ -1619,11 +1550,14 @@ extension HTMLInputElementExtension on HTMLInputElement {
 
 @JS('HTMLButtonElement')
 @staticInterop
-class HTMLButtonElement extends HTMLElement implements PopoverTargetElement {
-  external factory HTMLButtonElement.a0();
+class HTMLButtonElement implements HTMLElement, PopoverTargetElement {
+  external factory HTMLButtonElement();
 }
 
 extension HTMLButtonElementExtension on HTMLButtonElement {
+  external JSBoolean checkValidity();
+  external JSBoolean reportValidity();
+  external JSVoid setCustomValidity(JSString error);
   external set disabled(JSBoolean value);
   external JSBoolean get disabled;
   external HTMLFormElement? get form;
@@ -1646,19 +1580,26 @@ extension HTMLButtonElementExtension on HTMLButtonElement {
   external JSBoolean get willValidate;
   external ValidityState get validity;
   external JSString get validationMessage;
-  external JSBoolean checkValidity();
-  external JSBoolean reportValidity();
-  external JSVoid setCustomValidity(JSString error);
   external NodeList get labels;
 }
 
 @JS('HTMLSelectElement')
 @staticInterop
-class HTMLSelectElement extends HTMLElement {
-  external factory HTMLSelectElement.a0();
+class HTMLSelectElement implements HTMLElement {
+  external factory HTMLSelectElement();
 }
 
 extension HTMLSelectElementExtension on HTMLSelectElement {
+  external HTMLOptionElement? item(JSNumber index);
+  external HTMLOptionElement? namedItem(JSString name);
+  external JSVoid add(
+    JSAny element, [
+    JSAny? before,
+  ]);
+  external JSVoid remove([JSNumber index]);
+  external JSBoolean checkValidity();
+  external JSBoolean reportValidity();
+  external JSVoid setCustomValidity(JSString error);
   external set autocomplete(JSString value);
   external JSString get autocomplete;
   external set disabled(JSBoolean value);
@@ -1676,16 +1617,6 @@ extension HTMLSelectElementExtension on HTMLSelectElement {
   external HTMLOptionsCollection get options;
   external set length(JSNumber value);
   external JSNumber get length;
-  external HTMLOptionElement? item(JSNumber index);
-  external HTMLOptionElement? namedItem(JSString name);
-  external JSVoid add(JSAny element);
-  external JSVoid add1(
-    JSAny element,
-    JSAny? before,
-  );
-  external JSVoid remove();
-  @JS('remove')
-  external JSVoid remove_1_(JSNumber index);
   external HTMLCollection get selectedOptions;
   external set selectedIndex(JSNumber value);
   external JSNumber get selectedIndex;
@@ -1694,16 +1625,13 @@ extension HTMLSelectElementExtension on HTMLSelectElement {
   external JSBoolean get willValidate;
   external ValidityState get validity;
   external JSString get validationMessage;
-  external JSBoolean checkValidity();
-  external JSBoolean reportValidity();
-  external JSVoid setCustomValidity(JSString error);
   external NodeList get labels;
 }
 
 @JS('HTMLDataListElement')
 @staticInterop
-class HTMLDataListElement extends HTMLElement {
-  external factory HTMLDataListElement.a0();
+class HTMLDataListElement implements HTMLElement {
+  external factory HTMLDataListElement();
 }
 
 extension HTMLDataListElementExtension on HTMLDataListElement {
@@ -1712,8 +1640,8 @@ extension HTMLDataListElementExtension on HTMLDataListElement {
 
 @JS('HTMLOptGroupElement')
 @staticInterop
-class HTMLOptGroupElement extends HTMLElement {
-  external factory HTMLOptGroupElement.a0();
+class HTMLOptGroupElement implements HTMLElement {
+  external factory HTMLOptGroupElement();
 }
 
 extension HTMLOptGroupElementExtension on HTMLOptGroupElement {
@@ -1725,8 +1653,8 @@ extension HTMLOptGroupElementExtension on HTMLOptGroupElement {
 
 @JS('HTMLOptionElement')
 @staticInterop
-class HTMLOptionElement extends HTMLElement {
-  external factory HTMLOptionElement.a0();
+class HTMLOptionElement implements HTMLElement {
+  external factory HTMLOptionElement();
 }
 
 extension HTMLOptionElementExtension on HTMLOptionElement {
@@ -1748,11 +1676,26 @@ extension HTMLOptionElementExtension on HTMLOptionElement {
 
 @JS('HTMLTextAreaElement')
 @staticInterop
-class HTMLTextAreaElement extends HTMLElement {
-  external factory HTMLTextAreaElement.a0();
+class HTMLTextAreaElement implements HTMLElement {
+  external factory HTMLTextAreaElement();
 }
 
 extension HTMLTextAreaElementExtension on HTMLTextAreaElement {
+  external JSBoolean checkValidity();
+  external JSBoolean reportValidity();
+  external JSVoid setCustomValidity(JSString error);
+  external JSVoid select();
+  external JSVoid setRangeText(
+    JSString replacement, [
+    JSNumber start,
+    JSNumber end,
+    SelectionMode selectionMode,
+  ]);
+  external JSVoid setSelectionRange(
+    JSNumber start,
+    JSNumber end, [
+    JSString direction,
+  ]);
   external set autocomplete(JSString value);
   external JSString get autocomplete;
   external set cols(JSNumber value);
@@ -1787,49 +1730,25 @@ extension HTMLTextAreaElementExtension on HTMLTextAreaElement {
   external JSBoolean get willValidate;
   external ValidityState get validity;
   external JSString get validationMessage;
-  external JSBoolean checkValidity();
-  external JSBoolean reportValidity();
-  external JSVoid setCustomValidity(JSString error);
   external NodeList get labels;
-  external JSVoid select();
   external set selectionStart(JSNumber value);
   external JSNumber get selectionStart;
   external set selectionEnd(JSNumber value);
   external JSNumber get selectionEnd;
   external set selectionDirection(JSString value);
   external JSString get selectionDirection;
-  external JSVoid setRangeText(JSString replacement);
-  @JS('setRangeText')
-  external JSVoid setRangeText_1_(
-    JSString replacement,
-    JSNumber start,
-    JSNumber end,
-  );
-  @JS('setRangeText')
-  external JSVoid setRangeText_1_1(
-    JSString replacement,
-    JSNumber start,
-    JSNumber end,
-    SelectionMode selectionMode,
-  );
-  external JSVoid setSelectionRange(
-    JSNumber start,
-    JSNumber end,
-  );
-  external JSVoid setSelectionRange1(
-    JSNumber start,
-    JSNumber end,
-    JSString direction,
-  );
 }
 
 @JS('HTMLOutputElement')
 @staticInterop
-class HTMLOutputElement extends HTMLElement {
-  external factory HTMLOutputElement.a0();
+class HTMLOutputElement implements HTMLElement {
+  external factory HTMLOutputElement();
 }
 
 extension HTMLOutputElementExtension on HTMLOutputElement {
+  external JSBoolean checkValidity();
+  external JSBoolean reportValidity();
+  external JSVoid setCustomValidity(JSString error);
   external DOMTokenList get htmlFor;
   external HTMLFormElement? get form;
   external set name(JSString value);
@@ -1842,16 +1761,13 @@ extension HTMLOutputElementExtension on HTMLOutputElement {
   external JSBoolean get willValidate;
   external ValidityState get validity;
   external JSString get validationMessage;
-  external JSBoolean checkValidity();
-  external JSBoolean reportValidity();
-  external JSVoid setCustomValidity(JSString error);
   external NodeList get labels;
 }
 
 @JS('HTMLProgressElement')
 @staticInterop
-class HTMLProgressElement extends HTMLElement {
-  external factory HTMLProgressElement.a0();
+class HTMLProgressElement implements HTMLElement {
+  external factory HTMLProgressElement();
 }
 
 extension HTMLProgressElementExtension on HTMLProgressElement {
@@ -1865,8 +1781,8 @@ extension HTMLProgressElementExtension on HTMLProgressElement {
 
 @JS('HTMLMeterElement')
 @staticInterop
-class HTMLMeterElement extends HTMLElement {
-  external factory HTMLMeterElement.a0();
+class HTMLMeterElement implements HTMLElement {
+  external factory HTMLMeterElement();
 }
 
 extension HTMLMeterElementExtension on HTMLMeterElement {
@@ -1887,11 +1803,14 @@ extension HTMLMeterElementExtension on HTMLMeterElement {
 
 @JS('HTMLFieldSetElement')
 @staticInterop
-class HTMLFieldSetElement extends HTMLElement {
-  external factory HTMLFieldSetElement.a0();
+class HTMLFieldSetElement implements HTMLElement {
+  external factory HTMLFieldSetElement();
 }
 
 extension HTMLFieldSetElementExtension on HTMLFieldSetElement {
+  external JSBoolean checkValidity();
+  external JSBoolean reportValidity();
+  external JSVoid setCustomValidity(JSString error);
   external set disabled(JSBoolean value);
   external JSBoolean get disabled;
   external HTMLFormElement? get form;
@@ -1902,15 +1821,12 @@ extension HTMLFieldSetElementExtension on HTMLFieldSetElement {
   external JSBoolean get willValidate;
   external ValidityState get validity;
   external JSString get validationMessage;
-  external JSBoolean checkValidity();
-  external JSBoolean reportValidity();
-  external JSVoid setCustomValidity(JSString error);
 }
 
 @JS('HTMLLegendElement')
 @staticInterop
-class HTMLLegendElement extends HTMLElement {
-  external factory HTMLLegendElement.a0();
+class HTMLLegendElement implements HTMLElement {
+  external factory HTMLLegendElement();
 }
 
 extension HTMLLegendElementExtension on HTMLLegendElement {
@@ -1921,9 +1837,7 @@ extension HTMLLegendElementExtension on HTMLLegendElement {
 
 @JS('ValidityState')
 @staticInterop
-class ValidityState {
-  external factory ValidityState();
-}
+class ValidityState {}
 
 extension ValidityStateExtension on ValidityState {
   external JSBoolean get valueMissing;
@@ -1941,15 +1855,11 @@ extension ValidityStateExtension on ValidityState {
 
 @JS('SubmitEvent')
 @staticInterop
-class SubmitEvent extends Event {
-  external factory SubmitEvent();
-
-  external factory SubmitEvent.a1(JSString type);
-
-  external factory SubmitEvent.a2(
-    JSString type,
+class SubmitEvent implements Event {
+  external factory SubmitEvent(
+    JSString type, [
     SubmitEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension SubmitEventExtension on SubmitEvent {
@@ -1959,7 +1869,7 @@ extension SubmitEventExtension on SubmitEvent {
 @JS()
 @staticInterop
 @anonymous
-class SubmitEventInit extends EventInit {
+class SubmitEventInit implements EventInit {
   external factory SubmitEventInit({HTMLElement? submitter});
 }
 
@@ -1970,10 +1880,8 @@ extension SubmitEventInitExtension on SubmitEventInit {
 
 @JS('FormDataEvent')
 @staticInterop
-class FormDataEvent extends Event {
-  external factory FormDataEvent();
-
-  external factory FormDataEvent.a1(
+class FormDataEvent implements Event {
+  external factory FormDataEvent(
     JSString type,
     FormDataEventInit eventInitDict,
   );
@@ -1986,7 +1894,7 @@ extension FormDataEventExtension on FormDataEvent {
 @JS()
 @staticInterop
 @anonymous
-class FormDataEventInit extends EventInit {
+class FormDataEventInit implements EventInit {
   external factory FormDataEventInit({required FormData formData});
 }
 
@@ -1997,8 +1905,8 @@ extension FormDataEventInitExtension on FormDataEventInit {
 
 @JS('HTMLDetailsElement')
 @staticInterop
-class HTMLDetailsElement extends HTMLElement {
-  external factory HTMLDetailsElement.a0();
+class HTMLDetailsElement implements HTMLElement {
+  external factory HTMLDetailsElement();
 }
 
 extension HTMLDetailsElementExtension on HTMLDetailsElement {
@@ -2008,26 +1916,24 @@ extension HTMLDetailsElementExtension on HTMLDetailsElement {
 
 @JS('HTMLDialogElement')
 @staticInterop
-class HTMLDialogElement extends HTMLElement {
-  external factory HTMLDialogElement.a0();
+class HTMLDialogElement implements HTMLElement {
+  external factory HTMLDialogElement();
 }
 
 extension HTMLDialogElementExtension on HTMLDialogElement {
+  external JSVoid show();
+  external JSVoid showModal();
+  external JSVoid close([JSString returnValue]);
   external set open(JSBoolean value);
   external JSBoolean get open;
   external set returnValue(JSString value);
   external JSString get returnValue;
-  external JSVoid show();
-  external JSVoid showModal();
-  external JSVoid close();
-  external JSVoid close1(JSString returnValue);
 }
 
 @JS('HTMLScriptElement')
 @staticInterop
-class HTMLScriptElement extends HTMLElement
-    implements HTMLAttributionSrcElementUtils {
-  external factory HTMLScriptElement.a0();
+class HTMLScriptElement implements HTMLElement, HTMLAttributionSrcElementUtils {
+  external factory HTMLScriptElement();
 
   external static JSBoolean supports(JSString type);
 }
@@ -2064,8 +1970,8 @@ extension HTMLScriptElementExtension on HTMLScriptElement {
 
 @JS('HTMLTemplateElement')
 @staticInterop
-class HTMLTemplateElement extends HTMLElement {
-  external factory HTMLTemplateElement.a0();
+class HTMLTemplateElement implements HTMLElement {
+  external factory HTMLTemplateElement();
 }
 
 extension HTMLTemplateElementExtension on HTMLTemplateElement {
@@ -2074,18 +1980,16 @@ extension HTMLTemplateElementExtension on HTMLTemplateElement {
 
 @JS('HTMLSlotElement')
 @staticInterop
-class HTMLSlotElement extends HTMLElement {
-  external factory HTMLSlotElement.a0();
+class HTMLSlotElement implements HTMLElement {
+  external factory HTMLSlotElement();
 }
 
 extension HTMLSlotElementExtension on HTMLSlotElement {
+  external JSArray assignedNodes([AssignedNodesOptions options]);
+  external JSArray assignedElements([AssignedNodesOptions options]);
+  external JSVoid assign(JSAny nodes);
   external set name(JSString value);
   external JSString get name;
-  external JSArray assignedNodes();
-  external JSArray assignedNodes1(AssignedNodesOptions options);
-  external JSArray assignedElements();
-  external JSArray assignedElements1(AssignedNodesOptions options);
-  external JSVoid assign(JSAny nodes);
 }
 
 @JS()
@@ -2102,39 +2006,30 @@ extension AssignedNodesOptionsExtension on AssignedNodesOptions {
 
 @JS('HTMLCanvasElement')
 @staticInterop
-class HTMLCanvasElement extends HTMLElement {
-  external factory HTMLCanvasElement.a0();
+class HTMLCanvasElement implements HTMLElement {
+  external factory HTMLCanvasElement();
 }
 
 extension HTMLCanvasElementExtension on HTMLCanvasElement {
+  external RenderingContext? getContext(
+    JSString contextId, [
+    JSAny options,
+  ]);
+  external JSString toDataURL([
+    JSString type,
+    JSAny quality,
+  ]);
+  external JSVoid toBlob(
+    BlobCallback callback, [
+    JSString type,
+    JSAny quality,
+  ]);
+  external OffscreenCanvas transferControlToOffscreen();
+  external MediaStream captureStream([JSNumber frameRequestRate]);
   external set width(JSNumber value);
   external JSNumber get width;
   external set height(JSNumber value);
   external JSNumber get height;
-  external RenderingContext? getContext(JSString contextId);
-  external RenderingContext? getContext1(
-    JSString contextId,
-    JSAny options,
-  );
-  external JSString toDataURL();
-  external JSString toDataURL1(JSString type);
-  external JSString toDataURL2(
-    JSString type,
-    JSAny quality,
-  );
-  external JSVoid toBlob(BlobCallback callback);
-  external JSVoid toBlob1(
-    BlobCallback callback,
-    JSString type,
-  );
-  external JSVoid toBlob2(
-    BlobCallback callback,
-    JSString type,
-    JSAny quality,
-  );
-  external OffscreenCanvas transferControlToOffscreen();
-  external MediaStream captureStream();
-  external MediaStream captureStream1(JSNumber frameRequestRate);
 }
 
 @JS()
@@ -2180,20 +2075,16 @@ class CanvasRenderingContext2D
         CanvasImageData,
         CanvasPathDrawingStyles,
         CanvasTextDrawingStyles,
-        CanvasPath {
-  external factory CanvasRenderingContext2D();
-}
+        CanvasPath {}
 
 extension CanvasRenderingContext2DExtension on CanvasRenderingContext2D {
-  external HTMLCanvasElement get canvas;
   external CanvasRenderingContext2DSettings getContextAttributes();
+  external HTMLCanvasElement get canvas;
 }
 
 @JS('CanvasState')
 @staticInterop
-class CanvasState {
-  external factory CanvasState();
-}
+class CanvasState {}
 
 extension CanvasStateExtension on CanvasState {
   external JSVoid save();
@@ -2204,9 +2095,7 @@ extension CanvasStateExtension on CanvasState {
 
 @JS('CanvasTransform')
 @staticInterop
-class CanvasTransform {
-  external factory CanvasTransform();
-}
+class CanvasTransform {}
 
 extension CanvasTransformExtension on CanvasTransform {
   external JSVoid scale(
@@ -2227,26 +2116,20 @@ extension CanvasTransformExtension on CanvasTransform {
     JSNumber f,
   );
   external DOMMatrix getTransform();
-  external JSVoid setTransform(
-    JSNumber a,
+  external JSVoid setTransform([
+    JSAny aOrTransform,
     JSNumber b,
     JSNumber c,
     JSNumber d,
     JSNumber e,
     JSNumber f,
-  );
-  @JS('setTransform')
-  external JSVoid setTransform_1_();
-  @JS('setTransform')
-  external JSVoid setTransform_1_1(DOMMatrix2DInit transform);
+  ]);
   external JSVoid resetTransform();
 }
 
 @JS('CanvasCompositing')
 @staticInterop
-class CanvasCompositing {
-  external factory CanvasCompositing();
-}
+class CanvasCompositing {}
 
 extension CanvasCompositingExtension on CanvasCompositing {
   external set globalAlpha(JSNumber value);
@@ -2257,9 +2140,7 @@ extension CanvasCompositingExtension on CanvasCompositing {
 
 @JS('CanvasImageSmoothing')
 @staticInterop
-class CanvasImageSmoothing {
-  external factory CanvasImageSmoothing();
-}
+class CanvasImageSmoothing {}
 
 extension CanvasImageSmoothingExtension on CanvasImageSmoothing {
   external set imageSmoothingEnabled(JSBoolean value);
@@ -2270,15 +2151,9 @@ extension CanvasImageSmoothingExtension on CanvasImageSmoothing {
 
 @JS('CanvasFillStrokeStyles')
 @staticInterop
-class CanvasFillStrokeStyles {
-  external factory CanvasFillStrokeStyles();
-}
+class CanvasFillStrokeStyles {}
 
 extension CanvasFillStrokeStylesExtension on CanvasFillStrokeStyles {
-  external set strokeStyle(JSAny value);
-  external JSAny get strokeStyle;
-  external set fillStyle(JSAny value);
-  external JSAny get fillStyle;
   external CanvasGradient createLinearGradient(
     JSNumber x0,
     JSNumber y0,
@@ -2302,13 +2177,15 @@ extension CanvasFillStrokeStylesExtension on CanvasFillStrokeStyles {
     CanvasImageSource image,
     JSString repetition,
   );
+  external set strokeStyle(JSAny value);
+  external JSAny get strokeStyle;
+  external set fillStyle(JSAny value);
+  external JSAny get fillStyle;
 }
 
 @JS('CanvasShadowStyles')
 @staticInterop
-class CanvasShadowStyles {
-  external factory CanvasShadowStyles();
-}
+class CanvasShadowStyles {}
 
 extension CanvasShadowStylesExtension on CanvasShadowStyles {
   external set shadowOffsetX(JSNumber value);
@@ -2323,9 +2200,7 @@ extension CanvasShadowStylesExtension on CanvasShadowStyles {
 
 @JS('CanvasFilters')
 @staticInterop
-class CanvasFilters {
-  external factory CanvasFilters();
-}
+class CanvasFilters {}
 
 extension CanvasFiltersExtension on CanvasFilters {
   external set filter(JSString value);
@@ -2334,9 +2209,7 @@ extension CanvasFiltersExtension on CanvasFilters {
 
 @JS('CanvasRect')
 @staticInterop
-class CanvasRect {
-  external factory CanvasRect();
-}
+class CanvasRect {}
 
 extension CanvasRectExtension on CanvasRect {
   external JSVoid clearRect(
@@ -2361,206 +2234,117 @@ extension CanvasRectExtension on CanvasRect {
 
 @JS('CanvasDrawPath')
 @staticInterop
-class CanvasDrawPath {
-  external factory CanvasDrawPath();
-}
+class CanvasDrawPath {}
 
 extension CanvasDrawPathExtension on CanvasDrawPath {
   external JSVoid beginPath();
-  external JSVoid fill();
-  external JSVoid fill1(CanvasFillRule fillRule);
-  @JS('fill')
-  external JSVoid fill_1_(Path2D path);
-  @JS('fill')
-  external JSVoid fill_1_1(
-    Path2D path,
+  external JSVoid fill([
+    JSAny fillRuleOrPath,
     CanvasFillRule fillRule,
-  );
-  external JSVoid stroke();
-  @JS('stroke')
-  external JSVoid stroke_1_(Path2D path);
-  external JSVoid clip();
-  external JSVoid clip1(CanvasFillRule fillRule);
-  @JS('clip')
-  external JSVoid clip_1_(Path2D path);
-  @JS('clip')
-  external JSVoid clip_1_1(
-    Path2D path,
+  ]);
+  external JSVoid stroke([Path2D path]);
+  external JSVoid clip([
+    JSAny fillRuleOrPath,
     CanvasFillRule fillRule,
-  );
+  ]);
   external JSBoolean isPointInPath(
-    JSNumber x,
-    JSNumber y,
-  );
-  external JSBoolean isPointInPath1(
-    JSNumber x,
-    JSNumber y,
+    JSAny pathOrX,
+    JSNumber xOrY, [
+    JSAny fillRuleOrY,
     CanvasFillRule fillRule,
-  );
-  @JS('isPointInPath')
-  external JSBoolean isPointInPath_1_(
-    Path2D path,
-    JSNumber x,
-    JSNumber y,
-  );
-  @JS('isPointInPath')
-  external JSBoolean isPointInPath_1_1(
-    Path2D path,
-    JSNumber x,
-    JSNumber y,
-    CanvasFillRule fillRule,
-  );
+  ]);
   external JSBoolean isPointInStroke(
-    JSNumber x,
+    JSAny pathOrX,
+    JSNumber xOrY, [
     JSNumber y,
-  );
-  @JS('isPointInStroke')
-  external JSBoolean isPointInStroke_1_(
-    Path2D path,
-    JSNumber x,
-    JSNumber y,
-  );
+  ]);
 }
 
 @JS('CanvasUserInterface')
 @staticInterop
-class CanvasUserInterface {
-  external factory CanvasUserInterface();
-}
+class CanvasUserInterface {}
 
 extension CanvasUserInterfaceExtension on CanvasUserInterface {
-  external JSVoid drawFocusIfNeeded(Element element);
-  @JS('drawFocusIfNeeded')
-  external JSVoid drawFocusIfNeeded_1_(
-    Path2D path,
+  external JSVoid drawFocusIfNeeded(
+    JSAny elementOrPath, [
     Element element,
-  );
-  external JSVoid scrollPathIntoView();
-  @JS('scrollPathIntoView')
-  external JSVoid scrollPathIntoView_1_(Path2D path);
+  ]);
+  external JSVoid scrollPathIntoView([Path2D path]);
 }
 
 @JS('CanvasText')
 @staticInterop
-class CanvasText {
-  external factory CanvasText();
-}
+class CanvasText {}
 
 extension CanvasTextExtension on CanvasText {
   external JSVoid fillText(
     JSString text,
     JSNumber x,
-    JSNumber y,
-  );
-  external JSVoid fillText1(
-    JSString text,
-    JSNumber x,
-    JSNumber y,
+    JSNumber y, [
     JSNumber maxWidth,
-  );
+  ]);
   external JSVoid strokeText(
     JSString text,
     JSNumber x,
-    JSNumber y,
-  );
-  external JSVoid strokeText1(
-    JSString text,
-    JSNumber x,
-    JSNumber y,
+    JSNumber y, [
     JSNumber maxWidth,
-  );
+  ]);
   external TextMetrics measureText(JSString text);
 }
 
 @JS('CanvasDrawImage')
 @staticInterop
-class CanvasDrawImage {
-  external factory CanvasDrawImage();
-}
+class CanvasDrawImage {}
 
 extension CanvasDrawImageExtension on CanvasDrawImage {
   external JSVoid drawImage(
     CanvasImageSource image,
-    JSNumber dx,
-    JSNumber dy,
-  );
-  @JS('drawImage')
-  external JSVoid drawImage_1_(
-    CanvasImageSource image,
-    JSNumber dx,
-    JSNumber dy,
-    JSNumber dw,
-    JSNumber dh,
-  );
-  @JS('drawImage')
-  external JSVoid drawImage_2_(
-    CanvasImageSource image,
-    JSNumber sx,
-    JSNumber sy,
-    JSNumber sw,
-    JSNumber sh,
+    JSNumber dxOrSx,
+    JSNumber dyOrSy, [
+    JSNumber dwOrSw,
+    JSNumber dhOrSh,
     JSNumber dx,
     JSNumber dy,
     JSNumber dw,
     JSNumber dh,
-  );
+  ]);
 }
 
 @JS('CanvasImageData')
 @staticInterop
-class CanvasImageData {
-  external factory CanvasImageData();
-}
+class CanvasImageData {}
 
 extension CanvasImageDataExtension on CanvasImageData {
   external ImageData createImageData(
-    JSNumber sw,
-    JSNumber sh,
-  );
-  external ImageData createImageData1(
-    JSNumber sw,
+    JSAny imagedataOrSw, [
     JSNumber sh,
     ImageDataSettings settings,
-  );
-  @JS('createImageData')
-  external ImageData createImageData_1_(ImageData imagedata);
+  ]);
   external ImageData getImageData(
     JSNumber sx,
     JSNumber sy,
     JSNumber sw,
-    JSNumber sh,
-  );
-  external ImageData getImageData1(
-    JSNumber sx,
-    JSNumber sy,
-    JSNumber sw,
-    JSNumber sh,
+    JSNumber sh, [
     ImageDataSettings settings,
-  );
+  ]);
   external JSVoid putImageData(
     ImageData imagedata,
     JSNumber dx,
-    JSNumber dy,
-  );
-  @JS('putImageData')
-  external JSVoid putImageData_1_(
-    ImageData imagedata,
-    JSNumber dx,
-    JSNumber dy,
+    JSNumber dy, [
     JSNumber dirtyX,
     JSNumber dirtyY,
     JSNumber dirtyWidth,
     JSNumber dirtyHeight,
-  );
+  ]);
 }
 
 @JS('CanvasPathDrawingStyles')
 @staticInterop
-class CanvasPathDrawingStyles {
-  external factory CanvasPathDrawingStyles();
-}
+class CanvasPathDrawingStyles {}
 
 extension CanvasPathDrawingStylesExtension on CanvasPathDrawingStyles {
+  external JSVoid setLineDash(JSArray segments);
+  external JSArray getLineDash();
   external set lineWidth(JSNumber value);
   external JSNumber get lineWidth;
   external set lineCap(CanvasLineCap value);
@@ -2569,17 +2353,13 @@ extension CanvasPathDrawingStylesExtension on CanvasPathDrawingStyles {
   external CanvasLineJoin get lineJoin;
   external set miterLimit(JSNumber value);
   external JSNumber get miterLimit;
-  external JSVoid setLineDash(JSArray segments);
-  external JSArray getLineDash();
   external set lineDashOffset(JSNumber value);
   external JSNumber get lineDashOffset;
 }
 
 @JS('CanvasTextDrawingStyles')
 @staticInterop
-class CanvasTextDrawingStyles {
-  external factory CanvasTextDrawingStyles();
-}
+class CanvasTextDrawingStyles {}
 
 extension CanvasTextDrawingStylesExtension on CanvasTextDrawingStyles {
   external set font(JSString value);
@@ -2606,9 +2386,7 @@ extension CanvasTextDrawingStylesExtension on CanvasTextDrawingStyles {
 
 @JS('CanvasPath')
 @staticInterop
-class CanvasPath {
-  external factory CanvasPath();
-}
+class CanvasPath {}
 
 extension CanvasPathExtension on CanvasPath {
   external JSVoid closePath();
@@ -2651,30 +2429,17 @@ extension CanvasPathExtension on CanvasPath {
     JSNumber x,
     JSNumber y,
     JSNumber w,
-    JSNumber h,
-  );
-  external JSVoid roundRect1(
-    JSNumber x,
-    JSNumber y,
-    JSNumber w,
-    JSNumber h,
+    JSNumber h, [
     JSAny radii,
-  );
+  ]);
   external JSVoid arc(
     JSNumber x,
     JSNumber y,
     JSNumber radius,
     JSNumber startAngle,
-    JSNumber endAngle,
-  );
-  external JSVoid arc1(
-    JSNumber x,
-    JSNumber y,
-    JSNumber radius,
-    JSNumber startAngle,
-    JSNumber endAngle,
+    JSNumber endAngle, [
     JSBoolean counterclockwise,
-  );
+  ]);
   external JSVoid ellipse(
     JSNumber x,
     JSNumber y,
@@ -2682,25 +2447,14 @@ extension CanvasPathExtension on CanvasPath {
     JSNumber radiusY,
     JSNumber rotation,
     JSNumber startAngle,
-    JSNumber endAngle,
-  );
-  external JSVoid ellipse1(
-    JSNumber x,
-    JSNumber y,
-    JSNumber radiusX,
-    JSNumber radiusY,
-    JSNumber rotation,
-    JSNumber startAngle,
-    JSNumber endAngle,
+    JSNumber endAngle, [
     JSBoolean counterclockwise,
-  );
+  ]);
 }
 
 @JS('CanvasGradient')
 @staticInterop
-class CanvasGradient {
-  external factory CanvasGradient();
-}
+class CanvasGradient {}
 
 extension CanvasGradientExtension on CanvasGradient {
   external JSVoid addColorStop(
@@ -2711,20 +2465,15 @@ extension CanvasGradientExtension on CanvasGradient {
 
 @JS('CanvasPattern')
 @staticInterop
-class CanvasPattern {
-  external factory CanvasPattern();
-}
+class CanvasPattern {}
 
 extension CanvasPatternExtension on CanvasPattern {
-  external JSVoid setTransform();
-  external JSVoid setTransform1(DOMMatrix2DInit transform);
+  external JSVoid setTransform([DOMMatrix2DInit transform]);
 }
 
 @JS('TextMetrics')
 @staticInterop
-class TextMetrics {
-  external factory TextMetrics();
-}
+class TextMetrics {}
 
 extension TextMetricsExtension on TextMetrics {
   external JSNumber get width;
@@ -2756,36 +2505,12 @@ extension ImageDataSettingsExtension on ImageDataSettings {
 @JS('ImageData')
 @staticInterop
 class ImageData {
-  external factory ImageData();
-
-  external factory ImageData.a1(
-    JSNumber sw,
-    JSNumber sh,
-  );
-
-  external factory ImageData.a2(
-    JSNumber sw,
-    JSNumber sh,
+  external factory ImageData(
+    JSAny dataOrSw,
+    JSNumber shOrSw, [
+    JSAny settingsOrSh,
     ImageDataSettings settings,
-  );
-
-  external factory ImageData.a3(
-    JSUint8ClampedArray data,
-    JSNumber sw,
-  );
-
-  external factory ImageData.a4(
-    JSUint8ClampedArray data,
-    JSNumber sw,
-    JSNumber sh,
-  );
-
-  external factory ImageData.a5(
-    JSUint8ClampedArray data,
-    JSNumber sw,
-    JSNumber sh,
-    ImageDataSettings settings,
-  );
+  ]);
 }
 
 extension ImageDataExtension on ImageData {
@@ -2798,30 +2523,23 @@ extension ImageDataExtension on ImageData {
 @JS('Path2D')
 @staticInterop
 class Path2D implements CanvasPath {
-  external factory Path2D();
-
-  external factory Path2D.a1();
-
-  external factory Path2D.a2(JSAny path);
+  external factory Path2D([JSAny path]);
 }
 
 extension Path2DExtension on Path2D {
-  external JSVoid addPath(Path2D path);
-  external JSVoid addPath1(
-    Path2D path,
+  external JSVoid addPath(
+    Path2D path, [
     DOMMatrix2DInit transform,
-  );
+  ]);
 }
 
 @JS('ImageBitmapRenderingContext')
 @staticInterop
-class ImageBitmapRenderingContext {
-  external factory ImageBitmapRenderingContext();
-}
+class ImageBitmapRenderingContext {}
 
 extension ImageBitmapRenderingContextExtension on ImageBitmapRenderingContext {
-  external JSAny get canvas;
   external JSVoid transferFromImageBitmap(ImageBitmap? bitmap);
+  external JSAny get canvas;
 }
 
 @JS()
@@ -2857,29 +2575,24 @@ extension ImageEncodeOptionsExtension on ImageEncodeOptions {
 
 @JS('OffscreenCanvas')
 @staticInterop
-class OffscreenCanvas extends EventTarget {
-  external factory OffscreenCanvas();
-
-  external factory OffscreenCanvas.a1(
+class OffscreenCanvas implements EventTarget {
+  external factory OffscreenCanvas(
     JSNumber width,
     JSNumber height,
   );
 }
 
 extension OffscreenCanvasExtension on OffscreenCanvas {
+  external OffscreenRenderingContext? getContext(
+    OffscreenRenderingContextId contextId, [
+    JSAny options,
+  ]);
+  external ImageBitmap transferToImageBitmap();
+  external JSPromise convertToBlob([ImageEncodeOptions options]);
   external set width(JSNumber value);
   external JSNumber get width;
   external set height(JSNumber value);
   external JSNumber get height;
-  external OffscreenRenderingContext? getContext(
-      OffscreenRenderingContextId contextId);
-  external OffscreenRenderingContext? getContext1(
-    OffscreenRenderingContextId contextId,
-    JSAny options,
-  );
-  external ImageBitmap transferToImageBitmap();
-  external JSPromise convertToBlob();
-  external JSPromise convertToBlob1(ImageEncodeOptions options);
   external set oncontextlost(EventHandler value);
   external EventHandler get oncontextlost;
   external set oncontextrestored(EventHandler value);
@@ -2904,9 +2617,7 @@ class OffscreenCanvasRenderingContext2D
         CanvasImageData,
         CanvasPathDrawingStyles,
         CanvasTextDrawingStyles,
-        CanvasPath {
-  external factory OffscreenCanvasRenderingContext2D();
-}
+        CanvasPath {}
 
 extension OffscreenCanvasRenderingContext2DExtension
     on OffscreenCanvasRenderingContext2D {
@@ -2916,20 +2627,14 @@ extension OffscreenCanvasRenderingContext2DExtension
 
 @JS('CustomElementRegistry')
 @staticInterop
-class CustomElementRegistry {
-  external factory CustomElementRegistry();
-}
+class CustomElementRegistry {}
 
 extension CustomElementRegistryExtension on CustomElementRegistry {
   external JSVoid define(
     JSString name,
-    CustomElementConstructor constructor,
-  );
-  external JSVoid define1(
-    JSString name,
-    CustomElementConstructor constructor,
+    CustomElementConstructor constructor, [
     ElementDefinitionOptions options,
-  );
+  ]);
   external JSAny get(JSString name);
   external JSPromise whenDefined(JSString name);
   external JSVoid upgrade(Node root);
@@ -2944,42 +2649,33 @@ class ElementDefinitionOptions {
 
 extension ElementDefinitionOptionsExtension on ElementDefinitionOptions {
   @JS('extends')
-  external set extends_0_(JSString value);
+  external set extends_(JSString value);
   @JS('extends')
-  external JSString get extends_0_;
+  external JSString get extends_;
 }
 
 @JS('ElementInternals')
 @staticInterop
-class ElementInternals implements ARIAMixin {
-  external factory ElementInternals();
-}
+class ElementInternals implements ARIAMixin {}
 
 extension ElementInternalsExtension on ElementInternals {
-  external CustomStateSet get states;
-  external ShadowRoot? get shadowRoot;
-  external JSVoid setFormValue(JSAny? value);
-  external JSVoid setFormValue1(
-    JSAny? value,
+  external JSVoid setFormValue(
+    JSAny? value, [
     JSAny? state,
-  );
-  external HTMLFormElement? get form;
-  external JSVoid setValidity();
-  external JSVoid setValidity1(ValidityStateFlags flags);
-  external JSVoid setValidity2(
-    ValidityStateFlags flags,
-    JSString message,
-  );
-  external JSVoid setValidity3(
+  ]);
+  external JSVoid setValidity([
     ValidityStateFlags flags,
     JSString message,
     HTMLElement anchor,
-  );
+  ]);
+  external JSBoolean checkValidity();
+  external JSBoolean reportValidity();
+  external CustomStateSet get states;
+  external ShadowRoot? get shadowRoot;
+  external HTMLFormElement? get form;
   external JSBoolean get willValidate;
   external ValidityState get validity;
   external JSString get validationMessage;
-  external JSBoolean checkValidity();
-  external JSBoolean reportValidity();
   external NodeList get labels;
 }
 
@@ -3026,9 +2722,7 @@ extension ValidityStateFlagsExtension on ValidityStateFlags {
 
 @JS('UserActivation')
 @staticInterop
-class UserActivation {
-  external factory UserActivation();
-}
+class UserActivation {}
 
 extension UserActivationExtension on UserActivation {
   external JSBoolean get hasBeenActive;
@@ -3054,9 +2748,7 @@ extension FocusOptionsExtension on FocusOptions {
 
 @JS('ElementContentEditable')
 @staticInterop
-class ElementContentEditable {
-  external factory ElementContentEditable();
-}
+class ElementContentEditable {}
 
 extension ElementContentEditableExtension on ElementContentEditable {
   external set contentEditable(JSString value);
@@ -3073,75 +2765,64 @@ extension ElementContentEditableExtension on ElementContentEditable {
 @JS('DataTransfer')
 @staticInterop
 class DataTransfer {
-  external factory DataTransfer.a0();
+  external factory DataTransfer();
 }
 
 extension DataTransferExtension on DataTransfer {
-  external set dropEffect(JSString value);
-  external JSString get dropEffect;
-  external set effectAllowed(JSString value);
-  external JSString get effectAllowed;
-  external DataTransferItemList get items;
   external JSVoid setDragImage(
     Element image,
     JSNumber x,
     JSNumber y,
   );
-  external JSArray get types;
   external JSString getData(JSString format);
   external JSVoid setData(
     JSString format,
     JSString data,
   );
-  external JSVoid clearData();
-  external JSVoid clearData1(JSString format);
+  external JSVoid clearData([JSString format]);
+  external set dropEffect(JSString value);
+  external JSString get dropEffect;
+  external set effectAllowed(JSString value);
+  external JSString get effectAllowed;
+  external DataTransferItemList get items;
+  external JSArray get types;
   external FileList get files;
 }
 
 @JS('DataTransferItemList')
 @staticInterop
-class DataTransferItemList {
-  external factory DataTransferItemList();
-}
+class DataTransferItemList {}
 
 extension DataTransferItemListExtension on DataTransferItemList {
-  external JSNumber get length;
   external DataTransferItem? add(
-    JSString data,
+    JSAny data, [
     JSString type,
-  );
-  @JS('add')
-  external DataTransferItem? add_1_(File data);
+  ]);
   external JSVoid remove(JSNumber index);
   external JSVoid clear();
+  external JSNumber get length;
 }
 
 @JS('DataTransferItem')
 @staticInterop
-class DataTransferItem {
-  external factory DataTransferItem();
-}
+class DataTransferItem {}
 
 extension DataTransferItemExtension on DataTransferItem {
   external FileSystemEntry? webkitGetAsEntry();
   external JSPromise getAsFileSystemHandle();
-  external JSString get kind;
-  external JSString get type;
   external JSVoid getAsString(FunctionStringCallback? callback);
   external File? getAsFile();
+  external JSString get kind;
+  external JSString get type;
 }
 
 @JS('DragEvent')
 @staticInterop
-class DragEvent extends MouseEvent {
-  external factory DragEvent();
-
-  external factory DragEvent.a1(JSString type);
-
-  external factory DragEvent.a2(
-    JSString type,
+class DragEvent implements MouseEvent {
+  external factory DragEvent(
+    JSString type, [
     DragEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension DragEventExtension on DragEvent {
@@ -3151,7 +2832,7 @@ extension DragEventExtension on DragEvent {
 @JS()
 @staticInterop
 @anonymous
-class DragEventInit extends MouseEventInit {
+class DragEventInit implements MouseEventInit {
   external factory DragEventInit({DataTransfer? dataTransfer});
 }
 
@@ -3162,9 +2843,7 @@ extension DragEventInitExtension on DragEventInit {
 
 @JS('PopoverTargetElement')
 @staticInterop
-class PopoverTargetElement {
-  external factory PopoverTargetElement();
-}
+class PopoverTargetElement {}
 
 extension PopoverTargetElementExtension on PopoverTargetElement {
   external set popoverToggleTargetElement(Element? value);
@@ -3177,15 +2856,11 @@ extension PopoverTargetElementExtension on PopoverTargetElement {
 
 @JS('ToggleEvent')
 @staticInterop
-class ToggleEvent extends Event {
-  external factory ToggleEvent();
-
-  external factory ToggleEvent.a1(JSString type);
-
-  external factory ToggleEvent.a2(
-    JSString type,
+class ToggleEvent implements Event {
+  external factory ToggleEvent(
+    JSString type, [
     ToggleEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension ToggleEventExtension on ToggleEvent {
@@ -3196,7 +2871,7 @@ extension ToggleEventExtension on ToggleEvent {
 @JS()
 @staticInterop
 @anonymous
-class ToggleEventInit extends EventInit {
+class ToggleEventInit implements EventInit {
   external factory ToggleEventInit({
     JSString oldState = '',
     JSString newState = '',
@@ -3215,26 +2890,19 @@ external Window get window;
 
 @JS('Window')
 @staticInterop
-class Window extends EventTarget
+class Window
     implements
+        EventTarget,
         GlobalEventHandlers,
         WindowEventHandlers,
         WindowOrWorkerGlobalScope,
         AnimationFrameProvider,
         WindowSessionStorage,
-        WindowLocalStorage {
-  external factory Window();
-}
+        WindowLocalStorage {}
 
 extension WindowExtension on Window {
-  external JSNumber get orientation;
-  external set onorientationchange(EventHandler value);
-  external EventHandler get onorientationchange;
-  external CookieStore get cookieStore;
   external JSVoid navigate(SpatialNavigationDirection dir);
   external MediaQueryList matchMedia(JSString query);
-  external Screen get screen;
-  external VisualViewport? get visualViewport;
   external JSVoid moveTo(
     JSNumber x,
     JSNumber y,
@@ -3251,33 +2919,69 @@ extension WindowExtension on Window {
     JSNumber x,
     JSNumber y,
   );
+  external JSVoid scroll([
+    JSAny optionsOrX,
+    JSNumber y,
+  ]);
+  external JSVoid scrollTo([
+    JSAny optionsOrX,
+    JSNumber y,
+  ]);
+  external JSVoid scrollBy([
+    JSAny optionsOrX,
+    JSNumber y,
+  ]);
+  external CSSStyleDeclaration getComputedStyle(
+    Element elt, [
+    JSString? pseudoElt,
+  ]);
+  external JSPromise getDigitalGoodsService(JSString serviceProvider);
+  external JSPromise showOpenFilePicker([OpenFilePickerOptions options]);
+  external JSPromise showSaveFilePicker([SaveFilePickerOptions options]);
+  external JSPromise showDirectoryPicker([DirectoryPickerOptions options]);
+  external JSVoid close();
+  external JSVoid stop();
+  external JSVoid focus();
+  external JSVoid blur();
+  external Window? open([
+    JSString url,
+    JSString target,
+    JSString features,
+  ]);
+  external JSVoid alert([JSString message]);
+  external JSBoolean confirm([JSString message]);
+  external JSString? prompt([
+    JSString message,
+    JSString default_,
+  ]);
+  external JSVoid print();
+  external JSVoid postMessage(
+    JSAny message, [
+    JSAny optionsOrTargetOrigin,
+    JSArray transfer,
+  ]);
+  external JSVoid captureEvents();
+  external JSVoid releaseEvents();
+  external JSPromise queryLocalFonts([QueryOptions options]);
+  external JSNumber requestIdleCallback(
+    IdleRequestCallback callback, [
+    IdleRequestOptions options,
+  ]);
+  external JSVoid cancelIdleCallback(JSNumber handle);
+  external Selection? getSelection();
+  external JSPromise getScreenDetails();
+  external JSNumber get orientation;
+  external set onorientationchange(EventHandler value);
+  external EventHandler get onorientationchange;
+  external CookieStore get cookieStore;
+  external Screen get screen;
+  external VisualViewport? get visualViewport;
   external JSNumber get innerWidth;
   external JSNumber get innerHeight;
   external JSNumber get scrollX;
   external JSNumber get pageXOffset;
   external JSNumber get scrollY;
   external JSNumber get pageYOffset;
-  external JSVoid scroll();
-  external JSVoid scroll1(ScrollToOptions options);
-  @JS('scroll')
-  external JSVoid scroll_1_(
-    JSNumber x,
-    JSNumber y,
-  );
-  external JSVoid scrollTo();
-  external JSVoid scrollTo1(ScrollToOptions options);
-  @JS('scrollTo')
-  external JSVoid scrollTo_1_(
-    JSNumber x,
-    JSNumber y,
-  );
-  external JSVoid scrollBy();
-  external JSVoid scrollBy1(ScrollToOptions options);
-  @JS('scrollBy')
-  external JSVoid scrollBy_1_(
-    JSNumber x,
-    JSNumber y,
-  );
   external JSNumber get screenX;
   external JSNumber get screenLeft;
   external JSNumber get screenY;
@@ -3285,19 +2989,7 @@ extension WindowExtension on Window {
   external JSNumber get outerWidth;
   external JSNumber get outerHeight;
   external JSNumber get devicePixelRatio;
-  external CSSStyleDeclaration getComputedStyle(Element elt);
-  external CSSStyleDeclaration getComputedStyle1(
-    Element elt,
-    JSString? pseudoElt,
-  );
-  external JSPromise getDigitalGoodsService(JSString serviceProvider);
   external JSAny get event;
-  external JSPromise showOpenFilePicker();
-  external JSPromise showOpenFilePicker1(OpenFilePickerOptions options);
-  external JSPromise showSaveFilePicker();
-  external JSPromise showSaveFilePicker1(SaveFilePickerOptions options);
-  external JSPromise showDirectoryPicker();
-  external JSPromise showDirectoryPicker1(DirectoryPickerOptions options);
   external Window get window;
   external Window get self;
   external Document get document;
@@ -3314,11 +3006,7 @@ extension WindowExtension on Window {
   external BarProp get toolbar;
   external set status(JSString value);
   external JSString get status;
-  external JSVoid close();
   external JSBoolean get closed;
-  external JSVoid stop();
-  external JSVoid focus();
-  external JSVoid blur();
   external Window get frames;
   external JSNumber get length;
   external Window? get top;
@@ -3326,53 +3014,10 @@ extension WindowExtension on Window {
   external JSAny get opener;
   external Window? get parent;
   external Element? get frameElement;
-  external Window? open();
-  external Window? open1(JSString url);
-  external Window? open2(
-    JSString url,
-    JSString target,
-  );
-  external Window? open3(
-    JSString url,
-    JSString target,
-    JSString features,
-  );
   external Navigator get navigator;
   external Navigator get clientInformation;
   external JSBoolean get originAgentCluster;
-  external JSVoid alert();
-  @JS('alert')
-  external JSVoid alert_1_(JSString message);
-  external JSBoolean confirm();
-  external JSBoolean confirm1(JSString message);
-  external JSString? prompt();
-  external JSString? prompt1(JSString message);
-  external JSString? prompt2(
-    JSString message,
-    JSString default_,
-  );
-  external JSVoid print();
-  external JSVoid postMessage(
-    JSAny message,
-    JSString targetOrigin,
-  );
-  external JSVoid postMessage1(
-    JSAny message,
-    JSString targetOrigin,
-    JSArray transfer,
-  );
-  @JS('postMessage')
-  external JSVoid postMessage_1_(JSAny message);
-  @JS('postMessage')
-  external JSVoid postMessage_1_1(
-    JSAny message,
-    WindowPostMessageOptions options,
-  );
-  external JSVoid captureEvents();
-  external JSVoid releaseEvents();
   external External get external;
-  external JSPromise queryLocalFonts();
-  external JSPromise queryLocalFonts1(QueryOptions options);
   external set onappinstalled(EventHandler value);
   external EventHandler get onappinstalled;
   external set onbeforeinstallprompt(EventHandler value);
@@ -3387,22 +3032,14 @@ extension WindowExtension on Window {
   external set ondevicemotion(EventHandler value);
   external EventHandler get ondevicemotion;
   external PortalHost? get portalHost;
-  external JSNumber requestIdleCallback(IdleRequestCallback callback);
-  external JSNumber requestIdleCallback1(
-    IdleRequestCallback callback,
-    IdleRequestOptions options,
-  );
-  external JSVoid cancelIdleCallback(JSNumber handle);
-  external Selection? getSelection();
   external SpeechSynthesis get speechSynthesis;
   external LaunchQueue get launchQueue;
-  external JSPromise getScreenDetails();
 }
 
 @JS()
 @staticInterop
 @anonymous
-class WindowPostMessageOptions extends StructuredSerializeOptions {
+class WindowPostMessageOptions implements StructuredSerializeOptions {
   external factory WindowPostMessageOptions({JSString targetOrigin = '/'});
 }
 
@@ -3413,9 +3050,7 @@ extension WindowPostMessageOptionsExtension on WindowPostMessageOptions {
 
 @JS('BarProp')
 @staticInterop
-class BarProp {
-  external factory BarProp();
-}
+class BarProp {}
 
 extension BarPropExtension on BarProp {
   external JSBoolean get visible;
@@ -3423,11 +3058,12 @@ extension BarPropExtension on BarProp {
 
 @JS('Location')
 @staticInterop
-class Location {
-  external factory Location();
-}
+class Location {}
 
 extension LocationExtension on Location {
+  external JSVoid assign(JSString url);
+  external JSVoid replace(JSString url);
+  external JSVoid reload();
   external set href(JSString value);
   external JSString get href;
   external JSString get origin;
@@ -3445,58 +3081,40 @@ extension LocationExtension on Location {
   external JSString get search;
   external set hash(JSString value);
   external JSString get hash;
-  external JSVoid assign(JSString url);
-  external JSVoid replace(JSString url);
-  external JSVoid reload();
   external DOMStringList get ancestorOrigins;
 }
 
 @JS('History')
 @staticInterop
-class History {
-  external factory History();
-}
+class History {}
 
 extension HistoryExtension on History {
-  external JSNumber get length;
-  external set scrollRestoration(ScrollRestoration value);
-  external ScrollRestoration get scrollRestoration;
-  external JSAny get state;
-  external JSVoid go();
-  external JSVoid go1(JSNumber delta);
+  external JSVoid go([JSNumber delta]);
   external JSVoid back();
   external JSVoid forward();
   external JSVoid pushState(
     JSAny data,
-    JSString unused,
-  );
-  external JSVoid pushState1(
-    JSAny data,
-    JSString unused,
+    JSString unused, [
     JSString? url,
-  );
+  ]);
   external JSVoid replaceState(
     JSAny data,
-    JSString unused,
-  );
-  external JSVoid replaceState1(
-    JSAny data,
-    JSString unused,
+    JSString unused, [
     JSString? url,
-  );
+  ]);
+  external JSNumber get length;
+  external set scrollRestoration(ScrollRestoration value);
+  external ScrollRestoration get scrollRestoration;
+  external JSAny get state;
 }
 
 @JS('PopStateEvent')
 @staticInterop
-class PopStateEvent extends Event {
-  external factory PopStateEvent();
-
-  external factory PopStateEvent.a1(JSString type);
-
-  external factory PopStateEvent.a2(
-    JSString type,
+class PopStateEvent implements Event {
+  external factory PopStateEvent(
+    JSString type, [
     PopStateEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension PopStateEventExtension on PopStateEvent {
@@ -3506,7 +3124,7 @@ extension PopStateEventExtension on PopStateEvent {
 @JS()
 @staticInterop
 @anonymous
-class PopStateEventInit extends EventInit {
+class PopStateEventInit implements EventInit {
   external factory PopStateEventInit({JSAny state});
 }
 
@@ -3517,15 +3135,11 @@ extension PopStateEventInitExtension on PopStateEventInit {
 
 @JS('HashChangeEvent')
 @staticInterop
-class HashChangeEvent extends Event {
-  external factory HashChangeEvent();
-
-  external factory HashChangeEvent.a1(JSString type);
-
-  external factory HashChangeEvent.a2(
-    JSString type,
+class HashChangeEvent implements Event {
+  external factory HashChangeEvent(
+    JSString type, [
     HashChangeEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension HashChangeEventExtension on HashChangeEvent {
@@ -3536,7 +3150,7 @@ extension HashChangeEventExtension on HashChangeEvent {
 @JS()
 @staticInterop
 @anonymous
-class HashChangeEventInit extends EventInit {
+class HashChangeEventInit implements EventInit {
   external factory HashChangeEventInit({
     JSString oldURL = '',
     JSString newURL = '',
@@ -3552,15 +3166,11 @@ extension HashChangeEventInitExtension on HashChangeEventInit {
 
 @JS('PageTransitionEvent')
 @staticInterop
-class PageTransitionEvent extends Event {
-  external factory PageTransitionEvent();
-
-  external factory PageTransitionEvent.a1(JSString type);
-
-  external factory PageTransitionEvent.a2(
-    JSString type,
+class PageTransitionEvent implements Event {
+  external factory PageTransitionEvent(
+    JSString type, [
     PageTransitionEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension PageTransitionEventExtension on PageTransitionEvent {
@@ -3570,7 +3180,7 @@ extension PageTransitionEventExtension on PageTransitionEvent {
 @JS()
 @staticInterop
 @anonymous
-class PageTransitionEventInit extends EventInit {
+class PageTransitionEventInit implements EventInit {
   external factory PageTransitionEventInit({JSBoolean persisted = false});
 }
 
@@ -3581,9 +3191,7 @@ extension PageTransitionEventInitExtension on PageTransitionEventInit {
 
 @JS('BeforeUnloadEvent')
 @staticInterop
-class BeforeUnloadEvent extends Event {
-  external factory BeforeUnloadEvent();
-}
+class BeforeUnloadEvent implements Event {}
 
 extension BeforeUnloadEventExtension on BeforeUnloadEvent {
   external set returnValue(JSString value);
@@ -3592,15 +3200,11 @@ extension BeforeUnloadEventExtension on BeforeUnloadEvent {
 
 @JS('ErrorEvent')
 @staticInterop
-class ErrorEvent extends Event {
-  external factory ErrorEvent();
-
-  external factory ErrorEvent.a1(JSString type);
-
-  external factory ErrorEvent.a2(
-    JSString type,
+class ErrorEvent implements Event {
+  external factory ErrorEvent(
+    JSString type, [
     ErrorEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension ErrorEventExtension on ErrorEvent {
@@ -3614,7 +3218,7 @@ extension ErrorEventExtension on ErrorEvent {
 @JS()
 @staticInterop
 @anonymous
-class ErrorEventInit extends EventInit {
+class ErrorEventInit implements EventInit {
   external factory ErrorEventInit({
     JSString message = '',
     JSString filename = '',
@@ -3639,10 +3243,8 @@ extension ErrorEventInitExtension on ErrorEventInit {
 
 @JS('PromiseRejectionEvent')
 @staticInterop
-class PromiseRejectionEvent extends Event {
-  external factory PromiseRejectionEvent();
-
-  external factory PromiseRejectionEvent.a1(
+class PromiseRejectionEvent implements Event {
+  external factory PromiseRejectionEvent(
     JSString type,
     PromiseRejectionEventInit eventInitDict,
   );
@@ -3656,7 +3258,7 @@ extension PromiseRejectionEventExtension on PromiseRejectionEvent {
 @JS()
 @staticInterop
 @anonymous
-class PromiseRejectionEventInit extends EventInit {
+class PromiseRejectionEventInit implements EventInit {
   external factory PromiseRejectionEventInit({
     required JSPromise promise,
     JSAny reason,
@@ -3672,9 +3274,7 @@ extension PromiseRejectionEventInitExtension on PromiseRejectionEventInit {
 
 @JS('GlobalEventHandlers')
 @staticInterop
-class GlobalEventHandlers {
-  external factory GlobalEventHandlers();
-}
+class GlobalEventHandlers {}
 
 extension GlobalEventHandlersExtension on GlobalEventHandlers {
   external set onanimationstart(EventHandler value);
@@ -3881,9 +3481,7 @@ extension GlobalEventHandlersExtension on GlobalEventHandlers {
 
 @JS('WindowEventHandlers')
 @staticInterop
-class WindowEventHandlers {
-  external factory WindowEventHandlers();
-}
+class WindowEventHandlers {}
 
 extension WindowEventHandlersExtension on WindowEventHandlers {
   external set ongamepadconnected(EventHandler value);
@@ -3928,69 +3526,47 @@ extension WindowEventHandlersExtension on WindowEventHandlers {
 
 @JS('WindowOrWorkerGlobalScope')
 @staticInterop
-class WindowOrWorkerGlobalScope {
-  external factory WindowOrWorkerGlobalScope();
-}
+class WindowOrWorkerGlobalScope {}
 
 extension WindowOrWorkerGlobalScopeExtension on WindowOrWorkerGlobalScope {
+  external JSPromise fetch(
+    RequestInfo input, [
+    RequestInit init,
+  ]);
+  external JSVoid reportError(JSAny e);
+  external JSString btoa(JSString data);
+  external JSString atob(JSString data);
+  external JSNumber setTimeout(
+    TimerHandler handler,
+    JSAny arguments, [
+    JSNumber timeout,
+  ]);
+  external JSVoid clearTimeout([JSNumber id]);
+  external JSNumber setInterval(
+    TimerHandler handler,
+    JSAny arguments, [
+    JSNumber timeout,
+  ]);
+  external JSVoid clearInterval([JSNumber id]);
+  external JSVoid queueMicrotask(VoidFunction callback);
+  external JSPromise createImageBitmap(
+    ImageBitmapSource image, [
+    JSAny optionsOrSx,
+    JSNumber sy,
+    JSNumber sw,
+    JSNumber sh,
+    ImageBitmapOptions options,
+  ]);
+  external JSAny structuredClone(
+    JSAny value, [
+    StructuredSerializeOptions options,
+  ]);
   external IDBFactory get indexedDB;
   external Crypto get crypto;
-  external JSPromise fetch(RequestInfo input);
-  external JSPromise fetch1(
-    RequestInfo input,
-    RequestInit init,
-  );
   external Performance get performance;
   external JSString get origin;
   external JSBoolean get isSecureContext;
   external JSBoolean get crossOriginIsolated;
-  external JSVoid reportError(JSAny e);
-  external JSString btoa(JSString data);
-  external JSString atob(JSString data);
-  external JSNumber setTimeout(TimerHandler handler);
-  external JSNumber setTimeout1(
-    TimerHandler handler,
-    JSNumber timeout,
-    JSAny arguments,
-  );
-  external JSVoid clearTimeout();
-  external JSVoid clearTimeout1(JSNumber id);
-  external JSNumber setInterval(TimerHandler handler);
-  external JSNumber setInterval1(
-    TimerHandler handler,
-    JSNumber timeout,
-    JSAny arguments,
-  );
-  external JSVoid clearInterval();
-  external JSVoid clearInterval1(JSNumber id);
-  external JSVoid queueMicrotask(VoidFunction callback);
-  external JSPromise createImageBitmap(ImageBitmapSource image);
-  external JSPromise createImageBitmap1(
-    ImageBitmapSource image,
-    ImageBitmapOptions options,
-  );
-  @JS('createImageBitmap')
-  external JSPromise createImageBitmap_1_(
-    ImageBitmapSource image,
-    JSNumber sx,
-    JSNumber sy,
-    JSNumber sw,
-    JSNumber sh,
-  );
-  @JS('createImageBitmap')
-  external JSPromise createImageBitmap_1_1(
-    ImageBitmapSource image,
-    JSNumber sx,
-    JSNumber sy,
-    JSNumber sw,
-    JSNumber sh,
-    ImageBitmapOptions options,
-  );
-  external JSAny structuredClone(JSAny value);
-  external JSAny structuredClone1(
-    JSAny value,
-    StructuredSerializeOptions options,
-  );
   external Scheduler get scheduler;
   external CacheStorage get caches;
   external TrustedTypePolicyFactory get trustedTypes;
@@ -3999,7 +3575,7 @@ extension WindowOrWorkerGlobalScopeExtension on WindowOrWorkerGlobalScope {
 @JS('DOMParser')
 @staticInterop
 class DOMParser {
-  external factory DOMParser.a0();
+  external factory DOMParser();
 }
 
 extension DOMParserExtension on DOMParser {
@@ -4029,47 +3605,43 @@ class Navigator
         NavigatorLocks,
         NavigatorAutomationInformation,
         NavigatorGPU,
-        NavigatorML {
-  external factory Navigator();
-}
+        NavigatorML {}
 
 extension NavigatorExtension on Navigator {
-  external AutoplayPolicy getAutoplayPolicy(AutoplayPolicyMediaType type);
-  @JS('getAutoplayPolicy')
-  external AutoplayPolicy getAutoplayPolicy_1_(HTMLMediaElement element);
-  @JS('getAutoplayPolicy')
-  external AutoplayPolicy getAutoplayPolicy_2_(AudioContext context);
-  external JSPromise setClientBadge();
-  external JSPromise setClientBadge1(JSNumber contents);
+  external AutoplayPolicy getAutoplayPolicy(JSAny contextOrElementOrType);
+  external JSPromise setClientBadge([JSNumber contents]);
   external JSPromise clearClientBadge();
   external JSPromise getBattery();
-  external JSBoolean sendBeacon(JSString url);
-  external JSBoolean sendBeacon1(
-    JSString url,
+  external JSBoolean sendBeacon(
+    JSString url, [
     BodyInit? data,
-  );
-  external Clipboard get clipboard;
-  external ContactsManager get contacts;
-  external CredentialsContainer get credentials;
-  external DevicePosture get devicePosture;
+  ]);
   external JSPromise requestMediaKeySystemAccess(
     JSString keySystem,
     JSArray supportedConfigurations,
   );
   external JSArray getGamepads();
-  external Geolocation get geolocation;
   external JSPromise getInstalledRelatedApps();
+  external JSVoid getUserMedia(
+    MediaStreamConstraints constraints,
+    NavigatorUserMediaSuccessCallback successCallback,
+    NavigatorUserMediaErrorCallback errorCallback,
+  );
+  external JSBoolean vibrate(VibratePattern pattern);
+  external JSPromise share([ShareData data]);
+  external JSBoolean canShare([ShareData data]);
+  external JSPromise requestMIDIAccess([MIDIOptions options]);
+  external Clipboard get clipboard;
+  external ContactsManager get contacts;
+  external CredentialsContainer get credentials;
+  external DevicePosture get devicePosture;
+  external Geolocation get geolocation;
   external UserActivation get userActivation;
   external Ink get ink;
   external Scheduling get scheduling;
   external Keyboard get keyboard;
   external MediaCapabilities get mediaCapabilities;
   external MediaDevices get mediaDevices;
-  external JSVoid getUserMedia(
-    MediaStreamConstraints constraints,
-    NavigatorUserMediaSuccessCallback successCallback,
-    NavigatorUserMediaErrorCallback errorCallback,
-  );
   external MediaSession get mediaSession;
   external Permissions get permissions;
   external JSNumber get maxTouchPoints;
@@ -4077,16 +3649,9 @@ extension NavigatorExtension on Navigator {
   external WakeLock get wakeLock;
   external Serial get serial;
   external ServiceWorkerContainer get serviceWorker;
-  external JSBoolean vibrate(VibratePattern pattern);
   external VirtualKeyboard get virtualKeyboard;
   external Bluetooth get bluetooth;
-  external JSPromise share();
-  external JSPromise share1(ShareData data);
-  external JSBoolean canShare();
-  external JSBoolean canShare1(ShareData data);
   external HID get hid;
-  external JSPromise requestMIDIAccess();
-  external JSPromise requestMIDIAccess1(MIDIOptions options);
   external USB get usb;
   external XRSystem get xr;
   external WindowControlsOverlay get windowControlsOverlay;
@@ -4094,11 +3659,10 @@ extension NavigatorExtension on Navigator {
 
 @JS('NavigatorID')
 @staticInterop
-class NavigatorID {
-  external factory NavigatorID();
-}
+class NavigatorID {}
 
 extension NavigatorIDExtension on NavigatorID {
+  external JSBoolean taintEnabled();
   external JSString get appCodeName;
   external JSString get appName;
   external JSString get appVersion;
@@ -4108,15 +3672,12 @@ extension NavigatorIDExtension on NavigatorID {
   external JSString get userAgent;
   external JSString get vendor;
   external JSString get vendorSub;
-  external JSBoolean taintEnabled();
   external JSString get oscpu;
 }
 
 @JS('NavigatorLanguage')
 @staticInterop
-class NavigatorLanguage {
-  external factory NavigatorLanguage();
-}
+class NavigatorLanguage {}
 
 extension NavigatorLanguageExtension on NavigatorLanguage {
   external JSString get language;
@@ -4125,9 +3686,7 @@ extension NavigatorLanguageExtension on NavigatorLanguage {
 
 @JS('NavigatorOnLine')
 @staticInterop
-class NavigatorOnLine {
-  external factory NavigatorOnLine();
-}
+class NavigatorOnLine {}
 
 extension NavigatorOnLineExtension on NavigatorOnLine {
   external JSBoolean get onLine;
@@ -4135,9 +3694,7 @@ extension NavigatorOnLineExtension on NavigatorOnLine {
 
 @JS('NavigatorContentUtils')
 @staticInterop
-class NavigatorContentUtils {
-  external factory NavigatorContentUtils();
-}
+class NavigatorContentUtils {}
 
 extension NavigatorContentUtilsExtension on NavigatorContentUtils {
   external JSVoid registerProtocolHandler(
@@ -4152,9 +3709,7 @@ extension NavigatorContentUtilsExtension on NavigatorContentUtils {
 
 @JS('NavigatorCookies')
 @staticInterop
-class NavigatorCookies {
-  external factory NavigatorCookies();
-}
+class NavigatorCookies {}
 
 extension NavigatorCookiesExtension on NavigatorCookies {
   external JSBoolean get cookieEnabled;
@@ -4162,62 +3717,52 @@ extension NavigatorCookiesExtension on NavigatorCookies {
 
 @JS('NavigatorPlugins')
 @staticInterop
-class NavigatorPlugins {
-  external factory NavigatorPlugins();
-}
+class NavigatorPlugins {}
 
 extension NavigatorPluginsExtension on NavigatorPlugins {
+  external JSBoolean javaEnabled();
   external PluginArray get plugins;
   external MimeTypeArray get mimeTypes;
-  external JSBoolean javaEnabled();
   external JSBoolean get pdfViewerEnabled;
 }
 
 @JS('PluginArray')
 @staticInterop
-class PluginArray {
-  external factory PluginArray();
-}
+class PluginArray {}
 
 extension PluginArrayExtension on PluginArray {
   external JSVoid refresh();
-  external JSNumber get length;
   external Plugin? item(JSNumber index);
   external Plugin? namedItem(JSString name);
+  external JSNumber get length;
 }
 
 @JS('MimeTypeArray')
 @staticInterop
-class MimeTypeArray {
-  external factory MimeTypeArray();
-}
+class MimeTypeArray {}
 
 extension MimeTypeArrayExtension on MimeTypeArray {
-  external JSNumber get length;
   external MimeType? item(JSNumber index);
   external MimeType? namedItem(JSString name);
+  external JSNumber get length;
 }
 
 @JS('Plugin')
 @staticInterop
-class Plugin {
-  external factory Plugin();
-}
+class Plugin {}
 
 extension PluginExtension on Plugin {
+  external MimeType? item(JSNumber index);
+  external MimeType? namedItem(JSString name);
   external JSString get name;
   external JSString get description;
   external JSString get filename;
   external JSNumber get length;
-  external MimeType? item(JSNumber index);
-  external MimeType? namedItem(JSString name);
 }
 
 @JS('MimeType')
 @staticInterop
-class MimeType {
-  external factory MimeType();
-}
+class MimeType {}
 
 extension MimeTypeExtension on MimeType {
   external JSString get type;
@@ -4228,14 +3773,12 @@ extension MimeTypeExtension on MimeType {
 
 @JS('ImageBitmap')
 @staticInterop
-class ImageBitmap {
-  external factory ImageBitmap();
-}
+class ImageBitmap {}
 
 extension ImageBitmapExtension on ImageBitmap {
+  external JSVoid close();
   external JSNumber get width;
   external JSNumber get height;
-  external JSVoid close();
 }
 
 @JS()
@@ -4269,9 +3812,7 @@ extension ImageBitmapOptionsExtension on ImageBitmapOptions {
 
 @JS('AnimationFrameProvider')
 @staticInterop
-class AnimationFrameProvider {
-  external factory AnimationFrameProvider();
-}
+class AnimationFrameProvider {}
 
 extension AnimationFrameProviderExtension on AnimationFrameProvider {
   external JSNumber requestAnimationFrame(FrameRequestCallback callback);
@@ -4280,65 +3821,16 @@ extension AnimationFrameProviderExtension on AnimationFrameProvider {
 
 @JS('MessageEvent')
 @staticInterop
-class MessageEvent extends Event {
-  external factory MessageEvent();
-
-  external factory MessageEvent.a1(JSString type);
-
-  external factory MessageEvent.a2(
-    JSString type,
+class MessageEvent implements Event {
+  external factory MessageEvent(
+    JSString type, [
     MessageEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension MessageEventExtension on MessageEvent {
-  external JSAny get data;
-  external JSString get origin;
-  external JSString get lastEventId;
-  external MessageEventSource? get source;
-  external JSArray get ports;
-  external JSVoid initMessageEvent(JSString type);
-  external JSVoid initMessageEvent1(
-    JSString type,
-    JSBoolean bubbles,
-  );
-  external JSVoid initMessageEvent2(
-    JSString type,
-    JSBoolean bubbles,
-    JSBoolean cancelable,
-  );
-  external JSVoid initMessageEvent3(
-    JSString type,
-    JSBoolean bubbles,
-    JSBoolean cancelable,
-    JSAny data,
-  );
-  external JSVoid initMessageEvent4(
-    JSString type,
-    JSBoolean bubbles,
-    JSBoolean cancelable,
-    JSAny data,
-    JSString origin,
-  );
-  external JSVoid initMessageEvent5(
-    JSString type,
-    JSBoolean bubbles,
-    JSBoolean cancelable,
-    JSAny data,
-    JSString origin,
-    JSString lastEventId,
-  );
-  external JSVoid initMessageEvent6(
-    JSString type,
-    JSBoolean bubbles,
-    JSBoolean cancelable,
-    JSAny data,
-    JSString origin,
-    JSString lastEventId,
-    MessageEventSource? source,
-  );
-  external JSVoid initMessageEvent7(
-    JSString type,
+  external JSVoid initMessageEvent(
+    JSString type, [
     JSBoolean bubbles,
     JSBoolean cancelable,
     JSAny data,
@@ -4346,13 +3838,18 @@ extension MessageEventExtension on MessageEvent {
     JSString lastEventId,
     MessageEventSource? source,
     JSArray ports,
-  );
+  ]);
+  external JSAny get data;
+  external JSString get origin;
+  external JSString get lastEventId;
+  external MessageEventSource? get source;
+  external JSArray get ports;
 }
 
 @JS()
 @staticInterop
 @anonymous
-class MessageEventInit extends EventInit {
+class MessageEventInit implements EventInit {
   external factory MessageEventInit({
     JSAny data,
     JSString origin = '',
@@ -4377,15 +3874,11 @@ extension MessageEventInitExtension on MessageEventInit {
 
 @JS('EventSource')
 @staticInterop
-class EventSource extends EventTarget {
-  external factory EventSource();
-
-  external factory EventSource.a1(JSString url);
-
-  external factory EventSource.a2(
-    JSString url,
+class EventSource implements EventTarget {
+  external factory EventSource(
+    JSString url, [
     EventSourceInit eventSourceInitDict,
-  );
+  ]);
 
   external static JSNumber get CONNECTING;
   external static JSNumber get OPEN;
@@ -4393,6 +3886,7 @@ class EventSource extends EventTarget {
 }
 
 extension EventSourceExtension on EventSource {
+  external JSVoid close();
   external JSString get url;
   external JSBoolean get withCredentials;
   external JSNumber get readyState;
@@ -4402,7 +3896,6 @@ extension EventSourceExtension on EventSource {
   external EventHandler get onmessage;
   external set onerror(EventHandler value);
   external EventHandler get onerror;
-  external JSVoid close();
 }
 
 @JS()
@@ -4420,7 +3913,7 @@ extension EventSourceInitExtension on EventSourceInit {
 @JS('MessageChannel')
 @staticInterop
 class MessageChannel {
-  external factory MessageChannel.a0();
+  external factory MessageChannel();
 }
 
 extension MessageChannelExtension on MessageChannel {
@@ -4430,22 +3923,13 @@ extension MessageChannelExtension on MessageChannel {
 
 @JS('MessagePort')
 @staticInterop
-class MessagePort extends EventTarget {
-  external factory MessagePort();
-}
+class MessagePort implements EventTarget {}
 
 extension MessagePortExtension on MessagePort {
   external JSVoid postMessage(
-    JSAny message,
-    JSArray transfer,
-  );
-  @JS('postMessage')
-  external JSVoid postMessage_1_(JSAny message);
-  @JS('postMessage')
-  external JSVoid postMessage_1_1(
-    JSAny message,
-    StructuredSerializeOptions options,
-  );
+    JSAny message, [
+    JSAny optionsOrTransfer,
+  ]);
   external JSVoid start();
   external JSVoid close();
   external set onmessage(EventHandler value);
@@ -4468,16 +3952,14 @@ extension StructuredSerializeOptionsExtension on StructuredSerializeOptions {
 
 @JS('BroadcastChannel')
 @staticInterop
-class BroadcastChannel extends EventTarget {
-  external factory BroadcastChannel();
-
-  external factory BroadcastChannel.a1(JSString name);
+class BroadcastChannel implements EventTarget {
+  external factory BroadcastChannel(JSString name);
 }
 
 extension BroadcastChannelExtension on BroadcastChannel {
-  external JSString get name;
   external JSVoid postMessage(JSAny message);
   external JSVoid close();
+  external JSString get name;
   external set onmessage(EventHandler value);
   external EventHandler get onmessage;
   external set onmessageerror(EventHandler value);
@@ -4486,16 +3968,14 @@ extension BroadcastChannelExtension on BroadcastChannel {
 
 @JS('WorkerGlobalScope')
 @staticInterop
-class WorkerGlobalScope extends EventTarget
-    implements FontFaceSource, WindowOrWorkerGlobalScope {
-  external factory WorkerGlobalScope();
-}
+class WorkerGlobalScope
+    implements EventTarget, FontFaceSource, WindowOrWorkerGlobalScope {}
 
 extension WorkerGlobalScopeExtension on WorkerGlobalScope {
+  external JSVoid importScripts(JSString urls);
   external WorkerGlobalScope get self;
   external WorkerLocation get location;
   external WorkerNavigator get navigator;
-  external JSVoid importScripts(JSString urls);
   external set onerror(OnErrorEventHandler value);
   external OnErrorEventHandler get onerror;
   external set onlanguagechange(EventHandler value);
@@ -4512,25 +3992,16 @@ extension WorkerGlobalScopeExtension on WorkerGlobalScope {
 
 @JS('DedicatedWorkerGlobalScope')
 @staticInterop
-class DedicatedWorkerGlobalScope extends WorkerGlobalScope
-    implements AnimationFrameProvider {
-  external factory DedicatedWorkerGlobalScope();
-}
+class DedicatedWorkerGlobalScope
+    implements WorkerGlobalScope, AnimationFrameProvider {}
 
 extension DedicatedWorkerGlobalScopeExtension on DedicatedWorkerGlobalScope {
-  external JSString get name;
   external JSVoid postMessage(
-    JSAny message,
-    JSArray transfer,
-  );
-  @JS('postMessage')
-  external JSVoid postMessage_1_(JSAny message);
-  @JS('postMessage')
-  external JSVoid postMessage_1_1(
-    JSAny message,
-    StructuredSerializeOptions options,
-  );
+    JSAny message, [
+    JSAny optionsOrTransfer,
+  ]);
   external JSVoid close();
+  external JSString get name;
   external set onmessage(EventHandler value);
   external EventHandler get onmessage;
   external set onmessageerror(EventHandler value);
@@ -4541,22 +4012,18 @@ extension DedicatedWorkerGlobalScopeExtension on DedicatedWorkerGlobalScope {
 
 @JS('SharedWorkerGlobalScope')
 @staticInterop
-class SharedWorkerGlobalScope extends WorkerGlobalScope {
-  external factory SharedWorkerGlobalScope();
-}
+class SharedWorkerGlobalScope implements WorkerGlobalScope {}
 
 extension SharedWorkerGlobalScopeExtension on SharedWorkerGlobalScope {
-  external JSString get name;
   external JSVoid close();
+  external JSString get name;
   external set onconnect(EventHandler value);
   external EventHandler get onconnect;
 }
 
 @JS('AbstractWorker')
 @staticInterop
-class AbstractWorker {
-  external factory AbstractWorker();
-}
+class AbstractWorker {}
 
 extension AbstractWorkerExtension on AbstractWorker {
   external set onerror(EventHandler value);
@@ -4565,30 +4032,19 @@ extension AbstractWorkerExtension on AbstractWorker {
 
 @JS('Worker')
 @staticInterop
-class Worker extends EventTarget implements AbstractWorker {
-  external factory Worker();
-
-  external factory Worker.a1(JSString scriptURL);
-
-  external factory Worker.a2(
-    JSString scriptURL,
+class Worker implements EventTarget, AbstractWorker {
+  external factory Worker(
+    JSString scriptURL, [
     WorkerOptions options,
-  );
+  ]);
 }
 
 extension WorkerExtension on Worker {
   external JSVoid terminate();
   external JSVoid postMessage(
-    JSAny message,
-    JSArray transfer,
-  );
-  @JS('postMessage')
-  external JSVoid postMessage_1_(JSAny message);
-  @JS('postMessage')
-  external JSVoid postMessage_1_1(
-    JSAny message,
-    StructuredSerializeOptions options,
-  );
+    JSAny message, [
+    JSAny optionsOrTransfer,
+  ]);
   external set onmessage(EventHandler value);
   external EventHandler get onmessage;
   external set onmessageerror(EventHandler value);
@@ -4617,15 +4073,11 @@ extension WorkerOptionsExtension on WorkerOptions {
 
 @JS('SharedWorker')
 @staticInterop
-class SharedWorker extends EventTarget implements AbstractWorker {
-  external factory SharedWorker();
-
-  external factory SharedWorker.a1(JSString scriptURL);
-
-  external factory SharedWorker.a2(
-    JSString scriptURL,
+class SharedWorker implements EventTarget, AbstractWorker {
+  external factory SharedWorker(
+    JSString scriptURL, [
     JSAny options,
-  );
+  ]);
 }
 
 extension SharedWorkerExtension on SharedWorker {
@@ -4634,9 +4086,7 @@ extension SharedWorkerExtension on SharedWorker {
 
 @JS('NavigatorConcurrentHardware')
 @staticInterop
-class NavigatorConcurrentHardware {
-  external factory NavigatorConcurrentHardware();
-}
+class NavigatorConcurrentHardware {}
 
 extension NavigatorConcurrentHardwareExtension on NavigatorConcurrentHardware {
   external JSNumber get hardwareConcurrency;
@@ -4658,9 +4108,7 @@ class WorkerNavigator
         NavigatorUA,
         NavigatorLocks,
         NavigatorGPU,
-        NavigatorML {
-  external factory WorkerNavigator();
-}
+        NavigatorML {}
 
 extension WorkerNavigatorExtension on WorkerNavigator {
   external MediaCapabilities get mediaCapabilities;
@@ -4673,9 +4121,7 @@ extension WorkerNavigatorExtension on WorkerNavigator {
 
 @JS('WorkerLocation')
 @staticInterop
-class WorkerLocation {
-  external factory WorkerLocation();
-}
+class WorkerLocation {}
 
 extension WorkerLocationExtension on WorkerLocation {
   external JSString get href;
@@ -4691,22 +4137,17 @@ extension WorkerLocationExtension on WorkerLocation {
 
 @JS('WorkletGlobalScope')
 @staticInterop
-class WorkletGlobalScope {
-  external factory WorkletGlobalScope();
-}
+class WorkletGlobalScope {}
 
 @JS('Worklet')
 @staticInterop
-class Worklet {
-  external factory Worklet();
-}
+class Worklet {}
 
 extension WorkletExtension on Worklet {
-  external JSPromise addModule(JSString moduleURL);
-  external JSPromise addModule1(
-    JSString moduleURL,
+  external JSPromise addModule(
+    JSString moduleURL, [
     WorkletOptions options,
-  );
+  ]);
 }
 
 @JS()
@@ -4724,12 +4165,9 @@ extension WorkletOptionsExtension on WorkletOptions {
 
 @JS('Storage')
 @staticInterop
-class Storage {
-  external factory Storage();
-}
+class Storage {}
 
 extension StorageExtension on Storage {
-  external JSNumber get length;
   external JSString? key(JSNumber index);
   external JSString? getItem(JSString key);
   external JSVoid setItem(
@@ -4738,13 +4176,12 @@ extension StorageExtension on Storage {
   );
   external JSVoid removeItem(JSString key);
   external JSVoid clear();
+  external JSNumber get length;
 }
 
 @JS('WindowSessionStorage')
 @staticInterop
-class WindowSessionStorage {
-  external factory WindowSessionStorage();
-}
+class WindowSessionStorage {}
 
 extension WindowSessionStorageExtension on WindowSessionStorage {
   external Storage get sessionStorage;
@@ -4752,9 +4189,7 @@ extension WindowSessionStorageExtension on WindowSessionStorage {
 
 @JS('WindowLocalStorage')
 @staticInterop
-class WindowLocalStorage {
-  external factory WindowLocalStorage();
-}
+class WindowLocalStorage {}
 
 extension WindowLocalStorageExtension on WindowLocalStorage {
   external Storage get localStorage;
@@ -4762,65 +4197,16 @@ extension WindowLocalStorageExtension on WindowLocalStorage {
 
 @JS('StorageEvent')
 @staticInterop
-class StorageEvent extends Event {
-  external factory StorageEvent();
-
-  external factory StorageEvent.a1(JSString type);
-
-  external factory StorageEvent.a2(
-    JSString type,
+class StorageEvent implements Event {
+  external factory StorageEvent(
+    JSString type, [
     StorageEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension StorageEventExtension on StorageEvent {
-  external JSString? get key;
-  external JSString? get oldValue;
-  external JSString? get newValue;
-  external JSString get url;
-  external Storage? get storageArea;
-  external JSVoid initStorageEvent(JSString type);
-  external JSVoid initStorageEvent1(
-    JSString type,
-    JSBoolean bubbles,
-  );
-  external JSVoid initStorageEvent2(
-    JSString type,
-    JSBoolean bubbles,
-    JSBoolean cancelable,
-  );
-  external JSVoid initStorageEvent3(
-    JSString type,
-    JSBoolean bubbles,
-    JSBoolean cancelable,
-    JSString? key,
-  );
-  external JSVoid initStorageEvent4(
-    JSString type,
-    JSBoolean bubbles,
-    JSBoolean cancelable,
-    JSString? key,
-    JSString? oldValue,
-  );
-  external JSVoid initStorageEvent5(
-    JSString type,
-    JSBoolean bubbles,
-    JSBoolean cancelable,
-    JSString? key,
-    JSString? oldValue,
-    JSString? newValue,
-  );
-  external JSVoid initStorageEvent6(
-    JSString type,
-    JSBoolean bubbles,
-    JSBoolean cancelable,
-    JSString? key,
-    JSString? oldValue,
-    JSString? newValue,
-    JSString url,
-  );
-  external JSVoid initStorageEvent7(
-    JSString type,
+  external JSVoid initStorageEvent(
+    JSString type, [
     JSBoolean bubbles,
     JSBoolean cancelable,
     JSString? key,
@@ -4828,13 +4214,18 @@ extension StorageEventExtension on StorageEvent {
     JSString? newValue,
     JSString url,
     Storage? storageArea,
-  );
+  ]);
+  external JSString? get key;
+  external JSString? get oldValue;
+  external JSString? get newValue;
+  external JSString get url;
+  external Storage? get storageArea;
 }
 
 @JS()
 @staticInterop
 @anonymous
-class StorageEventInit extends EventInit {
+class StorageEventInit implements EventInit {
   external factory StorageEventInit({
     JSString? key,
     JSString? oldValue,
@@ -4859,11 +4250,13 @@ extension StorageEventInitExtension on StorageEventInit {
 
 @JS('HTMLMarqueeElement')
 @staticInterop
-class HTMLMarqueeElement extends HTMLElement {
-  external factory HTMLMarqueeElement.a0();
+class HTMLMarqueeElement implements HTMLElement {
+  external factory HTMLMarqueeElement();
 }
 
 extension HTMLMarqueeElementExtension on HTMLMarqueeElement {
+  external JSVoid start();
+  external JSVoid stop();
   external set behavior(JSString value);
   external JSString get behavior;
   external set bgColor(JSString value);
@@ -4886,14 +4279,12 @@ extension HTMLMarqueeElementExtension on HTMLMarqueeElement {
   external JSNumber get vspace;
   external set width(JSString value);
   external JSString get width;
-  external JSVoid start();
-  external JSVoid stop();
 }
 
 @JS('HTMLFrameSetElement')
 @staticInterop
-class HTMLFrameSetElement extends HTMLElement implements WindowEventHandlers {
-  external factory HTMLFrameSetElement.a0();
+class HTMLFrameSetElement implements HTMLElement, WindowEventHandlers {
+  external factory HTMLFrameSetElement();
 }
 
 extension HTMLFrameSetElementExtension on HTMLFrameSetElement {
@@ -4905,8 +4296,8 @@ extension HTMLFrameSetElementExtension on HTMLFrameSetElement {
 
 @JS('HTMLFrameElement')
 @staticInterop
-class HTMLFrameElement extends HTMLElement {
-  external factory HTMLFrameElement.a0();
+class HTMLFrameElement implements HTMLElement {
+  external factory HTMLFrameElement();
 }
 
 extension HTMLFrameElementExtension on HTMLFrameElement {
@@ -4932,8 +4323,8 @@ extension HTMLFrameElementExtension on HTMLFrameElement {
 
 @JS('HTMLDirectoryElement')
 @staticInterop
-class HTMLDirectoryElement extends HTMLElement {
-  external factory HTMLDirectoryElement.a0();
+class HTMLDirectoryElement implements HTMLElement {
+  external factory HTMLDirectoryElement();
 }
 
 extension HTMLDirectoryElementExtension on HTMLDirectoryElement {
@@ -4943,8 +4334,8 @@ extension HTMLDirectoryElementExtension on HTMLDirectoryElement {
 
 @JS('HTMLFontElement')
 @staticInterop
-class HTMLFontElement extends HTMLElement {
-  external factory HTMLFontElement.a0();
+class HTMLFontElement implements HTMLElement {
+  external factory HTMLFontElement();
 }
 
 extension HTMLFontElementExtension on HTMLFontElement {
@@ -4958,8 +4349,8 @@ extension HTMLFontElementExtension on HTMLFontElement {
 
 @JS('HTMLParamElement')
 @staticInterop
-class HTMLParamElement extends HTMLElement {
-  external factory HTMLParamElement.a0();
+class HTMLParamElement implements HTMLElement {
+  external factory HTMLParamElement();
 }
 
 extension HTMLParamElementExtension on HTMLParamElement {
@@ -4975,9 +4366,7 @@ extension HTMLParamElementExtension on HTMLParamElement {
 
 @JS('External')
 @staticInterop
-class External {
-  external factory External();
-}
+class External {}
 
 extension ExternalExtension on External {
   external JSVoid AddSearchProvider();

--- a/lib/src/dom/idle_detection.dart
+++ b/lib/src/dom/idle_detection.dart
@@ -33,17 +33,16 @@ extension IdleOptionsExtension on IdleOptions {
 
 @JS('IdleDetector')
 @staticInterop
-class IdleDetector extends EventTarget {
-  external factory IdleDetector.a0();
+class IdleDetector implements EventTarget {
+  external factory IdleDetector();
 
   external static JSPromise requestPermission();
 }
 
 extension IdleDetectorExtension on IdleDetector {
+  external JSPromise start([IdleOptions options]);
   external UserIdleState? get userState;
   external ScreenIdleState? get screenState;
   external set onchange(EventHandler value);
   external EventHandler get onchange;
-  external JSPromise start();
-  external JSPromise start1(IdleOptions options);
 }

--- a/lib/src/dom/image_capture.dart
+++ b/lib/src/dom/image_capture.dart
@@ -18,14 +18,11 @@ typedef MeteringMode = JSString;
 @JS('ImageCapture')
 @staticInterop
 class ImageCapture {
-  external factory ImageCapture();
-
-  external factory ImageCapture.a1(MediaStreamTrack videoTrack);
+  external factory ImageCapture(MediaStreamTrack videoTrack);
 }
 
 extension ImageCaptureExtension on ImageCapture {
-  external JSPromise takePhoto();
-  external JSPromise takePhoto1(PhotoSettings photoSettings);
+  external JSPromise takePhoto([PhotoSettings photoSettings]);
   external JSPromise getPhotoCapabilities();
   external JSPromise getPhotoSettings();
   external JSPromise grabFrame();

--- a/lib/src/dom/indexeddb.dart
+++ b/lib/src/dom/indexeddb.dart
@@ -19,9 +19,7 @@ typedef IDBTransactionMode = JSString;
 
 @JS('IDBRequest')
 @staticInterop
-class IDBRequest extends EventTarget {
-  external factory IDBRequest();
-}
+class IDBRequest implements EventTarget {}
 
 extension IDBRequestExtension on IDBRequest {
   external JSAny get result;
@@ -37,9 +35,7 @@ extension IDBRequestExtension on IDBRequest {
 
 @JS('IDBOpenDBRequest')
 @staticInterop
-class IDBOpenDBRequest extends IDBRequest {
-  external factory IDBOpenDBRequest();
-}
+class IDBOpenDBRequest implements IDBRequest {}
 
 extension IDBOpenDBRequestExtension on IDBOpenDBRequest {
   external set onblocked(EventHandler value);
@@ -50,15 +46,11 @@ extension IDBOpenDBRequestExtension on IDBOpenDBRequest {
 
 @JS('IDBVersionChangeEvent')
 @staticInterop
-class IDBVersionChangeEvent extends Event {
-  external factory IDBVersionChangeEvent();
-
-  external factory IDBVersionChangeEvent.a1(JSString type);
-
-  external factory IDBVersionChangeEvent.a2(
-    JSString type,
+class IDBVersionChangeEvent implements Event {
+  external factory IDBVersionChangeEvent(
+    JSString type, [
     IDBVersionChangeEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension IDBVersionChangeEventExtension on IDBVersionChangeEvent {
@@ -69,7 +61,7 @@ extension IDBVersionChangeEventExtension on IDBVersionChangeEvent {
 @JS()
 @staticInterop
 @anonymous
-class IDBVersionChangeEventInit extends EventInit {
+class IDBVersionChangeEventInit implements EventInit {
   external factory IDBVersionChangeEventInit({
     JSNumber oldVersion = 0,
     JSNumber? newVersion,
@@ -85,16 +77,13 @@ extension IDBVersionChangeEventInitExtension on IDBVersionChangeEventInit {
 
 @JS('IDBFactory')
 @staticInterop
-class IDBFactory {
-  external factory IDBFactory();
-}
+class IDBFactory {}
 
 extension IDBFactoryExtension on IDBFactory {
-  external IDBOpenDBRequest open(JSString name);
-  external IDBOpenDBRequest open1(
-    JSString name,
+  external IDBOpenDBRequest open(
+    JSString name, [
     JSNumber version,
-  );
+  ]);
   external IDBOpenDBRequest deleteDatabase(JSString name);
   external JSPromise databases();
   external JSNumber cmp(
@@ -122,31 +111,23 @@ extension IDBDatabaseInfoExtension on IDBDatabaseInfo {
 
 @JS('IDBDatabase')
 @staticInterop
-class IDBDatabase extends EventTarget {
-  external factory IDBDatabase();
-}
+class IDBDatabase implements EventTarget {}
 
 extension IDBDatabaseExtension on IDBDatabase {
+  external IDBTransaction transaction(
+    JSAny storeNames, [
+    IDBTransactionMode mode,
+    IDBTransactionOptions options,
+  ]);
+  external JSVoid close();
+  external IDBObjectStore createObjectStore(
+    JSString name, [
+    IDBObjectStoreParameters options,
+  ]);
+  external JSVoid deleteObjectStore(JSString name);
   external JSString get name;
   external JSNumber get version;
   external DOMStringList get objectStoreNames;
-  external IDBTransaction transaction(JSAny storeNames);
-  external IDBTransaction transaction1(
-    JSAny storeNames,
-    IDBTransactionMode mode,
-  );
-  external IDBTransaction transaction2(
-    JSAny storeNames,
-    IDBTransactionMode mode,
-    IDBTransactionOptions options,
-  );
-  external JSVoid close();
-  external IDBObjectStore createObjectStore(JSString name);
-  external IDBObjectStore createObjectStore1(
-    JSString name,
-    IDBObjectStoreParameters options,
-  );
-  external JSVoid deleteObjectStore(JSString name);
   external set onabort(EventHandler value);
   external EventHandler get onabort;
   external set onclose(EventHandler value);
@@ -189,68 +170,51 @@ extension IDBObjectStoreParametersExtension on IDBObjectStoreParameters {
 
 @JS('IDBObjectStore')
 @staticInterop
-class IDBObjectStore {
-  external factory IDBObjectStore();
-}
+class IDBObjectStore {}
 
 extension IDBObjectStoreExtension on IDBObjectStore {
+  external IDBRequest put(
+    JSAny value, [
+    JSAny key,
+  ]);
+  external IDBRequest add(
+    JSAny value, [
+    JSAny key,
+  ]);
+  external IDBRequest delete(JSAny query);
+  external IDBRequest clear();
+  external IDBRequest get(JSAny query);
+  external IDBRequest getKey(JSAny query);
+  external IDBRequest getAll([
+    JSAny query,
+    JSNumber count,
+  ]);
+  external IDBRequest getAllKeys([
+    JSAny query,
+    JSNumber count,
+  ]);
+  external IDBRequest count([JSAny query]);
+  external IDBRequest openCursor([
+    JSAny query,
+    IDBCursorDirection direction,
+  ]);
+  external IDBRequest openKeyCursor([
+    JSAny query,
+    IDBCursorDirection direction,
+  ]);
+  external IDBIndex index(JSString name);
+  external IDBIndex createIndex(
+    JSString name,
+    JSAny keyPath, [
+    IDBIndexParameters options,
+  ]);
+  external JSVoid deleteIndex(JSString name);
   external set name(JSString value);
   external JSString get name;
   external JSAny get keyPath;
   external DOMStringList get indexNames;
   external IDBTransaction get transaction;
   external JSBoolean get autoIncrement;
-  external IDBRequest put(JSAny value);
-  external IDBRequest put1(
-    JSAny value,
-    JSAny key,
-  );
-  external IDBRequest add(JSAny value);
-  external IDBRequest add1(
-    JSAny value,
-    JSAny key,
-  );
-  external IDBRequest delete(JSAny query);
-  external IDBRequest clear();
-  external IDBRequest get(JSAny query);
-  external IDBRequest getKey(JSAny query);
-  external IDBRequest getAll();
-  external IDBRequest getAll1(JSAny query);
-  external IDBRequest getAll2(
-    JSAny query,
-    JSNumber count,
-  );
-  external IDBRequest getAllKeys();
-  external IDBRequest getAllKeys1(JSAny query);
-  external IDBRequest getAllKeys2(
-    JSAny query,
-    JSNumber count,
-  );
-  external IDBRequest count();
-  external IDBRequest count1(JSAny query);
-  external IDBRequest openCursor();
-  external IDBRequest openCursor1(JSAny query);
-  external IDBRequest openCursor2(
-    JSAny query,
-    IDBCursorDirection direction,
-  );
-  external IDBRequest openKeyCursor();
-  external IDBRequest openKeyCursor1(JSAny query);
-  external IDBRequest openKeyCursor2(
-    JSAny query,
-    IDBCursorDirection direction,
-  );
-  external IDBIndex index(JSString name);
-  external IDBIndex createIndex(
-    JSString name,
-    JSAny keyPath,
-  );
-  external IDBIndex createIndex1(
-    JSString name,
-    JSAny keyPath,
-    IDBIndexParameters options,
-  );
-  external JSVoid deleteIndex(JSString name);
 }
 
 @JS()
@@ -272,118 +236,88 @@ extension IDBIndexParametersExtension on IDBIndexParameters {
 
 @JS('IDBIndex')
 @staticInterop
-class IDBIndex {
-  external factory IDBIndex();
-}
+class IDBIndex {}
 
 extension IDBIndexExtension on IDBIndex {
+  external IDBRequest get(JSAny query);
+  external IDBRequest getKey(JSAny query);
+  external IDBRequest getAll([
+    JSAny query,
+    JSNumber count,
+  ]);
+  external IDBRequest getAllKeys([
+    JSAny query,
+    JSNumber count,
+  ]);
+  external IDBRequest count([JSAny query]);
+  external IDBRequest openCursor([
+    JSAny query,
+    IDBCursorDirection direction,
+  ]);
+  external IDBRequest openKeyCursor([
+    JSAny query,
+    IDBCursorDirection direction,
+  ]);
   external set name(JSString value);
   external JSString get name;
   external IDBObjectStore get objectStore;
   external JSAny get keyPath;
   external JSBoolean get multiEntry;
   external JSBoolean get unique;
-  external IDBRequest get(JSAny query);
-  external IDBRequest getKey(JSAny query);
-  external IDBRequest getAll();
-  external IDBRequest getAll1(JSAny query);
-  external IDBRequest getAll2(
-    JSAny query,
-    JSNumber count,
-  );
-  external IDBRequest getAllKeys();
-  external IDBRequest getAllKeys1(JSAny query);
-  external IDBRequest getAllKeys2(
-    JSAny query,
-    JSNumber count,
-  );
-  external IDBRequest count();
-  external IDBRequest count1(JSAny query);
-  external IDBRequest openCursor();
-  external IDBRequest openCursor1(JSAny query);
-  external IDBRequest openCursor2(
-    JSAny query,
-    IDBCursorDirection direction,
-  );
-  external IDBRequest openKeyCursor();
-  external IDBRequest openKeyCursor1(JSAny query);
-  external IDBRequest openKeyCursor2(
-    JSAny query,
-    IDBCursorDirection direction,
-  );
 }
 
 @JS('IDBKeyRange')
 @staticInterop
 class IDBKeyRange {
-  external factory IDBKeyRange();
-
   external static IDBKeyRange only(JSAny value);
-  external static IDBKeyRange lowerBound(JSAny lower);
-  external static IDBKeyRange lowerBound1(
-    JSAny lower,
+  external static IDBKeyRange lowerBound(
+    JSAny lower, [
     JSBoolean open,
-  );
-  external static IDBKeyRange upperBound(JSAny upper);
-  external static IDBKeyRange upperBound1(
-    JSAny upper,
+  ]);
+  external static IDBKeyRange upperBound(
+    JSAny upper, [
     JSBoolean open,
-  );
+  ]);
   external static IDBKeyRange bound(
     JSAny lower,
-    JSAny upper,
-  );
-  external static IDBKeyRange bound1(
-    JSAny lower,
-    JSAny upper,
-    JSBoolean lowerOpen,
-  );
-  external static IDBKeyRange bound2(
-    JSAny lower,
-    JSAny upper,
+    JSAny upper, [
     JSBoolean lowerOpen,
     JSBoolean upperOpen,
-  );
+  ]);
 }
 
 extension IDBKeyRangeExtension on IDBKeyRange {
+  external JSBoolean includes(JSAny key);
   external JSAny get lower;
   external JSAny get upper;
   external JSBoolean get lowerOpen;
   external JSBoolean get upperOpen;
-  external JSBoolean includes(JSAny key);
 }
 
 @JS('IDBCursor')
 @staticInterop
-class IDBCursor {
-  external factory IDBCursor();
-}
+class IDBCursor {}
 
 extension IDBCursorExtension on IDBCursor {
-  external JSAny get source;
-  external IDBCursorDirection get direction;
-  external JSAny get key;
-  external JSAny get primaryKey;
-  external IDBRequest get request;
   external JSVoid advance(JSNumber count);
   @JS('continue')
-  external JSVoid continue_0_();
-  @JS('continue')
-  external JSVoid continue_0_1(JSAny key);
+  external JSVoid continue_([JSAny key]);
   external JSVoid continuePrimaryKey(
     JSAny key,
     JSAny primaryKey,
   );
   external IDBRequest update(JSAny value);
   external IDBRequest delete();
+  external JSAny get source;
+  external IDBCursorDirection get direction;
+  external JSAny get key;
+  external JSAny get primaryKey;
+  external IDBRequest get request;
 }
 
 @JS('IDBCursorWithValue')
 @staticInterop
-class IDBCursorWithValue extends IDBCursor {
-  external factory IDBCursorWithValue();
-}
+class IDBCursorWithValue implements IDBCursor {}
 
 extension IDBCursorWithValueExtension on IDBCursorWithValue {
   external JSAny get value;
@@ -391,19 +325,17 @@ extension IDBCursorWithValueExtension on IDBCursorWithValue {
 
 @JS('IDBTransaction')
 @staticInterop
-class IDBTransaction extends EventTarget {
-  external factory IDBTransaction();
-}
+class IDBTransaction implements EventTarget {}
 
 extension IDBTransactionExtension on IDBTransaction {
+  external IDBObjectStore objectStore(JSString name);
+  external JSVoid commit();
+  external JSVoid abort();
   external DOMStringList get objectStoreNames;
   external IDBTransactionMode get mode;
   external IDBTransactionDurability get durability;
   external IDBDatabase get db;
   external DOMException? get error;
-  external IDBObjectStore objectStore(JSString name);
-  external JSVoid commit();
-  external JSVoid abort();
   external set onabort(EventHandler value);
   external EventHandler get onabort;
   external set oncomplete(EventHandler value);

--- a/lib/src/dom/ink_enhancement.dart
+++ b/lib/src/dom/ink_enhancement.dart
@@ -13,13 +13,10 @@ import 'pointerevents.dart';
 
 @JS('Ink')
 @staticInterop
-class Ink {
-  external factory Ink();
-}
+class Ink {}
 
 extension InkExtension on Ink {
-  external JSPromise requestPresenter();
-  external JSPromise requestPresenter1(InkPresenterParam param);
+  external JSPromise requestPresenter([InkPresenterParam param]);
 }
 
 @JS()
@@ -36,17 +33,15 @@ extension InkPresenterParamExtension on InkPresenterParam {
 
 @JS('InkPresenter')
 @staticInterop
-class InkPresenter {
-  external factory InkPresenter();
-}
+class InkPresenter {}
 
 extension InkPresenterExtension on InkPresenter {
-  external Element? get presentationArea;
-  external JSNumber get expectedImprovement;
   external JSVoid updateInkTrailStartPoint(
     PointerEvent event,
     InkTrailStyle style,
   );
+  external Element? get presentationArea;
+  external JSNumber get expectedImprovement;
 }
 
 @JS()

--- a/lib/src/dom/input_device_capabilities.dart
+++ b/lib/src/dom/input_device_capabilities.dart
@@ -11,12 +11,8 @@ import 'package:js/js.dart' hide JS;
 @JS('InputDeviceCapabilities')
 @staticInterop
 class InputDeviceCapabilities {
-  external factory InputDeviceCapabilities();
-
-  external factory InputDeviceCapabilities.a1();
-
-  external factory InputDeviceCapabilities.a2(
-      InputDeviceCapabilitiesInit deviceInitDict);
+  external factory InputDeviceCapabilities(
+      [InputDeviceCapabilitiesInit deviceInitDict]);
 }
 
 extension InputDeviceCapabilitiesExtension on InputDeviceCapabilities {

--- a/lib/src/dom/intersection_observer.dart
+++ b/lib/src/dom/intersection_observer.dart
@@ -17,33 +17,26 @@ typedef IntersectionObserverCallback = JSFunction;
 @JS('IntersectionObserver')
 @staticInterop
 class IntersectionObserver {
-  external factory IntersectionObserver();
-
-  external factory IntersectionObserver.a1(
-      IntersectionObserverCallback callback);
-
-  external factory IntersectionObserver.a2(
-    IntersectionObserverCallback callback,
+  external factory IntersectionObserver(
+    IntersectionObserverCallback callback, [
     IntersectionObserverInit options,
-  );
+  ]);
 }
 
 extension IntersectionObserverExtension on IntersectionObserver {
-  external JSAny? get root;
-  external JSString get rootMargin;
-  external JSArray get thresholds;
   external JSVoid observe(Element target);
   external JSVoid unobserve(Element target);
   external JSVoid disconnect();
   external JSArray takeRecords();
+  external JSAny? get root;
+  external JSString get rootMargin;
+  external JSArray get thresholds;
 }
 
 @JS('IntersectionObserverEntry')
 @staticInterop
 class IntersectionObserverEntry {
-  external factory IntersectionObserverEntry();
-
-  external factory IntersectionObserverEntry.a1(
+  external factory IntersectionObserverEntry(
       IntersectionObserverEntryInit intersectionObserverEntryInit);
 }
 

--- a/lib/src/dom/intervention_reporting.dart
+++ b/lib/src/dom/intervention_reporting.dart
@@ -12,9 +12,7 @@ import 'reporting.dart';
 
 @JS('InterventionReportBody')
 @staticInterop
-class InterventionReportBody extends ReportBody {
-  external factory InterventionReportBody();
-}
+class InterventionReportBody implements ReportBody {}
 
 extension InterventionReportBodyExtension on InterventionReportBody {
   external JSObject toJSON();

--- a/lib/src/dom/is_input_pending.dart
+++ b/lib/src/dom/is_input_pending.dart
@@ -22,12 +22,9 @@ extension IsInputPendingOptionsExtension on IsInputPendingOptions {
 
 @JS('Scheduling')
 @staticInterop
-class Scheduling {
-  external factory Scheduling();
-}
+class Scheduling {}
 
 extension SchedulingExtension on Scheduling {
-  external JSBoolean isInputPending();
-  external JSBoolean isInputPending1(
-      IsInputPendingOptions isInputPendingOptions);
+  external JSBoolean isInputPending(
+      [IsInputPendingOptions isInputPendingOptions]);
 }

--- a/lib/src/dom/js_self_profiling.dart
+++ b/lib/src/dom/js_self_profiling.dart
@@ -15,16 +15,14 @@ typedef ProfilerResource = JSString;
 
 @JS('Profiler')
 @staticInterop
-class Profiler extends EventTarget {
-  external factory Profiler();
-
-  external factory Profiler.a1(ProfilerInitOptions options);
+class Profiler implements EventTarget {
+  external factory Profiler(ProfilerInitOptions options);
 }
 
 extension ProfilerExtension on Profiler {
+  external JSPromise stop();
   external DOMHighResTimeStamp get sampleInterval;
   external JSBoolean get stopped;
-  external JSPromise stop();
 }
 
 @JS()

--- a/lib/src/dom/keyboard_lock.dart
+++ b/lib/src/dom/keyboard_lock.dart
@@ -13,13 +13,10 @@ import 'html.dart';
 
 @JS('Keyboard')
 @staticInterop
-class Keyboard extends EventTarget {
-  external factory Keyboard();
-}
+class Keyboard implements EventTarget {}
 
 extension KeyboardExtension on Keyboard {
-  external JSPromise lock();
-  external JSPromise lock1(JSArray keyCodes);
+  external JSPromise lock([JSArray keyCodes]);
   external JSVoid unlock();
   external JSPromise getLayoutMap();
   external set onlayoutchange(EventHandler value);

--- a/lib/src/dom/keyboard_map.dart
+++ b/lib/src/dom/keyboard_map.dart
@@ -10,8 +10,6 @@ import 'package:js/js.dart' hide JS;
 
 @JS('KeyboardLayoutMap')
 @staticInterop
-class KeyboardLayoutMap {
-  external factory KeyboardLayoutMap();
-}
+class KeyboardLayoutMap {}
 
 extension KeyboardLayoutMapExtension on KeyboardLayoutMap {}

--- a/lib/src/dom/khr_parallel_shader_compile.dart
+++ b/lib/src/dom/khr_parallel_shader_compile.dart
@@ -13,7 +13,5 @@ import 'webgl1.dart';
 @JS('KHR_parallel_shader_compile')
 @staticInterop
 class KHR_parallel_shader_compile {
-  external factory KHR_parallel_shader_compile();
-
   external static GLenum get COMPLETION_STATUS_KHR;
 }

--- a/lib/src/dom/largest_contentful_paint.dart
+++ b/lib/src/dom/largest_contentful_paint.dart
@@ -14,16 +14,14 @@ import 'performance_timeline.dart';
 
 @JS('LargestContentfulPaint')
 @staticInterop
-class LargestContentfulPaint extends PerformanceEntry {
-  external factory LargestContentfulPaint();
-}
+class LargestContentfulPaint implements PerformanceEntry {}
 
 extension LargestContentfulPaintExtension on LargestContentfulPaint {
+  external JSObject toJSON();
   external DOMHighResTimeStamp get renderTime;
   external DOMHighResTimeStamp get loadTime;
   external JSNumber get size;
   external JSString get id;
   external JSString get url;
   external Element? get element;
-  external JSObject toJSON();
 }

--- a/lib/src/dom/layout_instability.dart
+++ b/lib/src/dom/layout_instability.dart
@@ -15,23 +15,19 @@ import 'performance_timeline.dart';
 
 @JS('LayoutShift')
 @staticInterop
-class LayoutShift extends PerformanceEntry {
-  external factory LayoutShift();
-}
+class LayoutShift implements PerformanceEntry {}
 
 extension LayoutShiftExtension on LayoutShift {
+  external JSObject toJSON();
   external JSNumber get value;
   external JSBoolean get hadRecentInput;
   external DOMHighResTimeStamp get lastInputTime;
   external JSArray get sources;
-  external JSObject toJSON();
 }
 
 @JS('LayoutShiftAttribution')
 @staticInterop
-class LayoutShiftAttribution {
-  external factory LayoutShiftAttribution();
-}
+class LayoutShiftAttribution {}
 
 extension LayoutShiftAttributionExtension on LayoutShiftAttribution {
   external Node? get node;

--- a/lib/src/dom/local_font_access.dart
+++ b/lib/src/dom/local_font_access.dart
@@ -22,9 +22,7 @@ extension QueryOptionsExtension on QueryOptions {
 
 @JS('FontData')
 @staticInterop
-class FontData {
-  external factory FontData();
-}
+class FontData {}
 
 extension FontDataExtension on FontData {
   external JSPromise blob();

--- a/lib/src/dom/longtasks.dart
+++ b/lib/src/dom/longtasks.dart
@@ -12,25 +12,21 @@ import 'performance_timeline.dart';
 
 @JS('PerformanceLongTaskTiming')
 @staticInterop
-class PerformanceLongTaskTiming extends PerformanceEntry {
-  external factory PerformanceLongTaskTiming();
-}
+class PerformanceLongTaskTiming implements PerformanceEntry {}
 
 extension PerformanceLongTaskTimingExtension on PerformanceLongTaskTiming {
-  external JSArray get attribution;
   external JSObject toJSON();
+  external JSArray get attribution;
 }
 
 @JS('TaskAttributionTiming')
 @staticInterop
-class TaskAttributionTiming extends PerformanceEntry {
-  external factory TaskAttributionTiming();
-}
+class TaskAttributionTiming implements PerformanceEntry {}
 
 extension TaskAttributionTimingExtension on TaskAttributionTiming {
+  external JSObject toJSON();
   external JSString get containerType;
   external JSString get containerSrc;
   external JSString get containerId;
   external JSString get containerName;
-  external JSObject toJSON();
 }

--- a/lib/src/dom/magnetometer.dart
+++ b/lib/src/dom/magnetometer.dart
@@ -14,12 +14,8 @@ typedef MagnetometerLocalCoordinateSystem = JSString;
 
 @JS('Magnetometer')
 @staticInterop
-class Magnetometer extends Sensor {
-  external factory Magnetometer();
-
-  external factory Magnetometer.a1();
-
-  external factory Magnetometer.a2(MagnetometerSensorOptions sensorOptions);
+class Magnetometer implements Sensor {
+  external factory Magnetometer([MagnetometerSensorOptions sensorOptions]);
 }
 
 extension MagnetometerExtension on Magnetometer {
@@ -31,7 +27,7 @@ extension MagnetometerExtension on Magnetometer {
 @JS()
 @staticInterop
 @anonymous
-class MagnetometerSensorOptions extends SensorOptions {
+class MagnetometerSensorOptions implements SensorOptions {
   external factory MagnetometerSensorOptions(
       {MagnetometerLocalCoordinateSystem referenceFrame = 'device'});
 }
@@ -43,13 +39,9 @@ extension MagnetometerSensorOptionsExtension on MagnetometerSensorOptions {
 
 @JS('UncalibratedMagnetometer')
 @staticInterop
-class UncalibratedMagnetometer extends Sensor {
-  external factory UncalibratedMagnetometer();
-
-  external factory UncalibratedMagnetometer.a1();
-
-  external factory UncalibratedMagnetometer.a2(
-      MagnetometerSensorOptions sensorOptions);
+class UncalibratedMagnetometer implements Sensor {
+  external factory UncalibratedMagnetometer(
+      [MagnetometerSensorOptions sensorOptions]);
 }
 
 extension UncalibratedMagnetometerExtension on UncalibratedMagnetometer {

--- a/lib/src/dom/manifest_incubations.dart
+++ b/lib/src/dom/manifest_incubations.dart
@@ -14,15 +14,11 @@ typedef AppBannerPromptOutcome = JSString;
 
 @JS('BeforeInstallPromptEvent')
 @staticInterop
-class BeforeInstallPromptEvent extends Event {
-  external factory BeforeInstallPromptEvent();
-
-  external factory BeforeInstallPromptEvent.a1(JSString type);
-
-  external factory BeforeInstallPromptEvent.a2(
-    JSString type,
+class BeforeInstallPromptEvent implements Event {
+  external factory BeforeInstallPromptEvent(
+    JSString type, [
     EventInit eventInitDict,
-  );
+  ]);
 }
 
 extension BeforeInstallPromptEventExtension on BeforeInstallPromptEvent {

--- a/lib/src/dom/mathml_core.dart
+++ b/lib/src/dom/mathml_core.dart
@@ -14,7 +14,9 @@ import 'html.dart';
 
 @JS('MathMLElement')
 @staticInterop
-class MathMLElement extends Element
-    implements ElementCSSInlineStyle, GlobalEventHandlers, HTMLOrSVGElement {
-  external factory MathMLElement();
-}
+class MathMLElement
+    implements
+        Element,
+        ElementCSSInlineStyle,
+        GlobalEventHandlers,
+        HTMLOrSVGElement {}

--- a/lib/src/dom/media_capabilities.dart
+++ b/lib/src/dom/media_capabilities.dart
@@ -36,7 +36,7 @@ extension MediaConfigurationExtension on MediaConfiguration {
 @JS()
 @staticInterop
 @anonymous
-class MediaDecodingConfiguration extends MediaConfiguration {
+class MediaDecodingConfiguration implements MediaConfiguration {
   external factory MediaDecodingConfiguration({
     required MediaDecodingType type,
     MediaCapabilitiesKeySystemConfiguration keySystemConfiguration,
@@ -54,7 +54,7 @@ extension MediaDecodingConfigurationExtension on MediaDecodingConfiguration {
 @JS()
 @staticInterop
 @anonymous
-class MediaEncodingConfiguration extends MediaConfiguration {
+class MediaEncodingConfiguration implements MediaConfiguration {
   external factory MediaEncodingConfiguration(
       {required MediaEncodingType type});
 }
@@ -207,7 +207,7 @@ extension MediaCapabilitiesInfoExtension on MediaCapabilitiesInfo {
 @JS()
 @staticInterop
 @anonymous
-class MediaCapabilitiesDecodingInfo extends MediaCapabilitiesInfo {
+class MediaCapabilitiesDecodingInfo implements MediaCapabilitiesInfo {
   external factory MediaCapabilitiesDecodingInfo({
     required MediaKeySystemAccess keySystemAccess,
     MediaDecodingConfiguration configuration,
@@ -225,7 +225,7 @@ extension MediaCapabilitiesDecodingInfoExtension
 @JS()
 @staticInterop
 @anonymous
-class MediaCapabilitiesEncodingInfo extends MediaCapabilitiesInfo {
+class MediaCapabilitiesEncodingInfo implements MediaCapabilitiesInfo {
   external factory MediaCapabilitiesEncodingInfo(
       {MediaEncodingConfiguration configuration});
 }
@@ -238,9 +238,7 @@ extension MediaCapabilitiesEncodingInfoExtension
 
 @JS('MediaCapabilities')
 @staticInterop
-class MediaCapabilities {
-  external factory MediaCapabilities();
-}
+class MediaCapabilities {}
 
 extension MediaCapabilitiesExtension on MediaCapabilities {
   external JSPromise decodingInfo(MediaDecodingConfiguration configuration);

--- a/lib/src/dom/media_playback_quality.dart
+++ b/lib/src/dom/media_playback_quality.dart
@@ -12,9 +12,7 @@ import 'hr_time.dart';
 
 @JS('VideoPlaybackQuality')
 @staticInterop
-class VideoPlaybackQuality {
-  external factory VideoPlaybackQuality();
-}
+class VideoPlaybackQuality {}
 
 extension VideoPlaybackQualityExtension on VideoPlaybackQuality {
   external DOMHighResTimeStamp get creationTime;

--- a/lib/src/dom/media_source.dart
+++ b/lib/src/dom/media_source.dart
@@ -18,14 +18,22 @@ typedef AppendMode = JSString;
 
 @JS('MediaSource')
 @staticInterop
-class MediaSource extends EventTarget {
-  external factory MediaSource.a0();
+class MediaSource implements EventTarget {
+  external factory MediaSource();
 
-  external static JSBoolean get canConstructInDedicatedWorker;
   external static JSBoolean isTypeSupported(JSString type);
+  external static JSBoolean get canConstructInDedicatedWorker;
 }
 
 extension MediaSourceExtension on MediaSource {
+  external SourceBuffer addSourceBuffer(JSString type);
+  external JSVoid removeSourceBuffer(SourceBuffer sourceBuffer);
+  external JSVoid endOfStream([EndOfStreamError error]);
+  external JSVoid setLiveSeekableRange(
+    JSNumber start,
+    JSNumber end,
+  );
+  external JSVoid clearLiveSeekableRange();
   external MediaSourceHandle get handle;
   external SourceBufferList get sourceBuffers;
   external SourceBufferList get activeSourceBuffers;
@@ -38,30 +46,24 @@ extension MediaSourceExtension on MediaSource {
   external EventHandler get onsourceended;
   external set onsourceclose(EventHandler value);
   external EventHandler get onsourceclose;
-  external SourceBuffer addSourceBuffer(JSString type);
-  external JSVoid removeSourceBuffer(SourceBuffer sourceBuffer);
-  external JSVoid endOfStream();
-  external JSVoid endOfStream1(EndOfStreamError error);
-  external JSVoid setLiveSeekableRange(
-    JSNumber start,
-    JSNumber end,
-  );
-  external JSVoid clearLiveSeekableRange();
 }
 
 @JS('MediaSourceHandle')
 @staticInterop
-class MediaSourceHandle {
-  external factory MediaSourceHandle();
-}
+class MediaSourceHandle {}
 
 @JS('SourceBuffer')
 @staticInterop
-class SourceBuffer extends EventTarget {
-  external factory SourceBuffer();
-}
+class SourceBuffer implements EventTarget {}
 
 extension SourceBufferExtension on SourceBuffer {
+  external JSVoid appendBuffer(BufferSource data);
+  external JSVoid abort();
+  external JSVoid changeType(JSString type);
+  external JSVoid remove(
+    JSNumber start,
+    JSNumber end,
+  );
   external set mode(AppendMode value);
   external AppendMode get mode;
   external JSBoolean get updating;
@@ -85,20 +87,11 @@ extension SourceBufferExtension on SourceBuffer {
   external EventHandler get onerror;
   external set onabort(EventHandler value);
   external EventHandler get onabort;
-  external JSVoid appendBuffer(BufferSource data);
-  external JSVoid abort();
-  external JSVoid changeType(JSString type);
-  external JSVoid remove(
-    JSNumber start,
-    JSNumber end,
-  );
 }
 
 @JS('SourceBufferList')
 @staticInterop
-class SourceBufferList extends EventTarget {
-  external factory SourceBufferList();
-}
+class SourceBufferList implements EventTarget {}
 
 extension SourceBufferListExtension on SourceBufferList {
   external JSNumber get length;

--- a/lib/src/dom/mediacapture_automation.dart
+++ b/lib/src/dom/mediacapture_automation.dart
@@ -52,7 +52,7 @@ extension MockCaptureDeviceConfigurationExtension
 @JS()
 @staticInterop
 @anonymous
-class MockCameraConfiguration extends MockCaptureDeviceConfiguration {
+class MockCameraConfiguration implements MockCaptureDeviceConfiguration {
   external factory MockCameraConfiguration({
     JSNumber defaultFrameRate = 30,
     JSString facingMode = 'user',
@@ -69,7 +69,7 @@ extension MockCameraConfigurationExtension on MockCameraConfiguration {
 @JS()
 @staticInterop
 @anonymous
-class MockMicrophoneConfiguration extends MockCaptureDeviceConfiguration {
+class MockMicrophoneConfiguration implements MockCaptureDeviceConfiguration {
   external factory MockMicrophoneConfiguration(
       {JSNumber defaultSampleRate = 44100});
 }

--- a/lib/src/dom/mediacapture_fromelement.dart
+++ b/lib/src/dom/mediacapture_fromelement.dart
@@ -13,12 +13,10 @@ import 'mediacapture_streams.dart';
 
 @JS('CanvasCaptureMediaStreamTrack')
 @staticInterop
-class CanvasCaptureMediaStreamTrack extends MediaStreamTrack {
-  external factory CanvasCaptureMediaStreamTrack();
-}
+class CanvasCaptureMediaStreamTrack implements MediaStreamTrack {}
 
 extension CanvasCaptureMediaStreamTrackExtension
     on CanvasCaptureMediaStreamTrack {
-  external HTMLCanvasElement get canvas;
   external JSVoid requestFrame();
+  external HTMLCanvasElement get canvas;
 }

--- a/lib/src/dom/mediacapture_handle_actions.dart
+++ b/lib/src/dom/mediacapture_handle_actions.dart
@@ -14,12 +14,8 @@ typedef CaptureAction = JSString;
 
 @JS('CaptureActionEvent')
 @staticInterop
-class CaptureActionEvent extends Event {
-  external factory CaptureActionEvent();
-
-  external factory CaptureActionEvent.a1();
-
-  external factory CaptureActionEvent.a2(CaptureActionEventInit init);
+class CaptureActionEvent implements Event {
+  external factory CaptureActionEvent([CaptureActionEventInit init]);
 }
 
 extension CaptureActionEventExtension on CaptureActionEvent {
@@ -29,7 +25,7 @@ extension CaptureActionEventExtension on CaptureActionEvent {
 @JS()
 @staticInterop
 @anonymous
-class CaptureActionEventInit extends EventInit {
+class CaptureActionEventInit implements EventInit {
   external factory CaptureActionEventInit({JSString action});
 }
 

--- a/lib/src/dom/mediacapture_region.dart
+++ b/lib/src/dom/mediacapture_region.dart
@@ -14,16 +14,12 @@ import 'mediacapture_streams.dart';
 @JS('CropTarget')
 @staticInterop
 class CropTarget {
-  external factory CropTarget();
-
   external static JSPromise fromElement(Element element);
 }
 
 @JS('BrowserCaptureMediaStreamTrack')
 @staticInterop
-class BrowserCaptureMediaStreamTrack extends MediaStreamTrack {
-  external factory BrowserCaptureMediaStreamTrack();
-}
+class BrowserCaptureMediaStreamTrack implements MediaStreamTrack {}
 
 extension BrowserCaptureMediaStreamTrackExtension
     on BrowserCaptureMediaStreamTrack {

--- a/lib/src/dom/mediacapture_streams.dart
+++ b/lib/src/dom/mediacapture_streams.dart
@@ -32,16 +32,11 @@ typedef MediaDeviceKind = JSString;
 
 @JS('MediaStream')
 @staticInterop
-class MediaStream extends EventTarget {
-  external factory MediaStream.a0();
-
-  external factory MediaStream.a1(MediaStream stream);
-
-  external factory MediaStream.a2(JSArray tracks);
+class MediaStream implements EventTarget {
+  external factory MediaStream([JSAny streamOrTracks]);
 }
 
 extension MediaStreamExtension on MediaStream {
-  external JSString get id;
   external JSArray getAudioTracks();
   external JSArray getVideoTracks();
   external JSArray getTracks();
@@ -49,6 +44,7 @@ extension MediaStreamExtension on MediaStream {
   external JSVoid addTrack(MediaStreamTrack track);
   external JSVoid removeTrack(MediaStreamTrack track);
   external MediaStream clone();
+  external JSString get id;
   external JSBoolean get active;
   external set onaddtrack(EventHandler value);
   external EventHandler get onaddtrack;
@@ -58,16 +54,20 @@ extension MediaStreamExtension on MediaStream {
 
 @JS('MediaStreamTrack')
 @staticInterop
-class MediaStreamTrack extends EventTarget {
-  external factory MediaStreamTrack();
-}
+class MediaStreamTrack implements EventTarget {}
 
 extension MediaStreamTrackExtension on MediaStreamTrack {
   external CaptureHandle? getCaptureHandle();
-  external set oncapturehandlechange(EventHandler value);
-  external EventHandler get oncapturehandlechange;
   external JSArray getSupportedCaptureActions();
   external JSPromise sendCaptureAction(CaptureAction action);
+  external MediaStreamTrack clone();
+  external JSVoid stop();
+  external MediaTrackCapabilities getCapabilities();
+  external MediaTrackConstraints getConstraints();
+  external MediaTrackSettings getSettings();
+  external JSPromise applyConstraints([MediaTrackConstraints constraints]);
+  external set oncapturehandlechange(EventHandler value);
+  external EventHandler get oncapturehandlechange;
   external JSString get kind;
   external JSString get id;
   external JSString get label;
@@ -81,13 +81,6 @@ extension MediaStreamTrackExtension on MediaStreamTrack {
   external MediaStreamTrackState get readyState;
   external set onended(EventHandler value);
   external EventHandler get onended;
-  external MediaStreamTrack clone();
-  external JSVoid stop();
-  external MediaTrackCapabilities getCapabilities();
-  external MediaTrackConstraints getConstraints();
-  external MediaTrackSettings getSettings();
-  external JSPromise applyConstraints();
-  external JSPromise applyConstraints1(MediaTrackConstraints constraints);
   external set contentHint(JSString value);
   external JSString get contentHint;
   external JSBoolean get isolated;
@@ -334,7 +327,7 @@ extension MediaTrackCapabilitiesExtension on MediaTrackCapabilities {
 @JS()
 @staticInterop
 @anonymous
-class MediaTrackConstraints extends MediaTrackConstraintSet {
+class MediaTrackConstraints implements MediaTrackConstraintSet {
   external factory MediaTrackConstraints({JSArray advanced});
 }
 
@@ -589,10 +582,8 @@ extension MediaTrackSettingsExtension on MediaTrackSettings {
 
 @JS('MediaStreamTrackEvent')
 @staticInterop
-class MediaStreamTrackEvent extends Event {
-  external factory MediaStreamTrackEvent();
-
-  external factory MediaStreamTrackEvent.a1(
+class MediaStreamTrackEvent implements Event {
+  external factory MediaStreamTrackEvent(
     JSString type,
     MediaStreamTrackEventInit eventInitDict,
   );
@@ -605,7 +596,7 @@ extension MediaStreamTrackEventExtension on MediaStreamTrackEvent {
 @JS()
 @staticInterop
 @anonymous
-class MediaStreamTrackEventInit extends EventInit {
+class MediaStreamTrackEventInit implements EventInit {
   external factory MediaStreamTrackEventInit({required MediaStreamTrack track});
 }
 
@@ -616,15 +607,11 @@ extension MediaStreamTrackEventInitExtension on MediaStreamTrackEventInit {
 
 @JS('OverconstrainedError')
 @staticInterop
-class OverconstrainedError extends DOMException {
-  external factory OverconstrainedError();
-
-  external factory OverconstrainedError.a1(JSString constraint);
-
-  external factory OverconstrainedError.a2(
-    JSString constraint,
+class OverconstrainedError implements DOMException {
+  external factory OverconstrainedError(
+    JSString constraint, [
     JSString message,
-  );
+  ]);
 }
 
 extension OverconstrainedErrorExtension on OverconstrainedError {
@@ -633,50 +620,39 @@ extension OverconstrainedErrorExtension on OverconstrainedError {
 
 @JS('MediaDevices')
 @staticInterop
-class MediaDevices extends EventTarget {
-  external factory MediaDevices();
-}
+class MediaDevices implements EventTarget {}
 
 extension MediaDevicesExtension on MediaDevices {
-  external JSPromise selectAudioOutput();
-  external JSPromise selectAudioOutput1(AudioOutputOptions options);
-  external JSVoid setCaptureHandleConfig();
-  external JSVoid setCaptureHandleConfig1(CaptureHandleConfig config);
+  external JSPromise selectAudioOutput([AudioOutputOptions options]);
+  external JSVoid setCaptureHandleConfig([CaptureHandleConfig config]);
   external JSVoid setSupportedCaptureActions(JSArray actions);
+  external JSPromise enumerateDevices();
+  external MediaTrackSupportedConstraints getSupportedConstraints();
+  external JSPromise getUserMedia([MediaStreamConstraints constraints]);
+  external JSPromise getViewportMedia(
+      [ViewportMediaStreamConstraints constraints]);
+  external JSPromise getDisplayMedia([DisplayMediaStreamOptions options]);
   external set oncaptureaction(EventHandler value);
   external EventHandler get oncaptureaction;
   external set ondevicechange(EventHandler value);
   external EventHandler get ondevicechange;
-  external JSPromise enumerateDevices();
-  external MediaTrackSupportedConstraints getSupportedConstraints();
-  external JSPromise getUserMedia();
-  external JSPromise getUserMedia1(MediaStreamConstraints constraints);
-  external JSPromise getViewportMedia();
-  external JSPromise getViewportMedia1(
-      ViewportMediaStreamConstraints constraints);
-  external JSPromise getDisplayMedia();
-  external JSPromise getDisplayMedia1(DisplayMediaStreamOptions options);
 }
 
 @JS('MediaDeviceInfo')
 @staticInterop
-class MediaDeviceInfo {
-  external factory MediaDeviceInfo();
-}
+class MediaDeviceInfo {}
 
 extension MediaDeviceInfoExtension on MediaDeviceInfo {
+  external JSObject toJSON();
   external JSString get deviceId;
   external MediaDeviceKind get kind;
   external JSString get label;
   external JSString get groupId;
-  external JSObject toJSON();
 }
 
 @JS('InputDeviceInfo')
 @staticInterop
-class InputDeviceInfo extends MediaDeviceInfo {
-  external factory InputDeviceInfo();
-}
+class InputDeviceInfo implements MediaDeviceInfo {}
 
 extension InputDeviceInfoExtension on InputDeviceInfo {
   external MediaTrackCapabilities getCapabilities();
@@ -725,7 +701,7 @@ extension DoubleRangeExtension on DoubleRange {
 @JS()
 @staticInterop
 @anonymous
-class ConstrainDoubleRange extends DoubleRange {
+class ConstrainDoubleRange implements DoubleRange {
   external factory ConstrainDoubleRange({
     JSNumber exact,
     JSNumber ideal,
@@ -759,7 +735,7 @@ extension ULongRangeExtension on ULongRange {
 @JS()
 @staticInterop
 @anonymous
-class ConstrainULongRange extends ULongRange {
+class ConstrainULongRange implements ULongRange {
   external factory ConstrainULongRange({
     JSNumber exact,
     JSNumber ideal,
@@ -811,7 +787,7 @@ extension ConstrainDOMStringParametersExtension
 @JS()
 @staticInterop
 @anonymous
-class DevicePermissionDescriptor extends PermissionDescriptor {
+class DevicePermissionDescriptor implements PermissionDescriptor {
   external factory DevicePermissionDescriptor({JSString deviceId});
 }
 
@@ -823,7 +799,7 @@ extension DevicePermissionDescriptorExtension on DevicePermissionDescriptor {
 @JS()
 @staticInterop
 @anonymous
-class CameraDevicePermissionDescriptor extends DevicePermissionDescriptor {
+class CameraDevicePermissionDescriptor implements DevicePermissionDescriptor {
   external factory CameraDevicePermissionDescriptor(
       {JSBoolean panTiltZoom = false});
 }

--- a/lib/src/dom/mediacapture_transform.dart
+++ b/lib/src/dom/mediacapture_transform.dart
@@ -14,9 +14,7 @@ import 'streams.dart';
 @JS('MediaStreamTrackProcessor')
 @staticInterop
 class MediaStreamTrackProcessor {
-  external factory MediaStreamTrackProcessor();
-
-  external factory MediaStreamTrackProcessor.a1(
+  external factory MediaStreamTrackProcessor(
       MediaStreamTrackProcessorInit init);
 }
 
@@ -46,7 +44,7 @@ extension MediaStreamTrackProcessorInitExtension
 @JS('VideoTrackGenerator')
 @staticInterop
 class VideoTrackGenerator {
-  external factory VideoTrackGenerator.a0();
+  external factory VideoTrackGenerator();
 }
 
 extension VideoTrackGeneratorExtension on VideoTrackGenerator {

--- a/lib/src/dom/mediasession.dart
+++ b/lib/src/dom/mediasession.dart
@@ -14,33 +14,26 @@ typedef MediaSessionAction = JSString;
 
 @JS('MediaSession')
 @staticInterop
-class MediaSession {
-  external factory MediaSession();
-}
+class MediaSession {}
 
 extension MediaSessionExtension on MediaSession {
-  external set metadata(MediaMetadata? value);
-  external MediaMetadata? get metadata;
-  external set playbackState(MediaSessionPlaybackState value);
-  external MediaSessionPlaybackState get playbackState;
   external JSVoid setActionHandler(
     MediaSessionAction action,
     MediaSessionActionHandler? handler,
   );
-  external JSVoid setPositionState();
-  external JSVoid setPositionState1(MediaPositionState state);
+  external JSVoid setPositionState([MediaPositionState state]);
   external JSVoid setMicrophoneActive(JSBoolean active);
   external JSVoid setCameraActive(JSBoolean active);
+  external set metadata(MediaMetadata? value);
+  external MediaMetadata? get metadata;
+  external set playbackState(MediaSessionPlaybackState value);
+  external MediaSessionPlaybackState get playbackState;
 }
 
 @JS('MediaMetadata')
 @staticInterop
 class MediaMetadata {
-  external factory MediaMetadata();
-
-  external factory MediaMetadata.a1();
-
-  external factory MediaMetadata.a2(MediaMetadataInit init);
+  external factory MediaMetadata([MediaMetadataInit init]);
 }
 
 extension MediaMetadataExtension on MediaMetadata {

--- a/lib/src/dom/mediastream_recording.dart
+++ b/lib/src/dom/mediastream_recording.dart
@@ -19,20 +19,21 @@ typedef RecordingState = JSString;
 
 @JS('MediaRecorder')
 @staticInterop
-class MediaRecorder extends EventTarget {
-  external factory MediaRecorder();
-
-  external factory MediaRecorder.a1(MediaStream stream);
-
-  external factory MediaRecorder.a2(
-    MediaStream stream,
+class MediaRecorder implements EventTarget {
+  external factory MediaRecorder(
+    MediaStream stream, [
     MediaRecorderOptions options,
-  );
+  ]);
 
   external static JSBoolean isTypeSupported(JSString type);
 }
 
 extension MediaRecorderExtension on MediaRecorder {
+  external JSVoid start([JSNumber timeslice]);
+  external JSVoid stop();
+  external JSVoid pause();
+  external JSVoid resume();
+  external JSVoid requestData();
   external MediaStream get stream;
   external JSString get mimeType;
   external RecordingState get state;
@@ -51,12 +52,6 @@ extension MediaRecorderExtension on MediaRecorder {
   external JSNumber get videoBitsPerSecond;
   external JSNumber get audioBitsPerSecond;
   external BitrateMode get audioBitrateMode;
-  external JSVoid start();
-  external JSVoid start1(JSNumber timeslice);
-  external JSVoid stop();
-  external JSVoid pause();
-  external JSVoid resume();
-  external JSVoid requestData();
 }
 
 @JS()
@@ -87,10 +82,8 @@ extension MediaRecorderOptionsExtension on MediaRecorderOptions {
 
 @JS('BlobEvent')
 @staticInterop
-class BlobEvent extends Event {
-  external factory BlobEvent();
-
-  external factory BlobEvent.a1(
+class BlobEvent implements Event {
+  external factory BlobEvent(
     JSString type,
     BlobEventInit eventInitDict,
   );

--- a/lib/src/dom/model_element.dart
+++ b/lib/src/dom/model_element.dart
@@ -12,6 +12,4 @@ import 'html.dart';
 
 @JS('HTMLModelElement')
 @staticInterop
-class HTMLModelElement extends HTMLElement {
-  external factory HTMLModelElement();
-}
+class HTMLModelElement implements HTMLElement {}

--- a/lib/src/dom/navigation_api.dart
+++ b/lib/src/dom/navigation_api.dart
@@ -20,34 +20,27 @@ typedef NavigationType = JSString;
 
 @JS('Navigation')
 @staticInterop
-class Navigation extends EventTarget {
-  external factory Navigation();
-}
+class Navigation implements EventTarget {}
 
 extension NavigationExtension on Navigation {
   external JSArray entries();
-  external NavigationHistoryEntry? get currentEntry;
   external JSVoid updateCurrentEntry(
       NavigationUpdateCurrentEntryOptions options);
+  external NavigationResult navigate(
+    JSString url, [
+    NavigationNavigateOptions options,
+  ]);
+  external NavigationResult reload([NavigationReloadOptions options]);
+  external NavigationResult traverseTo(
+    JSString key, [
+    NavigationOptions options,
+  ]);
+  external NavigationResult back([NavigationOptions options]);
+  external NavigationResult forward([NavigationOptions options]);
+  external NavigationHistoryEntry? get currentEntry;
   external NavigationTransition? get transition;
   external JSBoolean get canGoBack;
   external JSBoolean get canGoForward;
-  external NavigationResult navigate(JSString url);
-  external NavigationResult navigate1(
-    JSString url,
-    NavigationNavigateOptions options,
-  );
-  external NavigationResult reload();
-  external NavigationResult reload1(NavigationReloadOptions options);
-  external NavigationResult traverseTo(JSString key);
-  external NavigationResult traverseTo1(
-    JSString key,
-    NavigationOptions options,
-  );
-  external NavigationResult back();
-  external NavigationResult back1(NavigationOptions options);
-  external NavigationResult forward();
-  external NavigationResult forward1(NavigationOptions options);
   external set onnavigate(EventHandler value);
   external EventHandler get onnavigate;
   external set onnavigatesuccess(EventHandler value);
@@ -86,7 +79,7 @@ extension NavigationOptionsExtension on NavigationOptions {
 @JS()
 @staticInterop
 @anonymous
-class NavigationNavigateOptions extends NavigationOptions {
+class NavigationNavigateOptions implements NavigationOptions {
   external factory NavigationNavigateOptions({
     JSAny state,
     NavigationHistoryBehavior history = 'auto',
@@ -103,7 +96,7 @@ extension NavigationNavigateOptionsExtension on NavigationNavigateOptions {
 @JS()
 @staticInterop
 @anonymous
-class NavigationReloadOptions extends NavigationOptions {
+class NavigationReloadOptions implements NavigationOptions {
   external factory NavigationReloadOptions({JSAny state});
 }
 
@@ -131,10 +124,8 @@ extension NavigationResultExtension on NavigationResult {
 
 @JS('NavigationCurrentEntryChangeEvent')
 @staticInterop
-class NavigationCurrentEntryChangeEvent extends Event {
-  external factory NavigationCurrentEntryChangeEvent();
-
-  external factory NavigationCurrentEntryChangeEvent.a1(
+class NavigationCurrentEntryChangeEvent implements Event {
+  external factory NavigationCurrentEntryChangeEvent(
     JSString type,
     NavigationCurrentEntryChangeEventInit eventInit,
   );
@@ -149,7 +140,7 @@ extension NavigationCurrentEntryChangeEventExtension
 @JS()
 @staticInterop
 @anonymous
-class NavigationCurrentEntryChangeEventInit extends EventInit {
+class NavigationCurrentEntryChangeEventInit implements EventInit {
   external factory NavigationCurrentEntryChangeEventInit({
     NavigationType? navigationType,
     required NavigationHistoryEntry destination,
@@ -166,9 +157,7 @@ extension NavigationCurrentEntryChangeEventInitExtension
 
 @JS('NavigationTransition')
 @staticInterop
-class NavigationTransition {
-  external factory NavigationTransition();
-}
+class NavigationTransition {}
 
 extension NavigationTransitionExtension on NavigationTransition {
   external NavigationType get navigationType;
@@ -178,16 +167,16 @@ extension NavigationTransitionExtension on NavigationTransition {
 
 @JS('NavigateEvent')
 @staticInterop
-class NavigateEvent extends Event {
-  external factory NavigateEvent();
-
-  external factory NavigateEvent.a1(
+class NavigateEvent implements Event {
+  external factory NavigateEvent(
     JSString type,
     NavigateEventInit eventInit,
   );
 }
 
 extension NavigateEventExtension on NavigateEvent {
+  external JSVoid intercept([NavigationInterceptOptions options]);
+  external JSVoid scroll();
   external NavigationType get navigationType;
   external NavigationDestination get destination;
   external JSBoolean get canIntercept;
@@ -197,15 +186,12 @@ extension NavigateEventExtension on NavigateEvent {
   external FormData? get formData;
   external JSString? get downloadRequest;
   external JSAny get info;
-  external JSVoid intercept();
-  external JSVoid intercept1(NavigationInterceptOptions options);
-  external JSVoid scroll();
 }
 
 @JS()
 @staticInterop
 @anonymous
-class NavigateEventInit extends EventInit {
+class NavigateEventInit implements EventInit {
   external factory NavigateEventInit({
     NavigationType navigationType = 'push',
     required NavigationDestination destination,
@@ -262,32 +248,28 @@ extension NavigationInterceptOptionsExtension on NavigationInterceptOptions {
 
 @JS('NavigationDestination')
 @staticInterop
-class NavigationDestination {
-  external factory NavigationDestination();
-}
+class NavigationDestination {}
 
 extension NavigationDestinationExtension on NavigationDestination {
+  external JSAny getState();
   external JSString get url;
   external JSString? get key;
   external JSString? get id;
   external JSNumber get index;
   external JSBoolean get sameDocument;
-  external JSAny getState();
 }
 
 @JS('NavigationHistoryEntry')
 @staticInterop
-class NavigationHistoryEntry extends EventTarget {
-  external factory NavigationHistoryEntry();
-}
+class NavigationHistoryEntry implements EventTarget {}
 
 extension NavigationHistoryEntryExtension on NavigationHistoryEntry {
+  external JSAny getState();
   external JSString? get url;
   external JSString get key;
   external JSString get id;
   external JSNumber get index;
   external JSBoolean get sameDocument;
-  external JSAny getState();
   external set ondispose(EventHandler value);
   external EventHandler get ondispose;
 }

--- a/lib/src/dom/navigation_timing.dart
+++ b/lib/src/dom/navigation_timing.dart
@@ -15,11 +15,10 @@ typedef NavigationTimingType = JSString;
 
 @JS('PerformanceNavigationTiming')
 @staticInterop
-class PerformanceNavigationTiming extends PerformanceResourceTiming {
-  external factory PerformanceNavigationTiming();
-}
+class PerformanceNavigationTiming implements PerformanceResourceTiming {}
 
 extension PerformanceNavigationTimingExtension on PerformanceNavigationTiming {
+  external JSObject toJSON();
   external DOMHighResTimeStamp get unloadEventStart;
   external DOMHighResTimeStamp get unloadEventEnd;
   external DOMHighResTimeStamp get domInteractive;
@@ -30,17 +29,15 @@ extension PerformanceNavigationTimingExtension on PerformanceNavigationTiming {
   external DOMHighResTimeStamp get loadEventEnd;
   external NavigationTimingType get type;
   external JSNumber get redirectCount;
-  external JSObject toJSON();
   external DOMHighResTimeStamp get activationStart;
 }
 
 @JS('PerformanceTiming')
 @staticInterop
-class PerformanceTiming {
-  external factory PerformanceTiming();
-}
+class PerformanceTiming {}
 
 extension PerformanceTimingExtension on PerformanceTiming {
+  external JSObject toJSON();
   external JSNumber get navigationStart;
   external JSNumber get unloadEventStart;
   external JSNumber get unloadEventEnd;
@@ -62,14 +59,11 @@ extension PerformanceTimingExtension on PerformanceTiming {
   external JSNumber get domComplete;
   external JSNumber get loadEventStart;
   external JSNumber get loadEventEnd;
-  external JSObject toJSON();
 }
 
 @JS('PerformanceNavigation')
 @staticInterop
 class PerformanceNavigation {
-  external factory PerformanceNavigation();
-
   external static JSNumber get TYPE_NAVIGATE;
   external static JSNumber get TYPE_RELOAD;
   external static JSNumber get TYPE_BACK_FORWARD;
@@ -77,7 +71,7 @@ class PerformanceNavigation {
 }
 
 extension PerformanceNavigationExtension on PerformanceNavigation {
+  external JSObject toJSON();
   external JSNumber get type;
   external JSNumber get redirectCount;
-  external JSObject toJSON();
 }

--- a/lib/src/dom/netinfo.dart
+++ b/lib/src/dom/netinfo.dart
@@ -19,9 +19,7 @@ typedef EffectiveConnectionType = JSString;
 
 @JS('NavigatorNetworkInformation')
 @staticInterop
-class NavigatorNetworkInformation {
-  external factory NavigatorNetworkInformation();
-}
+class NavigatorNetworkInformation {}
 
 extension NavigatorNetworkInformationExtension on NavigatorNetworkInformation {
   external NetworkInformation get connection;
@@ -29,10 +27,7 @@ extension NavigatorNetworkInformationExtension on NavigatorNetworkInformation {
 
 @JS('NetworkInformation')
 @staticInterop
-class NetworkInformation extends EventTarget
-    implements NetworkInformationSaveData {
-  external factory NetworkInformation();
-}
+class NetworkInformation implements EventTarget, NetworkInformationSaveData {}
 
 extension NetworkInformationExtension on NetworkInformation {
   external ConnectionType get type;

--- a/lib/src/dom/notifications.dart
+++ b/lib/src/dom/notifications.dart
@@ -20,24 +20,20 @@ typedef NotificationDirection = JSString;
 
 @JS('Notification')
 @staticInterop
-class Notification extends EventTarget {
-  external factory Notification();
-
-  external factory Notification.a1(JSString title);
-
-  external factory Notification.a2(
-    JSString title,
+class Notification implements EventTarget {
+  external factory Notification(
+    JSString title, [
     NotificationOptions options,
-  );
+  ]);
 
+  external static JSPromise requestPermission(
+      [NotificationPermissionCallback deprecatedCallback]);
   external static NotificationPermission get permission;
-  external static JSPromise requestPermission();
-  external static JSPromise requestPermission1(
-      NotificationPermissionCallback deprecatedCallback);
   external static JSNumber get maxActions;
 }
 
 extension NotificationExtension on Notification {
+  external JSVoid close();
   external set onclick(EventHandler value);
   external EventHandler get onclick;
   external set onshow(EventHandler value);
@@ -61,7 +57,6 @@ extension NotificationExtension on Notification {
   external JSBoolean get requireInteraction;
   external JSAny get data;
   external JSArray get actions;
-  external JSVoid close();
 }
 
 @JS()
@@ -151,10 +146,8 @@ extension GetNotificationOptionsExtension on GetNotificationOptions {
 
 @JS('NotificationEvent')
 @staticInterop
-class NotificationEvent extends ExtendableEvent {
-  external factory NotificationEvent();
-
-  external factory NotificationEvent.a1(
+class NotificationEvent implements ExtendableEvent {
+  external factory NotificationEvent(
     JSString type,
     NotificationEventInit eventInitDict,
   );
@@ -168,7 +161,7 @@ extension NotificationEventExtension on NotificationEvent {
 @JS()
 @staticInterop
 @anonymous
-class NotificationEventInit extends ExtendableEventInit {
+class NotificationEventInit implements ExtendableEventInit {
   external factory NotificationEventInit({
     required Notification notification,
     JSString action = '',

--- a/lib/src/dom/oes_draw_buffers_indexed.dart
+++ b/lib/src/dom/oes_draw_buffers_indexed.dart
@@ -12,9 +12,7 @@ import 'webgl1.dart';
 
 @JS('OES_draw_buffers_indexed')
 @staticInterop
-class OES_draw_buffers_indexed {
-  external factory OES_draw_buffers_indexed();
-}
+class OES_draw_buffers_indexed {}
 
 extension OESDrawBuffersIndexedExtension on OES_draw_buffers_indexed {
   external JSVoid enableiOES(

--- a/lib/src/dom/oes_element_index_uint.dart
+++ b/lib/src/dom/oes_element_index_uint.dart
@@ -10,6 +10,4 @@ import 'package:js/js.dart' hide JS;
 
 @JS('OES_element_index_uint')
 @staticInterop
-class OES_element_index_uint {
-  external factory OES_element_index_uint();
-}
+class OES_element_index_uint {}

--- a/lib/src/dom/oes_fbo_render_mipmap.dart
+++ b/lib/src/dom/oes_fbo_render_mipmap.dart
@@ -10,6 +10,4 @@ import 'package:js/js.dart' hide JS;
 
 @JS('OES_fbo_render_mipmap')
 @staticInterop
-class OES_fbo_render_mipmap {
-  external factory OES_fbo_render_mipmap();
-}
+class OES_fbo_render_mipmap {}

--- a/lib/src/dom/oes_standard_derivatives.dart
+++ b/lib/src/dom/oes_standard_derivatives.dart
@@ -13,7 +13,5 @@ import 'webgl1.dart';
 @JS('OES_standard_derivatives')
 @staticInterop
 class OES_standard_derivatives {
-  external factory OES_standard_derivatives();
-
   external static GLenum get FRAGMENT_SHADER_DERIVATIVE_HINT_OES;
 }

--- a/lib/src/dom/oes_texture_float.dart
+++ b/lib/src/dom/oes_texture_float.dart
@@ -10,6 +10,4 @@ import 'package:js/js.dart' hide JS;
 
 @JS('OES_texture_float')
 @staticInterop
-class OES_texture_float {
-  external factory OES_texture_float();
-}
+class OES_texture_float {}

--- a/lib/src/dom/oes_texture_float_linear.dart
+++ b/lib/src/dom/oes_texture_float_linear.dart
@@ -10,6 +10,4 @@ import 'package:js/js.dart' hide JS;
 
 @JS('OES_texture_float_linear')
 @staticInterop
-class OES_texture_float_linear {
-  external factory OES_texture_float_linear();
-}
+class OES_texture_float_linear {}

--- a/lib/src/dom/oes_texture_half_float.dart
+++ b/lib/src/dom/oes_texture_half_float.dart
@@ -13,7 +13,5 @@ import 'webgl1.dart';
 @JS('OES_texture_half_float')
 @staticInterop
 class OES_texture_half_float {
-  external factory OES_texture_half_float();
-
   external static GLenum get HALF_FLOAT_OES;
 }

--- a/lib/src/dom/oes_texture_half_float_linear.dart
+++ b/lib/src/dom/oes_texture_half_float_linear.dart
@@ -10,6 +10,4 @@ import 'package:js/js.dart' hide JS;
 
 @JS('OES_texture_half_float_linear')
 @staticInterop
-class OES_texture_half_float_linear {
-  external factory OES_texture_half_float_linear();
-}
+class OES_texture_half_float_linear {}

--- a/lib/src/dom/oes_vertex_array_object.dart
+++ b/lib/src/dom/oes_vertex_array_object.dart
@@ -12,15 +12,11 @@ import 'webgl1.dart';
 
 @JS('WebGLVertexArrayObjectOES')
 @staticInterop
-class WebGLVertexArrayObjectOES extends WebGLObject {
-  external factory WebGLVertexArrayObjectOES();
-}
+class WebGLVertexArrayObjectOES implements WebGLObject {}
 
 @JS('OES_vertex_array_object')
 @staticInterop
 class OES_vertex_array_object {
-  external factory OES_vertex_array_object();
-
   external static GLenum get VERTEX_ARRAY_BINDING_OES;
 }
 

--- a/lib/src/dom/orientation_event.dart
+++ b/lib/src/dom/orientation_event.dart
@@ -12,15 +12,11 @@ import 'dom.dart';
 
 @JS('DeviceOrientationEvent')
 @staticInterop
-class DeviceOrientationEvent extends Event {
-  external factory DeviceOrientationEvent();
-
-  external factory DeviceOrientationEvent.a1(JSString type);
-
-  external factory DeviceOrientationEvent.a2(
-    JSString type,
+class DeviceOrientationEvent implements Event {
+  external factory DeviceOrientationEvent(
+    JSString type, [
     DeviceOrientationEventInit eventInitDict,
-  );
+  ]);
 
   external static JSPromise requestPermission();
 }
@@ -35,7 +31,7 @@ extension DeviceOrientationEventExtension on DeviceOrientationEvent {
 @JS()
 @staticInterop
 @anonymous
-class DeviceOrientationEventInit extends EventInit {
+class DeviceOrientationEventInit implements EventInit {
   external factory DeviceOrientationEventInit({
     JSNumber? alpha,
     JSNumber? beta,
@@ -57,9 +53,7 @@ extension DeviceOrientationEventInitExtension on DeviceOrientationEventInit {
 
 @JS('DeviceMotionEventAcceleration')
 @staticInterop
-class DeviceMotionEventAcceleration {
-  external factory DeviceMotionEventAcceleration();
-}
+class DeviceMotionEventAcceleration {}
 
 extension DeviceMotionEventAccelerationExtension
     on DeviceMotionEventAcceleration {
@@ -70,9 +64,7 @@ extension DeviceMotionEventAccelerationExtension
 
 @JS('DeviceMotionEventRotationRate')
 @staticInterop
-class DeviceMotionEventRotationRate {
-  external factory DeviceMotionEventRotationRate();
-}
+class DeviceMotionEventRotationRate {}
 
 extension DeviceMotionEventRotationRateExtension
     on DeviceMotionEventRotationRate {
@@ -83,15 +75,11 @@ extension DeviceMotionEventRotationRateExtension
 
 @JS('DeviceMotionEvent')
 @staticInterop
-class DeviceMotionEvent extends Event {
-  external factory DeviceMotionEvent();
-
-  external factory DeviceMotionEvent.a1(JSString type);
-
-  external factory DeviceMotionEvent.a2(
-    JSString type,
+class DeviceMotionEvent implements Event {
+  external factory DeviceMotionEvent(
+    JSString type, [
     DeviceMotionEventInit eventInitDict,
-  );
+  ]);
 
   external static JSPromise requestPermission();
 }
@@ -148,7 +136,7 @@ extension DeviceMotionEventRotationRateInitExtension
 @JS()
 @staticInterop
 @anonymous
-class DeviceMotionEventInit extends EventInit {
+class DeviceMotionEventInit implements EventInit {
   external factory DeviceMotionEventInit({
     DeviceMotionEventAccelerationInit acceleration,
     DeviceMotionEventAccelerationInit accelerationIncludingGravity,

--- a/lib/src/dom/orientation_sensor.dart
+++ b/lib/src/dom/orientation_sensor.dart
@@ -15,19 +15,17 @@ typedef OrientationSensorLocalCoordinateSystem = JSString;
 
 @JS('OrientationSensor')
 @staticInterop
-class OrientationSensor extends Sensor {
-  external factory OrientationSensor();
-}
+class OrientationSensor implements Sensor {}
 
 extension OrientationSensorExtension on OrientationSensor {
-  external JSArray? get quaternion;
   external JSVoid populateMatrix(RotationMatrixType targetMatrix);
+  external JSArray? get quaternion;
 }
 
 @JS()
 @staticInterop
 @anonymous
-class OrientationSensorOptions extends SensorOptions {
+class OrientationSensorOptions implements SensorOptions {
   external factory OrientationSensorOptions(
       {OrientationSensorLocalCoordinateSystem referenceFrame = 'device'});
 }
@@ -39,24 +37,16 @@ extension OrientationSensorOptionsExtension on OrientationSensorOptions {
 
 @JS('AbsoluteOrientationSensor')
 @staticInterop
-class AbsoluteOrientationSensor extends OrientationSensor {
-  external factory AbsoluteOrientationSensor();
-
-  external factory AbsoluteOrientationSensor.a1();
-
-  external factory AbsoluteOrientationSensor.a2(
-      OrientationSensorOptions sensorOptions);
+class AbsoluteOrientationSensor implements OrientationSensor {
+  external factory AbsoluteOrientationSensor(
+      [OrientationSensorOptions sensorOptions]);
 }
 
 @JS('RelativeOrientationSensor')
 @staticInterop
-class RelativeOrientationSensor extends OrientationSensor {
-  external factory RelativeOrientationSensor();
-
-  external factory RelativeOrientationSensor.a1();
-
-  external factory RelativeOrientationSensor.a2(
-      OrientationSensorOptions sensorOptions);
+class RelativeOrientationSensor implements OrientationSensor {
+  external factory RelativeOrientationSensor(
+      [OrientationSensorOptions sensorOptions]);
 }
 
 @JS()
@@ -77,6 +67,6 @@ extension AbsoluteOrientationReadingValuesExtension
 @staticInterop
 @anonymous
 class RelativeOrientationReadingValues
-    extends AbsoluteOrientationReadingValues {
+    implements AbsoluteOrientationReadingValues {
   external factory RelativeOrientationReadingValues();
 }

--- a/lib/src/dom/ovr_multiview2.dart
+++ b/lib/src/dom/ovr_multiview2.dart
@@ -13,8 +13,6 @@ import 'webgl1.dart';
 @JS('OVR_multiview2')
 @staticInterop
 class OVR_multiview2 {
-  external factory OVR_multiview2();
-
   external static GLenum get FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR;
   external static GLenum get FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR;
   external static GLenum get MAX_VIEWS_OVR;

--- a/lib/src/dom/paint_timing.dart
+++ b/lib/src/dom/paint_timing.dart
@@ -12,6 +12,4 @@ import 'performance_timeline.dart';
 
 @JS('PerformancePaintTiming')
 @staticInterop
-class PerformancePaintTiming extends PerformanceEntry {
-  external factory PerformancePaintTiming();
-}
+class PerformancePaintTiming implements PerformanceEntry {}

--- a/lib/src/dom/payment_handler.dart
+++ b/lib/src/dom/payment_handler.dart
@@ -16,22 +16,18 @@ typedef PaymentShippingType = JSString;
 
 @JS('PaymentManager')
 @staticInterop
-class PaymentManager {
-  external factory PaymentManager();
-}
+class PaymentManager {}
 
 extension PaymentManagerExtension on PaymentManager {
+  external JSPromise enableDelegations(JSArray delegations);
   external set userHint(JSString value);
   external JSString get userHint;
-  external JSPromise enableDelegations(JSArray delegations);
 }
 
 @JS('CanMakePaymentEvent')
 @staticInterop
-class CanMakePaymentEvent extends ExtendableEvent {
-  external factory CanMakePaymentEvent();
-
-  external factory CanMakePaymentEvent.a1(JSString type);
+class CanMakePaymentEvent implements ExtendableEvent {
+  external factory CanMakePaymentEvent(JSString type);
 }
 
 extension CanMakePaymentEventExtension on CanMakePaymentEvent {
@@ -69,18 +65,22 @@ extension PaymentRequestDetailsUpdateExtension on PaymentRequestDetailsUpdate {
 
 @JS('PaymentRequestEvent')
 @staticInterop
-class PaymentRequestEvent extends ExtendableEvent {
-  external factory PaymentRequestEvent();
-
-  external factory PaymentRequestEvent.a1(JSString type);
-
-  external factory PaymentRequestEvent.a2(
-    JSString type,
+class PaymentRequestEvent implements ExtendableEvent {
+  external factory PaymentRequestEvent(
+    JSString type, [
     PaymentRequestEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension PaymentRequestEventExtension on PaymentRequestEvent {
+  external JSPromise openWindow(JSString url);
+  external JSPromise changePaymentMethod(
+    JSString methodName, [
+    JSObject? methodDetails,
+  ]);
+  external JSPromise changeShippingAddress([AddressInit shippingAddress]);
+  external JSPromise changeShippingOption(JSString shippingOption);
+  external JSVoid respondWith(JSPromise handlerResponsePromise);
   external JSString get topOrigin;
   external JSString get paymentRequestOrigin;
   external JSString get paymentRequestId;
@@ -89,22 +89,12 @@ extension PaymentRequestEventExtension on PaymentRequestEvent {
   external JSArray get modifiers;
   external JSObject? get paymentOptions;
   external JSArray? get shippingOptions;
-  external JSPromise openWindow(JSString url);
-  external JSPromise changePaymentMethod(JSString methodName);
-  external JSPromise changePaymentMethod1(
-    JSString methodName,
-    JSObject? methodDetails,
-  );
-  external JSPromise changeShippingAddress();
-  external JSPromise changeShippingAddress1(AddressInit shippingAddress);
-  external JSPromise changeShippingOption(JSString shippingOption);
-  external JSVoid respondWith(JSPromise handlerResponsePromise);
 }
 
 @JS()
 @staticInterop
 @anonymous
-class PaymentRequestEventInit extends ExtendableEventInit {
+class PaymentRequestEventInit implements ExtendableEventInit {
   external factory PaymentRequestEventInit({
     JSString topOrigin,
     JSString paymentRequestOrigin,

--- a/lib/src/dom/payment_request.dart
+++ b/lib/src/dom/payment_request.dart
@@ -15,18 +15,15 @@ typedef PaymentComplete = JSString;
 
 @JS('PaymentRequest')
 @staticInterop
-class PaymentRequest extends EventTarget {
-  external factory PaymentRequest();
-
-  external factory PaymentRequest.a1(
+class PaymentRequest implements EventTarget {
+  external factory PaymentRequest(
     JSArray methodData,
     PaymentDetailsInit details,
   );
 }
 
 extension PaymentRequestExtension on PaymentRequest {
-  external JSPromise show();
-  external JSPromise show1(JSPromise detailsPromise);
+  external JSPromise show([JSPromise detailsPromise]);
   external JSPromise abort();
   external JSPromise canMakePayment();
   external JSString get id;
@@ -88,7 +85,7 @@ extension PaymentDetailsBaseExtension on PaymentDetailsBase {
 @JS()
 @staticInterop
 @anonymous
-class PaymentDetailsInit extends PaymentDetailsBase {
+class PaymentDetailsInit implements PaymentDetailsBase {
   external factory PaymentDetailsInit({
     JSString id,
     required PaymentItem total,
@@ -105,7 +102,7 @@ extension PaymentDetailsInitExtension on PaymentDetailsInit {
 @JS()
 @staticInterop
 @anonymous
-class PaymentDetailsUpdate extends PaymentDetailsBase {
+class PaymentDetailsUpdate implements PaymentDetailsBase {
   external factory PaymentDetailsUpdate({
     PaymentItem total,
     JSObject paymentMethodErrors,
@@ -176,23 +173,18 @@ extension PaymentCompleteDetailsExtension on PaymentCompleteDetails {
 
 @JS('PaymentResponse')
 @staticInterop
-class PaymentResponse extends EventTarget {
-  external factory PaymentResponse();
-}
+class PaymentResponse implements EventTarget {}
 
 extension PaymentResponseExtension on PaymentResponse {
   external JSObject toJSON();
+  external JSPromise complete([
+    PaymentComplete result,
+    PaymentCompleteDetails details,
+  ]);
+  external JSPromise retry([PaymentValidationErrors errorFields]);
   external JSString get requestId;
   external JSString get methodName;
   external JSObject get details;
-  external JSPromise complete();
-  external JSPromise complete1(PaymentComplete result);
-  external JSPromise complete2(
-    PaymentComplete result,
-    PaymentCompleteDetails details,
-  );
-  external JSPromise retry();
-  external JSPromise retry1(PaymentValidationErrors errorFields);
 }
 
 @JS()
@@ -214,15 +206,11 @@ extension PaymentValidationErrorsExtension on PaymentValidationErrors {
 
 @JS('PaymentMethodChangeEvent')
 @staticInterop
-class PaymentMethodChangeEvent extends PaymentRequestUpdateEvent {
-  external factory PaymentMethodChangeEvent();
-
-  external factory PaymentMethodChangeEvent.a1(JSString type);
-
-  external factory PaymentMethodChangeEvent.a2(
-    JSString type,
+class PaymentMethodChangeEvent implements PaymentRequestUpdateEvent {
+  external factory PaymentMethodChangeEvent(
+    JSString type, [
     PaymentMethodChangeEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension PaymentMethodChangeEventExtension on PaymentMethodChangeEvent {
@@ -233,7 +221,7 @@ extension PaymentMethodChangeEventExtension on PaymentMethodChangeEvent {
 @JS()
 @staticInterop
 @anonymous
-class PaymentMethodChangeEventInit extends PaymentRequestUpdateEventInit {
+class PaymentMethodChangeEventInit implements PaymentRequestUpdateEventInit {
   external factory PaymentMethodChangeEventInit({
     JSString methodName = '',
     JSObject? methodDetails,
@@ -250,15 +238,11 @@ extension PaymentMethodChangeEventInitExtension
 
 @JS('PaymentRequestUpdateEvent')
 @staticInterop
-class PaymentRequestUpdateEvent extends Event {
-  external factory PaymentRequestUpdateEvent();
-
-  external factory PaymentRequestUpdateEvent.a1(JSString type);
-
-  external factory PaymentRequestUpdateEvent.a2(
-    JSString type,
+class PaymentRequestUpdateEvent implements Event {
+  external factory PaymentRequestUpdateEvent(
+    JSString type, [
     PaymentRequestUpdateEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension PaymentRequestUpdateEventExtension on PaymentRequestUpdateEvent {
@@ -268,6 +252,6 @@ extension PaymentRequestUpdateEventExtension on PaymentRequestUpdateEvent {
 @JS()
 @staticInterop
 @anonymous
-class PaymentRequestUpdateEventInit extends EventInit {
+class PaymentRequestUpdateEventInit implements EventInit {
   external factory PaymentRequestUpdateEventInit();
 }

--- a/lib/src/dom/performance_timeline.dart
+++ b/lib/src/dom/performance_timeline.dart
@@ -15,31 +15,26 @@ typedef PerformanceObserverCallback = JSFunction;
 
 @JS('PerformanceEntry')
 @staticInterop
-class PerformanceEntry {
-  external factory PerformanceEntry();
-}
+class PerformanceEntry {}
 
 extension PerformanceEntryExtension on PerformanceEntry {
+  external JSObject toJSON();
   external JSString get name;
   external JSString get entryType;
   external DOMHighResTimeStamp get startTime;
   external DOMHighResTimeStamp get duration;
-  external JSObject toJSON();
 }
 
 @JS('PerformanceObserver')
 @staticInterop
 class PerformanceObserver {
-  external factory PerformanceObserver();
-
-  external factory PerformanceObserver.a1(PerformanceObserverCallback callback);
+  external factory PerformanceObserver(PerformanceObserverCallback callback);
 
   external static JSArray get supportedEntryTypes;
 }
 
 extension PerformanceObserverExtension on PerformanceObserver {
-  external JSVoid observe();
-  external JSVoid observe1(PerformanceObserverInit options);
+  external JSVoid observe([PerformanceObserverInit options]);
   external JSVoid disconnect();
   external PerformanceEntryList takeRecords();
 }
@@ -83,17 +78,14 @@ extension PerformanceObserverInitExtension on PerformanceObserverInit {
 
 @JS('PerformanceObserverEntryList')
 @staticInterop
-class PerformanceObserverEntryList {
-  external factory PerformanceObserverEntryList();
-}
+class PerformanceObserverEntryList {}
 
 extension PerformanceObserverEntryListExtension
     on PerformanceObserverEntryList {
   external PerformanceEntryList getEntries();
   external PerformanceEntryList getEntriesByType(JSString type);
-  external PerformanceEntryList getEntriesByName(JSString name);
-  external PerformanceEntryList getEntriesByName1(
-    JSString name,
+  external PerformanceEntryList getEntriesByName(
+    JSString name, [
     JSString type,
-  );
+  ]);
 }

--- a/lib/src/dom/periodic_background_sync.dart
+++ b/lib/src/dom/periodic_background_sync.dart
@@ -12,16 +12,13 @@ import 'service_workers.dart';
 
 @JS('PeriodicSyncManager')
 @staticInterop
-class PeriodicSyncManager {
-  external factory PeriodicSyncManager();
-}
+class PeriodicSyncManager {}
 
 extension PeriodicSyncManagerExtension on PeriodicSyncManager {
-  external JSPromise register(JSString tag);
-  external JSPromise register1(
-    JSString tag,
+  external JSPromise register(
+    JSString tag, [
     BackgroundSyncOptions options,
-  );
+  ]);
   external JSPromise getTags();
   external JSPromise unregister(JSString tag);
 }
@@ -41,7 +38,7 @@ extension BackgroundSyncOptionsExtension on BackgroundSyncOptions {
 @JS()
 @staticInterop
 @anonymous
-class PeriodicSyncEventInit extends ExtendableEventInit {
+class PeriodicSyncEventInit implements ExtendableEventInit {
   external factory PeriodicSyncEventInit({required JSString tag});
 }
 
@@ -52,10 +49,8 @@ extension PeriodicSyncEventInitExtension on PeriodicSyncEventInit {
 
 @JS('PeriodicSyncEvent')
 @staticInterop
-class PeriodicSyncEvent extends ExtendableEvent {
-  external factory PeriodicSyncEvent();
-
-  external factory PeriodicSyncEvent.a1(
+class PeriodicSyncEvent implements ExtendableEvent {
+  external factory PeriodicSyncEvent(
     JSString type,
     PeriodicSyncEventInit init,
   );

--- a/lib/src/dom/permissions.dart
+++ b/lib/src/dom/permissions.dart
@@ -15,9 +15,7 @@ typedef PermissionState = JSString;
 
 @JS('Permissions')
 @staticInterop
-class Permissions {
-  external factory Permissions();
-}
+class Permissions {}
 
 extension PermissionsExtension on Permissions {
   external JSPromise request(JSObject permissionDesc);
@@ -39,9 +37,7 @@ extension PermissionDescriptorExtension on PermissionDescriptor {
 
 @JS('PermissionStatus')
 @staticInterop
-class PermissionStatus extends EventTarget {
-  external factory PermissionStatus();
-}
+class PermissionStatus implements EventTarget {}
 
 extension PermissionStatusExtension on PermissionStatus {
   external PermissionState get state;

--- a/lib/src/dom/permissions_policy.dart
+++ b/lib/src/dom/permissions_policy.dart
@@ -12,16 +12,13 @@ import 'reporting.dart';
 
 @JS('PermissionsPolicy')
 @staticInterop
-class PermissionsPolicy {
-  external factory PermissionsPolicy();
-}
+class PermissionsPolicy {}
 
 extension PermissionsPolicyExtension on PermissionsPolicy {
-  external JSBoolean allowsFeature(JSString feature);
-  external JSBoolean allowsFeature1(
-    JSString feature,
+  external JSBoolean allowsFeature(
+    JSString feature, [
     JSString origin,
-  );
+  ]);
   external JSArray features();
   external JSArray allowedFeatures();
   external JSArray getAllowlistForFeature(JSString feature);
@@ -29,9 +26,7 @@ extension PermissionsPolicyExtension on PermissionsPolicy {
 
 @JS('PermissionsPolicyViolationReportBody')
 @staticInterop
-class PermissionsPolicyViolationReportBody extends ReportBody {
-  external factory PermissionsPolicyViolationReportBody();
-}
+class PermissionsPolicyViolationReportBody implements ReportBody {}
 
 extension PermissionsPolicyViolationReportBodyExtension
     on PermissionsPolicyViolationReportBody {

--- a/lib/src/dom/picture_in_picture.dart
+++ b/lib/src/dom/picture_in_picture.dart
@@ -13,9 +13,7 @@ import 'html.dart';
 
 @JS('PictureInPictureWindow')
 @staticInterop
-class PictureInPictureWindow extends EventTarget {
-  external factory PictureInPictureWindow();
-}
+class PictureInPictureWindow implements EventTarget {}
 
 extension PictureInPictureWindowExtension on PictureInPictureWindow {
   external JSNumber get width;
@@ -26,10 +24,8 @@ extension PictureInPictureWindowExtension on PictureInPictureWindow {
 
 @JS('PictureInPictureEvent')
 @staticInterop
-class PictureInPictureEvent extends Event {
-  external factory PictureInPictureEvent();
-
-  external factory PictureInPictureEvent.a1(
+class PictureInPictureEvent implements Event {
+  external factory PictureInPictureEvent(
     JSString type,
     PictureInPictureEventInit eventInitDict,
   );
@@ -42,7 +38,7 @@ extension PictureInPictureEventExtension on PictureInPictureEvent {
 @JS()
 @staticInterop
 @anonymous
-class PictureInPictureEventInit extends EventInit {
+class PictureInPictureEventInit implements EventInit {
   external factory PictureInPictureEventInit(
       {required PictureInPictureWindow pictureInPictureWindow});
 }

--- a/lib/src/dom/pointerevents.dart
+++ b/lib/src/dom/pointerevents.dart
@@ -13,7 +13,7 @@ import 'uievents.dart';
 @JS()
 @staticInterop
 @anonymous
-class PointerEventInit extends MouseEventInit {
+class PointerEventInit implements MouseEventInit {
   external factory PointerEventInit({
     JSNumber pointerId = 0,
     JSNumber width = 1,
@@ -65,18 +65,16 @@ extension PointerEventInitExtension on PointerEventInit {
 
 @JS('PointerEvent')
 @staticInterop
-class PointerEvent extends MouseEvent {
-  external factory PointerEvent();
-
-  external factory PointerEvent.a1(JSString type);
-
-  external factory PointerEvent.a2(
-    JSString type,
+class PointerEvent implements MouseEvent {
+  external factory PointerEvent(
+    JSString type, [
     PointerEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension PointerEventExtension on PointerEvent {
+  external JSArray getCoalescedEvents();
+  external JSArray getPredictedEvents();
   external JSNumber get pointerId;
   external JSNumber get width;
   external JSNumber get height;
@@ -89,6 +87,4 @@ extension PointerEventExtension on PointerEvent {
   external JSNumber get azimuthAngle;
   external JSString get pointerType;
   external JSBoolean get isPrimary;
-  external JSArray getCoalescedEvents();
-  external JSArray getPredictedEvents();
 }

--- a/lib/src/dom/portals.dart
+++ b/lib/src/dom/portals.dart
@@ -13,22 +13,20 @@ import 'html.dart';
 
 @JS('HTMLPortalElement')
 @staticInterop
-class HTMLPortalElement extends HTMLElement {
-  external factory HTMLPortalElement.a0();
+class HTMLPortalElement implements HTMLElement {
+  external factory HTMLPortalElement();
 }
 
 extension HTMLPortalElementExtension on HTMLPortalElement {
+  external JSPromise activate([PortalActivateOptions options]);
+  external JSVoid postMessage(
+    JSAny message, [
+    StructuredSerializeOptions options,
+  ]);
   external set src(JSString value);
   external JSString get src;
   external set referrerPolicy(JSString value);
   external JSString get referrerPolicy;
-  external JSPromise activate();
-  external JSPromise activate1(PortalActivateOptions options);
-  external JSVoid postMessage(JSAny message);
-  external JSVoid postMessage1(
-    JSAny message,
-    StructuredSerializeOptions options,
-  );
   external set onmessage(EventHandler value);
   external EventHandler get onmessage;
   external set onmessageerror(EventHandler value);
@@ -38,7 +36,7 @@ extension HTMLPortalElementExtension on HTMLPortalElement {
 @JS()
 @staticInterop
 @anonymous
-class PortalActivateOptions extends StructuredSerializeOptions {
+class PortalActivateOptions implements StructuredSerializeOptions {
   external factory PortalActivateOptions({JSAny data});
 }
 
@@ -49,16 +47,13 @@ extension PortalActivateOptionsExtension on PortalActivateOptions {
 
 @JS('PortalHost')
 @staticInterop
-class PortalHost extends EventTarget {
-  external factory PortalHost();
-}
+class PortalHost implements EventTarget {}
 
 extension PortalHostExtension on PortalHost {
-  external JSVoid postMessage(JSAny message);
-  external JSVoid postMessage1(
-    JSAny message,
+  external JSVoid postMessage(
+    JSAny message, [
     StructuredSerializeOptions options,
-  );
+  ]);
   external set onmessage(EventHandler value);
   external EventHandler get onmessage;
   external set onmessageerror(EventHandler value);
@@ -67,26 +62,22 @@ extension PortalHostExtension on PortalHost {
 
 @JS('PortalActivateEvent')
 @staticInterop
-class PortalActivateEvent extends Event {
-  external factory PortalActivateEvent();
-
-  external factory PortalActivateEvent.a1(JSString type);
-
-  external factory PortalActivateEvent.a2(
-    JSString type,
+class PortalActivateEvent implements Event {
+  external factory PortalActivateEvent(
+    JSString type, [
     PortalActivateEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension PortalActivateEventExtension on PortalActivateEvent {
-  external JSAny get data;
   external HTMLPortalElement adoptPredecessor();
+  external JSAny get data;
 }
 
 @JS()
 @staticInterop
 @anonymous
-class PortalActivateEventInit extends EventInit {
+class PortalActivateEventInit implements EventInit {
   external factory PortalActivateEventInit({JSAny data});
 }
 

--- a/lib/src/dom/presentation_api.dart
+++ b/lib/src/dom/presentation_api.dart
@@ -9,9 +9,7 @@ import 'dart:js_interop';
 import 'package:js/js.dart' hide JS;
 
 import 'dom.dart';
-import 'fileapi.dart';
 import 'html.dart';
-import 'webidl.dart';
 import 'websockets.dart';
 
 typedef PresentationConnectionState = JSString;
@@ -19,9 +17,7 @@ typedef PresentationConnectionCloseReason = JSString;
 
 @JS('Presentation')
 @staticInterop
-class Presentation {
-  external factory Presentation();
-}
+class Presentation {}
 
 extension PresentationExtension on Presentation {
   external set defaultRequest(PresentationRequest? value);
@@ -31,12 +27,8 @@ extension PresentationExtension on Presentation {
 
 @JS('PresentationRequest')
 @staticInterop
-class PresentationRequest extends EventTarget {
-  external factory PresentationRequest();
-
-  external factory PresentationRequest.a1(JSString url);
-
-  external factory PresentationRequest.a2(JSArray urls);
+class PresentationRequest implements EventTarget {
+  external factory PresentationRequest(JSAny urlOrUrls);
 }
 
 extension PresentationRequestExtension on PresentationRequest {
@@ -49,9 +41,7 @@ extension PresentationRequestExtension on PresentationRequest {
 
 @JS('PresentationAvailability')
 @staticInterop
-class PresentationAvailability extends EventTarget {
-  external factory PresentationAvailability();
-}
+class PresentationAvailability implements EventTarget {}
 
 extension PresentationAvailabilityExtension on PresentationAvailability {
   external JSBoolean get value;
@@ -61,10 +51,8 @@ extension PresentationAvailabilityExtension on PresentationAvailability {
 
 @JS('PresentationConnectionAvailableEvent')
 @staticInterop
-class PresentationConnectionAvailableEvent extends Event {
-  external factory PresentationConnectionAvailableEvent();
-
-  external factory PresentationConnectionAvailableEvent.a1(
+class PresentationConnectionAvailableEvent implements Event {
+  external factory PresentationConnectionAvailableEvent(
     JSString type,
     PresentationConnectionAvailableEventInit eventInitDict,
   );
@@ -78,7 +66,7 @@ extension PresentationConnectionAvailableEventExtension
 @JS()
 @staticInterop
 @anonymous
-class PresentationConnectionAvailableEventInit extends EventInit {
+class PresentationConnectionAvailableEventInit implements EventInit {
   external factory PresentationConnectionAvailableEventInit(
       {required PresentationConnection connection});
 }
@@ -91,16 +79,15 @@ extension PresentationConnectionAvailableEventInitExtension
 
 @JS('PresentationConnection')
 @staticInterop
-class PresentationConnection extends EventTarget {
-  external factory PresentationConnection();
-}
+class PresentationConnection implements EventTarget {}
 
 extension PresentationConnectionExtension on PresentationConnection {
+  external JSVoid close();
+  external JSVoid terminate();
+  external JSVoid send(JSAny dataOrMessage);
   external JSString get id;
   external JSString get url;
   external PresentationConnectionState get state;
-  external JSVoid close();
-  external JSVoid terminate();
   external set onconnect(EventHandler value);
   external EventHandler get onconnect;
   external set onclose(EventHandler value);
@@ -111,21 +98,12 @@ extension PresentationConnectionExtension on PresentationConnection {
   external BinaryType get binaryType;
   external set onmessage(EventHandler value);
   external EventHandler get onmessage;
-  external JSVoid send(JSString message);
-  @JS('send')
-  external JSVoid send_1_(Blob data);
-  @JS('send')
-  external JSVoid send_2_(JSArrayBuffer data);
-  @JS('send')
-  external JSVoid send_3_(ArrayBufferView data);
 }
 
 @JS('PresentationConnectionCloseEvent')
 @staticInterop
-class PresentationConnectionCloseEvent extends Event {
-  external factory PresentationConnectionCloseEvent();
-
-  external factory PresentationConnectionCloseEvent.a1(
+class PresentationConnectionCloseEvent implements Event {
+  external factory PresentationConnectionCloseEvent(
     JSString type,
     PresentationConnectionCloseEventInit eventInitDict,
   );
@@ -140,7 +118,7 @@ extension PresentationConnectionCloseEventExtension
 @JS()
 @staticInterop
 @anonymous
-class PresentationConnectionCloseEventInit extends EventInit {
+class PresentationConnectionCloseEventInit implements EventInit {
   external factory PresentationConnectionCloseEventInit({
     required PresentationConnectionCloseReason reason,
     JSString message = '',
@@ -157,9 +135,7 @@ extension PresentationConnectionCloseEventInitExtension
 
 @JS('PresentationReceiver')
 @staticInterop
-class PresentationReceiver {
-  external factory PresentationReceiver();
-}
+class PresentationReceiver {}
 
 extension PresentationReceiverExtension on PresentationReceiver {
   external JSPromise get connectionList;
@@ -167,9 +143,7 @@ extension PresentationReceiverExtension on PresentationReceiver {
 
 @JS('PresentationConnectionList')
 @staticInterop
-class PresentationConnectionList extends EventTarget {
-  external factory PresentationConnectionList();
-}
+class PresentationConnectionList implements EventTarget {}
 
 extension PresentationConnectionListExtension on PresentationConnectionList {
   external JSArray get connections;

--- a/lib/src/dom/proximity.dart
+++ b/lib/src/dom/proximity.dart
@@ -12,12 +12,8 @@ import 'generic_sensor.dart';
 
 @JS('ProximitySensor')
 @staticInterop
-class ProximitySensor extends Sensor {
-  external factory ProximitySensor();
-
-  external factory ProximitySensor.a1();
-
-  external factory ProximitySensor.a2(SensorOptions sensorOptions);
+class ProximitySensor implements Sensor {
+  external factory ProximitySensor([SensorOptions sensorOptions]);
 }
 
 extension ProximitySensorExtension on ProximitySensor {

--- a/lib/src/dom/push_api.dart
+++ b/lib/src/dom/push_api.dart
@@ -19,7 +19,7 @@ typedef PushEncryptionKeyName = JSString;
 @JS()
 @staticInterop
 @anonymous
-class PushPermissionDescriptor extends PermissionDescriptor {
+class PushPermissionDescriptor implements PermissionDescriptor {
   external factory PushPermissionDescriptor(
       {JSBoolean userVisibleOnly = false});
 }
@@ -32,24 +32,18 @@ extension PushPermissionDescriptorExtension on PushPermissionDescriptor {
 @JS('PushManager')
 @staticInterop
 class PushManager {
-  external factory PushManager();
-
   external static JSArray get supportedContentEncodings;
 }
 
 extension PushManagerExtension on PushManager {
-  external JSPromise subscribe();
-  external JSPromise subscribe1(PushSubscriptionOptionsInit options);
+  external JSPromise subscribe([PushSubscriptionOptionsInit options]);
   external JSPromise getSubscription();
-  external JSPromise permissionState();
-  external JSPromise permissionState1(PushSubscriptionOptionsInit options);
+  external JSPromise permissionState([PushSubscriptionOptionsInit options]);
 }
 
 @JS('PushSubscriptionOptions')
 @staticInterop
-class PushSubscriptionOptions {
-  external factory PushSubscriptionOptions();
-}
+class PushSubscriptionOptions {}
 
 extension PushSubscriptionOptionsExtension on PushSubscriptionOptions {
   external JSBoolean get userVisibleOnly;
@@ -75,17 +69,15 @@ extension PushSubscriptionOptionsInitExtension on PushSubscriptionOptionsInit {
 
 @JS('PushSubscription')
 @staticInterop
-class PushSubscription {
-  external factory PushSubscription();
-}
+class PushSubscription {}
 
 extension PushSubscriptionExtension on PushSubscription {
-  external JSString get endpoint;
-  external EpochTimeStamp? get expirationTime;
-  external PushSubscriptionOptions get options;
   external JSArrayBuffer? getKey(PushEncryptionKeyName name);
   external JSPromise unsubscribe();
   external PushSubscriptionJSON toJSON();
+  external JSString get endpoint;
+  external EpochTimeStamp? get expirationTime;
+  external PushSubscriptionOptions get options;
 }
 
 @JS()
@@ -110,9 +102,7 @@ extension PushSubscriptionJSONExtension on PushSubscriptionJSON {
 
 @JS('PushMessageData')
 @staticInterop
-class PushMessageData {
-  external factory PushMessageData();
-}
+class PushMessageData {}
 
 extension PushMessageDataExtension on PushMessageData {
   external JSArrayBuffer arrayBuffer();
@@ -123,15 +113,11 @@ extension PushMessageDataExtension on PushMessageData {
 
 @JS('PushEvent')
 @staticInterop
-class PushEvent extends ExtendableEvent {
-  external factory PushEvent();
-
-  external factory PushEvent.a1(JSString type);
-
-  external factory PushEvent.a2(
-    JSString type,
+class PushEvent implements ExtendableEvent {
+  external factory PushEvent(
+    JSString type, [
     PushEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension PushEventExtension on PushEvent {
@@ -141,7 +127,7 @@ extension PushEventExtension on PushEvent {
 @JS()
 @staticInterop
 @anonymous
-class PushEventInit extends ExtendableEventInit {
+class PushEventInit implements ExtendableEventInit {
   external factory PushEventInit({PushMessageDataInit data});
 }
 
@@ -152,15 +138,11 @@ extension PushEventInitExtension on PushEventInit {
 
 @JS('PushSubscriptionChangeEvent')
 @staticInterop
-class PushSubscriptionChangeEvent extends ExtendableEvent {
-  external factory PushSubscriptionChangeEvent();
-
-  external factory PushSubscriptionChangeEvent.a1(JSString type);
-
-  external factory PushSubscriptionChangeEvent.a2(
-    JSString type,
+class PushSubscriptionChangeEvent implements ExtendableEvent {
+  external factory PushSubscriptionChangeEvent(
+    JSString type, [
     PushSubscriptionChangeEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension PushSubscriptionChangeEventExtension on PushSubscriptionChangeEvent {
@@ -171,7 +153,7 @@ extension PushSubscriptionChangeEventExtension on PushSubscriptionChangeEvent {
 @JS()
 @staticInterop
 @anonymous
-class PushSubscriptionChangeEventInit extends ExtendableEventInit {
+class PushSubscriptionChangeEventInit implements ExtendableEventInit {
   external factory PushSubscriptionChangeEventInit({
     PushSubscription newSubscription,
     PushSubscription oldSubscription,

--- a/lib/src/dom/raw_camera_access.dart
+++ b/lib/src/dom/raw_camera_access.dart
@@ -10,9 +10,7 @@ import 'package:js/js.dart' hide JS;
 
 @JS('XRCamera')
 @staticInterop
-class XRCamera {
-  external factory XRCamera();
-}
+class XRCamera {}
 
 extension XRCameraExtension on XRCamera {
   external JSNumber get width;

--- a/lib/src/dom/remote_playback.dart
+++ b/lib/src/dom/remote_playback.dart
@@ -16,15 +16,13 @@ typedef RemotePlaybackState = JSString;
 
 @JS('RemotePlayback')
 @staticInterop
-class RemotePlayback extends EventTarget {
-  external factory RemotePlayback();
-}
+class RemotePlayback implements EventTarget {}
 
 extension RemotePlaybackExtension on RemotePlayback {
   external JSPromise watchAvailability(
       RemotePlaybackAvailabilityCallback callback);
-  external JSPromise cancelWatchAvailability();
-  external JSPromise cancelWatchAvailability1(JSNumber id);
+  external JSPromise cancelWatchAvailability([JSNumber id]);
+  external JSPromise prompt();
   external RemotePlaybackState get state;
   external set onconnecting(EventHandler value);
   external EventHandler get onconnecting;
@@ -32,5 +30,4 @@ extension RemotePlaybackExtension on RemotePlayback {
   external EventHandler get onconnect;
   external set ondisconnect(EventHandler value);
   external EventHandler get ondisconnect;
-  external JSPromise prompt();
 }

--- a/lib/src/dom/reporting.dart
+++ b/lib/src/dom/reporting.dart
@@ -13,9 +13,7 @@ typedef ReportingObserverCallback = JSFunction;
 
 @JS('ReportBody')
 @staticInterop
-class ReportBody {
-  external factory ReportBody();
-}
+class ReportBody {}
 
 extension ReportBodyExtension on ReportBody {
   external JSObject toJSON();
@@ -23,9 +21,7 @@ extension ReportBodyExtension on ReportBody {
 
 @JS('Report')
 @staticInterop
-class Report {
-  external factory Report();
-}
+class Report {}
 
 extension ReportExtension on Report {
   external JSObject toJSON();
@@ -37,14 +33,10 @@ extension ReportExtension on Report {
 @JS('ReportingObserver')
 @staticInterop
 class ReportingObserver {
-  external factory ReportingObserver();
-
-  external factory ReportingObserver.a1(ReportingObserverCallback callback);
-
-  external factory ReportingObserver.a2(
-    ReportingObserverCallback callback,
+  external factory ReportingObserver(
+    ReportingObserverCallback callback, [
     ReportingObserverOptions options,
-  );
+  ]);
 }
 
 extension ReportingObserverExtension on ReportingObserver {

--- a/lib/src/dom/requestidlecallback.dart
+++ b/lib/src/dom/requestidlecallback.dart
@@ -26,9 +26,7 @@ extension IdleRequestOptionsExtension on IdleRequestOptions {
 
 @JS('IdleDeadline')
 @staticInterop
-class IdleDeadline {
-  external factory IdleDeadline();
-}
+class IdleDeadline {}
 
 extension IdleDeadlineExtension on IdleDeadline {
   external DOMHighResTimeStamp timeRemaining();

--- a/lib/src/dom/requeststorageaccessfororigin.dart
+++ b/lib/src/dom/requeststorageaccessfororigin.dart
@@ -13,7 +13,8 @@ import 'permissions.dart';
 @JS()
 @staticInterop
 @anonymous
-class TopLevelStorageAccessPermissionDescriptor extends PermissionDescriptor {
+class TopLevelStorageAccessPermissionDescriptor
+    implements PermissionDescriptor {
   external factory TopLevelStorageAccessPermissionDescriptor(
       {JSString requestedOrigin = ''});
 }

--- a/lib/src/dom/resize_observer.dart
+++ b/lib/src/dom/resize_observer.dart
@@ -30,26 +30,21 @@ extension ResizeObserverOptionsExtension on ResizeObserverOptions {
 @JS('ResizeObserver')
 @staticInterop
 class ResizeObserver {
-  external factory ResizeObserver();
-
-  external factory ResizeObserver.a1(ResizeObserverCallback callback);
+  external factory ResizeObserver(ResizeObserverCallback callback);
 }
 
 extension ResizeObserverExtension on ResizeObserver {
-  external JSVoid observe(Element target);
-  external JSVoid observe1(
-    Element target,
+  external JSVoid observe(
+    Element target, [
     ResizeObserverOptions options,
-  );
+  ]);
   external JSVoid unobserve(Element target);
   external JSVoid disconnect();
 }
 
 @JS('ResizeObserverEntry')
 @staticInterop
-class ResizeObserverEntry {
-  external factory ResizeObserverEntry();
-}
+class ResizeObserverEntry {}
 
 extension ResizeObserverEntryExtension on ResizeObserverEntry {
   external Element get target;
@@ -61,9 +56,7 @@ extension ResizeObserverEntryExtension on ResizeObserverEntry {
 
 @JS('ResizeObserverSize')
 @staticInterop
-class ResizeObserverSize {
-  external factory ResizeObserverSize();
-}
+class ResizeObserverSize {}
 
 extension ResizeObserverSizeExtension on ResizeObserverSize {
   external JSNumber get inlineSize;

--- a/lib/src/dom/resource_timing.dart
+++ b/lib/src/dom/resource_timing.dart
@@ -15,11 +15,10 @@ typedef RenderBlockingStatusType = JSString;
 
 @JS('PerformanceResourceTiming')
 @staticInterop
-class PerformanceResourceTiming extends PerformanceEntry {
-  external factory PerformanceResourceTiming();
-}
+class PerformanceResourceTiming implements PerformanceEntry {}
 
 extension PerformanceResourceTimingExtension on PerformanceResourceTiming {
+  external JSObject toJSON();
   external JSString get initiatorType;
   external JSString get nextHopProtocol;
   external DOMHighResTimeStamp get workerStart;
@@ -39,6 +38,5 @@ extension PerformanceResourceTimingExtension on PerformanceResourceTiming {
   external JSNumber get decodedBodySize;
   external JSNumber get responseStatus;
   external RenderBlockingStatusType get renderBlockingStatus;
-  external JSObject toJSON();
   external JSArray get serverTiming;
 }

--- a/lib/src/dom/sanitizer_api.dart
+++ b/lib/src/dom/sanitizer_api.dart
@@ -15,11 +15,7 @@ typedef AttributeMatchList = JSAny;
 @JS('Sanitizer')
 @staticInterop
 class Sanitizer {
-  external factory Sanitizer();
-
-  external factory Sanitizer.a1();
-
-  external factory Sanitizer.a2(SanitizerConfig config);
+  external factory Sanitizer([SanitizerConfig config]);
 
   external static SanitizerConfig getDefaultConfiguration();
 }

--- a/lib/src/dom/savedata.dart
+++ b/lib/src/dom/savedata.dart
@@ -10,9 +10,7 @@ import 'package:js/js.dart' hide JS;
 
 @JS('NetworkInformationSaveData')
 @staticInterop
-class NetworkInformationSaveData {
-  external factory NetworkInformationSaveData();
-}
+class NetworkInformationSaveData {}
 
 extension NetworkInformationSaveDataExtension on NetworkInformationSaveData {
   external JSBoolean get saveData;

--- a/lib/src/dom/scheduling_apis.dart
+++ b/lib/src/dom/scheduling_apis.dart
@@ -36,24 +36,19 @@ extension SchedulerPostTaskOptionsExtension on SchedulerPostTaskOptions {
 
 @JS('Scheduler')
 @staticInterop
-class Scheduler {
-  external factory Scheduler();
-}
+class Scheduler {}
 
 extension SchedulerExtension on Scheduler {
-  external JSPromise postTask(SchedulerPostTaskCallback callback);
-  external JSPromise postTask1(
-    SchedulerPostTaskCallback callback,
+  external JSPromise postTask(
+    SchedulerPostTaskCallback callback, [
     SchedulerPostTaskOptions options,
-  );
+  ]);
 }
 
 @JS('TaskPriorityChangeEvent')
 @staticInterop
-class TaskPriorityChangeEvent extends Event {
-  external factory TaskPriorityChangeEvent();
-
-  external factory TaskPriorityChangeEvent.a1(
+class TaskPriorityChangeEvent implements Event {
+  external factory TaskPriorityChangeEvent(
     JSString type,
     TaskPriorityChangeEventInit priorityChangeEventInitDict,
   );
@@ -66,7 +61,7 @@ extension TaskPriorityChangeEventExtension on TaskPriorityChangeEvent {
 @JS()
 @staticInterop
 @anonymous
-class TaskPriorityChangeEventInit extends EventInit {
+class TaskPriorityChangeEventInit implements EventInit {
   external factory TaskPriorityChangeEventInit(
       {required TaskPriority previousPriority});
 }
@@ -90,12 +85,8 @@ extension TaskControllerInitExtension on TaskControllerInit {
 
 @JS('TaskController')
 @staticInterop
-class TaskController extends AbortController {
-  external factory TaskController();
-
-  external factory TaskController.a1();
-
-  external factory TaskController.a2(TaskControllerInit init);
+class TaskController implements AbortController {
+  external factory TaskController([TaskControllerInit init]);
 }
 
 extension TaskControllerExtension on TaskController {
@@ -104,9 +95,7 @@ extension TaskControllerExtension on TaskController {
 
 @JS('TaskSignal')
 @staticInterop
-class TaskSignal extends AbortSignal {
-  external factory TaskSignal();
-}
+class TaskSignal implements AbortSignal {}
 
 extension TaskSignalExtension on TaskSignal {
   external TaskPriority get priority;

--- a/lib/src/dom/screen_capture.dart
+++ b/lib/src/dom/screen_capture.dart
@@ -18,7 +18,7 @@ typedef CursorCaptureConstraint = JSString;
 @JS('CaptureController')
 @staticInterop
 class CaptureController {
-  external factory CaptureController.a0();
+  external factory CaptureController();
 }
 
 extension CaptureControllerExtension on CaptureController {

--- a/lib/src/dom/screen_orientation.dart
+++ b/lib/src/dom/screen_orientation.dart
@@ -16,9 +16,7 @@ typedef OrientationType = JSString;
 
 @JS('ScreenOrientation')
 @staticInterop
-class ScreenOrientation extends EventTarget {
-  external factory ScreenOrientation();
-}
+class ScreenOrientation implements EventTarget {}
 
 extension ScreenOrientationExtension on ScreenOrientation {
   external JSPromise lock(OrientationLockType orientation);

--- a/lib/src/dom/screen_wake_lock.dart
+++ b/lib/src/dom/screen_wake_lock.dart
@@ -15,25 +15,20 @@ typedef WakeLockType = JSString;
 
 @JS('WakeLock')
 @staticInterop
-class WakeLock {
-  external factory WakeLock();
-}
+class WakeLock {}
 
 extension WakeLockExtension on WakeLock {
-  external JSPromise request();
-  external JSPromise request1(WakeLockType type);
+  external JSPromise request([WakeLockType type]);
 }
 
 @JS('WakeLockSentinel')
 @staticInterop
-class WakeLockSentinel extends EventTarget {
-  external factory WakeLockSentinel();
-}
+class WakeLockSentinel implements EventTarget {}
 
 extension WakeLockSentinelExtension on WakeLockSentinel {
+  external JSPromise release();
   external JSBoolean get released;
   external WakeLockType get type;
-  external JSPromise release();
   external set onrelease(EventHandler value);
   external EventHandler get onrelease;
 }

--- a/lib/src/dom/scroll_animations.dart
+++ b/lib/src/dom/scroll_animations.dart
@@ -33,12 +33,8 @@ extension ScrollTimelineOptionsExtension on ScrollTimelineOptions {
 
 @JS('ScrollTimeline')
 @staticInterop
-class ScrollTimeline extends AnimationTimeline {
-  external factory ScrollTimeline();
-
-  external factory ScrollTimeline.a1();
-
-  external factory ScrollTimeline.a2(ScrollTimelineOptions options);
+class ScrollTimeline implements AnimationTimeline {
+  external factory ScrollTimeline([ScrollTimelineOptions options]);
 }
 
 extension ScrollTimelineExtension on ScrollTimeline {
@@ -65,12 +61,8 @@ extension ViewTimelineOptionsExtension on ViewTimelineOptions {
 
 @JS('ViewTimeline')
 @staticInterop
-class ViewTimeline extends ScrollTimeline {
-  external factory ViewTimeline();
-
-  external factory ViewTimeline.a1();
-
-  external factory ViewTimeline.a2(ViewTimelineOptions options);
+class ViewTimeline implements ScrollTimeline {
+  external factory ViewTimeline([ViewTimelineOptions options]);
 }
 
 extension ViewTimelineExtension on ViewTimeline {

--- a/lib/src/dom/scroll_to_text_fragment.dart
+++ b/lib/src/dom/scroll_to_text_fragment.dart
@@ -10,6 +10,4 @@ import 'package:js/js.dart' hide JS;
 
 @JS('FragmentDirective')
 @staticInterop
-class FragmentDirective {
-  external factory FragmentDirective();
-}
+class FragmentDirective {}

--- a/lib/src/dom/secure_payment_confirmation.dart
+++ b/lib/src/dom/secure_payment_confirmation.dart
@@ -90,7 +90,7 @@ extension AuthenticationExtensionsPaymentInputsExtension
 @JS()
 @staticInterop
 @anonymous
-class CollectedClientPaymentData extends CollectedClientData {
+class CollectedClientPaymentData implements CollectedClientData {
   external factory CollectedClientPaymentData(
       {required CollectedClientAdditionalPaymentData payment});
 }

--- a/lib/src/dom/selection_api.dart
+++ b/lib/src/dom/selection_api.dart
@@ -12,41 +12,29 @@ import 'dom.dart';
 
 @JS('Selection')
 @staticInterop
-class Selection {
-  external factory Selection();
-}
+class Selection {}
 
 extension SelectionExtension on Selection {
-  external Node? get anchorNode;
-  external JSNumber get anchorOffset;
-  external Node? get focusNode;
-  external JSNumber get focusOffset;
-  external JSBoolean get isCollapsed;
-  external JSNumber get rangeCount;
-  external JSString get type;
   external Range getRangeAt(JSNumber index);
   external JSVoid addRange(Range range);
   external JSVoid removeRange(Range range);
   external JSVoid removeAllRanges();
   external JSVoid empty();
   external StaticRange getComposedRange(ShadowRoot shadowRoots);
-  external JSVoid collapse(Node? node);
-  external JSVoid collapse1(
-    Node? node,
+  external JSVoid collapse(
+    Node? node, [
     JSNumber offset,
-  );
-  external JSVoid setPosition(Node? node);
-  external JSVoid setPosition1(
-    Node? node,
+  ]);
+  external JSVoid setPosition(
+    Node? node, [
     JSNumber offset,
-  );
+  ]);
   external JSVoid collapseToStart();
   external JSVoid collapseToEnd();
-  external JSVoid extend(Node node);
-  external JSVoid extend1(
-    Node node,
+  external JSVoid extend(
+    Node node, [
     JSNumber offset,
-  );
+  ]);
   external JSVoid setBaseAndExtent(
     Node anchorNode,
     JSNumber anchorOffset,
@@ -54,21 +42,21 @@ extension SelectionExtension on Selection {
     JSNumber focusOffset,
   );
   external JSVoid selectAllChildren(Node node);
-  external JSVoid modify();
-  external JSVoid modify1(JSString alter);
-  external JSVoid modify2(
-    JSString alter,
-    JSString direction,
-  );
-  external JSVoid modify3(
+  external JSVoid modify([
     JSString alter,
     JSString direction,
     JSString granularity,
-  );
+  ]);
   external JSVoid deleteFromDocument();
-  external JSBoolean containsNode(Node node);
-  external JSBoolean containsNode1(
-    Node node,
+  external JSBoolean containsNode(
+    Node node, [
     JSBoolean allowPartialContainment,
-  );
+  ]);
+  external Node? get anchorNode;
+  external JSNumber get anchorOffset;
+  external Node? get focusNode;
+  external JSNumber get focusOffset;
+  external JSBoolean get isCollapsed;
+  external JSNumber get rangeCount;
+  external JSString get type;
 }

--- a/lib/src/dom/serial.dart
+++ b/lib/src/dom/serial.dart
@@ -17,18 +17,15 @@ typedef FlowControlType = JSString;
 
 @JS('Serial')
 @staticInterop
-class Serial extends EventTarget {
-  external factory Serial();
-}
+class Serial implements EventTarget {}
 
 extension SerialExtension on Serial {
+  external JSPromise getPorts();
+  external JSPromise requestPort([SerialPortRequestOptions options]);
   external set onconnect(EventHandler value);
   external EventHandler get onconnect;
   external set ondisconnect(EventHandler value);
   external EventHandler get ondisconnect;
-  external JSPromise getPorts();
-  external JSPromise requestPort();
-  external JSPromise requestPort1(SerialPortRequestOptions options);
 }
 
 @JS()
@@ -62,24 +59,21 @@ extension SerialPortFilterExtension on SerialPortFilter {
 
 @JS('SerialPort')
 @staticInterop
-class SerialPort extends EventTarget {
-  external factory SerialPort();
-}
+class SerialPort implements EventTarget {}
 
 extension SerialPortExtension on SerialPort {
+  external SerialPortInfo getInfo();
+  external JSPromise open(SerialOptions options);
+  external JSPromise setSignals([SerialOutputSignals signals]);
+  external JSPromise getSignals();
+  external JSPromise close();
+  external JSPromise forget();
   external set onconnect(EventHandler value);
   external EventHandler get onconnect;
   external set ondisconnect(EventHandler value);
   external EventHandler get ondisconnect;
   external ReadableStream get readable;
   external WritableStream get writable;
-  external SerialPortInfo getInfo();
-  external JSPromise open(SerialOptions options);
-  external JSPromise setSignals();
-  external JSPromise setSignals1(SerialOutputSignals signals);
-  external JSPromise getSignals();
-  external JSPromise close();
-  external JSPromise forget();
 }
 
 @JS()
@@ -145,9 +139,9 @@ extension SerialOutputSignalsExtension on SerialOutputSignals {
   external set requestToSend(JSBoolean value);
   external JSBoolean get requestToSend;
   @JS('break')
-  external set break_0_(JSBoolean value);
+  external set break_(JSBoolean value);
   @JS('break')
-  external JSBoolean get break_0_;
+  external JSBoolean get break_;
 }
 
 @JS()

--- a/lib/src/dom/server_timing.dart
+++ b/lib/src/dom/server_timing.dart
@@ -12,13 +12,11 @@ import 'hr_time.dart';
 
 @JS('PerformanceServerTiming')
 @staticInterop
-class PerformanceServerTiming {
-  external factory PerformanceServerTiming();
-}
+class PerformanceServerTiming {}
 
 extension PerformanceServerTimingExtension on PerformanceServerTiming {
+  external JSObject toJSON();
   external JSString get name;
   external DOMHighResTimeStamp get duration;
   external JSString get description;
-  external JSObject toJSON();
 }

--- a/lib/src/dom/service_workers.dart
+++ b/lib/src/dom/service_workers.dart
@@ -28,46 +28,35 @@ typedef ClientType = JSString;
 
 @JS('ServiceWorker')
 @staticInterop
-class ServiceWorker extends EventTarget implements AbstractWorker {
-  external factory ServiceWorker();
-}
+class ServiceWorker implements EventTarget, AbstractWorker {}
 
 extension ServiceWorkerExtension on ServiceWorker {
+  external JSVoid postMessage(
+    JSAny message, [
+    JSAny optionsOrTransfer,
+  ]);
   external JSString get scriptURL;
   external ServiceWorkerState get state;
-  external JSVoid postMessage(
-    JSAny message,
-    JSArray transfer,
-  );
-  @JS('postMessage')
-  external JSVoid postMessage_1_(JSAny message);
-  @JS('postMessage')
-  external JSVoid postMessage_1_1(
-    JSAny message,
-    StructuredSerializeOptions options,
-  );
   external set onstatechange(EventHandler value);
   external EventHandler get onstatechange;
 }
 
 @JS('ServiceWorkerRegistration')
 @staticInterop
-class ServiceWorkerRegistration extends EventTarget {
-  external factory ServiceWorkerRegistration();
-}
+class ServiceWorkerRegistration implements EventTarget {}
 
 extension ServiceWorkerRegistrationExtension on ServiceWorkerRegistration {
+  external JSPromise showNotification(
+    JSString title, [
+    NotificationOptions options,
+  ]);
+  external JSPromise getNotifications([GetNotificationOptions filter]);
+  external JSPromise update();
+  external JSPromise unregister();
   external BackgroundFetchManager get backgroundFetch;
   external SyncManager get sync;
   external ContentIndex get index;
   external CookieStoreManager get cookies;
-  external JSPromise showNotification(JSString title);
-  external JSPromise showNotification1(
-    JSString title,
-    NotificationOptions options,
-  );
-  external JSPromise getNotifications();
-  external JSPromise getNotifications1(GetNotificationOptions filter);
   external PaymentManager get paymentManager;
   external PeriodicSyncManager get periodicSync;
   external PushManager get pushManager;
@@ -77,30 +66,24 @@ extension ServiceWorkerRegistrationExtension on ServiceWorkerRegistration {
   external NavigationPreloadManager get navigationPreload;
   external JSString get scope;
   external ServiceWorkerUpdateViaCache get updateViaCache;
-  external JSPromise update();
-  external JSPromise unregister();
   external set onupdatefound(EventHandler value);
   external EventHandler get onupdatefound;
 }
 
 @JS('ServiceWorkerContainer')
 @staticInterop
-class ServiceWorkerContainer extends EventTarget {
-  external factory ServiceWorkerContainer();
-}
+class ServiceWorkerContainer implements EventTarget {}
 
 extension ServiceWorkerContainerExtension on ServiceWorkerContainer {
-  external ServiceWorker? get controller;
-  external JSPromise get ready;
-  external JSPromise register(JSString scriptURL);
-  external JSPromise register1(
-    JSString scriptURL,
+  external JSPromise register(
+    JSString scriptURL, [
     RegistrationOptions options,
-  );
-  external JSPromise getRegistration();
-  external JSPromise getRegistration1(JSString clientURL);
+  ]);
+  external JSPromise getRegistration([JSString clientURL]);
   external JSPromise getRegistrations();
   external JSVoid startMessages();
+  external ServiceWorker? get controller;
+  external JSPromise get ready;
   external set oncontrollerchange(EventHandler value);
   external EventHandler get oncontrollerchange;
   external set onmessage(EventHandler value);
@@ -131,9 +114,7 @@ extension RegistrationOptionsExtension on RegistrationOptions {
 
 @JS('NavigationPreloadManager')
 @staticInterop
-class NavigationPreloadManager {
-  external factory NavigationPreloadManager();
-}
+class NavigationPreloadManager {}
 
 extension NavigationPreloadManagerExtension on NavigationPreloadManager {
   external JSPromise enable();
@@ -161,11 +142,10 @@ extension NavigationPreloadStateExtension on NavigationPreloadState {
 
 @JS('ServiceWorkerGlobalScope')
 @staticInterop
-class ServiceWorkerGlobalScope extends WorkerGlobalScope {
-  external factory ServiceWorkerGlobalScope();
-}
+class ServiceWorkerGlobalScope implements WorkerGlobalScope {}
 
 extension ServiceWorkerGlobalScopeExtension on ServiceWorkerGlobalScope {
+  external JSPromise skipWaiting();
   external set onbackgroundfetchsuccess(EventHandler value);
   external EventHandler get onbackgroundfetchsuccess;
   external set onbackgroundfetchfail(EventHandler value);
@@ -198,7 +178,6 @@ extension ServiceWorkerGlobalScopeExtension on ServiceWorkerGlobalScope {
   external Clients get clients;
   external ServiceWorkerRegistration get registration;
   external ServiceWorker get serviceWorker;
-  external JSPromise skipWaiting();
   external set oninstall(EventHandler value);
   external EventHandler get oninstall;
   external set onactivate(EventHandler value);
@@ -213,53 +192,39 @@ extension ServiceWorkerGlobalScopeExtension on ServiceWorkerGlobalScope {
 
 @JS('Client')
 @staticInterop
-class Client {
-  external factory Client();
-}
+class Client {}
 
 extension ClientExtension on Client {
+  external JSVoid postMessage(
+    JSAny message, [
+    JSAny optionsOrTransfer,
+  ]);
   external ClientLifecycleState get lifecycleState;
   external JSString get url;
   external FrameType get frameType;
   external JSString get id;
   external ClientType get type;
-  external JSVoid postMessage(
-    JSAny message,
-    JSArray transfer,
-  );
-  @JS('postMessage')
-  external JSVoid postMessage_1_(JSAny message);
-  @JS('postMessage')
-  external JSVoid postMessage_1_1(
-    JSAny message,
-    StructuredSerializeOptions options,
-  );
 }
 
 @JS('WindowClient')
 @staticInterop
-class WindowClient extends Client {
-  external factory WindowClient();
-}
+class WindowClient implements Client {}
 
 extension WindowClientExtension on WindowClient {
+  external JSPromise focus();
+  external JSPromise navigate(JSString url);
   external DocumentVisibilityState get visibilityState;
   external JSBoolean get focused;
   external JSArray get ancestorOrigins;
-  external JSPromise focus();
-  external JSPromise navigate(JSString url);
 }
 
 @JS('Clients')
 @staticInterop
-class Clients {
-  external factory Clients();
-}
+class Clients {}
 
 extension ClientsExtension on Clients {
   external JSPromise get(JSString id);
-  external JSPromise matchAll();
-  external JSPromise matchAll1(ClientQueryOptions options);
+  external JSPromise matchAll([ClientQueryOptions options]);
   external JSPromise openWindow(JSString url);
   external JSPromise claim();
 }
@@ -283,15 +248,11 @@ extension ClientQueryOptionsExtension on ClientQueryOptions {
 
 @JS('ExtendableEvent')
 @staticInterop
-class ExtendableEvent extends Event {
-  external factory ExtendableEvent();
-
-  external factory ExtendableEvent.a1(JSString type);
-
-  external factory ExtendableEvent.a2(
-    JSString type,
+class ExtendableEvent implements Event {
+  external factory ExtendableEvent(
+    JSString type, [
     ExtendableEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension ExtendableEventExtension on ExtendableEvent {
@@ -301,35 +262,33 @@ extension ExtendableEventExtension on ExtendableEvent {
 @JS()
 @staticInterop
 @anonymous
-class ExtendableEventInit extends EventInit {
+class ExtendableEventInit implements EventInit {
   external factory ExtendableEventInit();
 }
 
 @JS('FetchEvent')
 @staticInterop
-class FetchEvent extends ExtendableEvent {
-  external factory FetchEvent();
-
-  external factory FetchEvent.a1(
+class FetchEvent implements ExtendableEvent {
+  external factory FetchEvent(
     JSString type,
     FetchEventInit eventInitDict,
   );
 }
 
 extension FetchEventExtension on FetchEvent {
+  external JSVoid respondWith(JSPromise r);
   external Request get request;
   external JSPromise get preloadResponse;
   external JSString get clientId;
   external JSString get resultingClientId;
   external JSString get replacesClientId;
   external JSPromise get handled;
-  external JSVoid respondWith(JSPromise r);
 }
 
 @JS()
 @staticInterop
 @anonymous
-class FetchEventInit extends ExtendableEventInit {
+class FetchEventInit implements ExtendableEventInit {
   external factory FetchEventInit({
     required Request request,
     JSPromise preloadResponse,
@@ -357,15 +316,11 @@ extension FetchEventInitExtension on FetchEventInit {
 
 @JS('ExtendableMessageEvent')
 @staticInterop
-class ExtendableMessageEvent extends ExtendableEvent {
-  external factory ExtendableMessageEvent();
-
-  external factory ExtendableMessageEvent.a1(JSString type);
-
-  external factory ExtendableMessageEvent.a2(
-    JSString type,
+class ExtendableMessageEvent implements ExtendableEvent {
+  external factory ExtendableMessageEvent(
+    JSString type, [
     ExtendableMessageEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension ExtendableMessageEventExtension on ExtendableMessageEvent {
@@ -379,7 +334,7 @@ extension ExtendableMessageEventExtension on ExtendableMessageEvent {
 @JS()
 @staticInterop
 @anonymous
-class ExtendableMessageEventInit extends ExtendableEventInit {
+class ExtendableMessageEventInit implements ExtendableEventInit {
   external factory ExtendableMessageEventInit({
     JSAny data,
     JSString origin = '',
@@ -404,39 +359,31 @@ extension ExtendableMessageEventInitExtension on ExtendableMessageEventInit {
 
 @JS('Cache')
 @staticInterop
-class Cache {
-  external factory Cache();
-}
+class Cache {}
 
 extension CacheExtension on Cache {
-  external JSPromise match(RequestInfo request);
-  external JSPromise match1(
+  external JSPromise match(
+    RequestInfo request, [
+    CacheQueryOptions options,
+  ]);
+  external JSPromise matchAll([
     RequestInfo request,
     CacheQueryOptions options,
-  );
-  external JSPromise matchAll();
-  external JSPromise matchAll1(RequestInfo request);
-  external JSPromise matchAll2(
-    RequestInfo request,
-    CacheQueryOptions options,
-  );
+  ]);
   external JSPromise add(RequestInfo request);
   external JSPromise addAll(JSArray requests);
   external JSPromise put(
     RequestInfo request,
     Response response,
   );
-  external JSPromise delete(RequestInfo request);
-  external JSPromise delete1(
+  external JSPromise delete(
+    RequestInfo request, [
+    CacheQueryOptions options,
+  ]);
+  external JSPromise keys([
     RequestInfo request,
     CacheQueryOptions options,
-  );
-  external JSPromise keys();
-  external JSPromise keys1(RequestInfo request);
-  external JSPromise keys2(
-    RequestInfo request,
-    CacheQueryOptions options,
-  );
+  ]);
 }
 
 @JS()
@@ -461,16 +408,13 @@ extension CacheQueryOptionsExtension on CacheQueryOptions {
 
 @JS('CacheStorage')
 @staticInterop
-class CacheStorage {
-  external factory CacheStorage();
-}
+class CacheStorage {}
 
 extension CacheStorageExtension on CacheStorage {
-  external JSPromise match(RequestInfo request);
-  external JSPromise match1(
-    RequestInfo request,
+  external JSPromise match(
+    RequestInfo request, [
     MultiCacheQueryOptions options,
-  );
+  ]);
   external JSPromise has(JSString cacheName);
   external JSPromise open(JSString cacheName);
   external JSPromise delete(JSString cacheName);
@@ -480,7 +424,7 @@ extension CacheStorageExtension on CacheStorage {
 @JS()
 @staticInterop
 @anonymous
-class MultiCacheQueryOptions extends CacheQueryOptions {
+class MultiCacheQueryOptions implements CacheQueryOptions {
   external factory MultiCacheQueryOptions({JSString cacheName});
 }
 

--- a/lib/src/dom/shape_detection_api.dart
+++ b/lib/src/dom/shape_detection_api.dart
@@ -17,11 +17,7 @@ typedef BarcodeFormat = JSString;
 @JS('FaceDetector')
 @staticInterop
 class FaceDetector {
-  external factory FaceDetector();
-
-  external factory FaceDetector.a1();
-
-  external factory FaceDetector.a2(FaceDetectorOptions faceDetectorOptions);
+  external factory FaceDetector([FaceDetectorOptions faceDetectorOptions]);
 }
 
 extension FaceDetectorExtension on FaceDetector {
@@ -82,12 +78,8 @@ extension LandmarkExtension on Landmark {
 @JS('BarcodeDetector')
 @staticInterop
 class BarcodeDetector {
-  external factory BarcodeDetector();
-
-  external factory BarcodeDetector.a1();
-
-  external factory BarcodeDetector.a2(
-      BarcodeDetectorOptions barcodeDetectorOptions);
+  external factory BarcodeDetector(
+      [BarcodeDetectorOptions barcodeDetectorOptions]);
 
   external static JSPromise getSupportedFormats();
 }

--- a/lib/src/dom/speech_api.dart
+++ b/lib/src/dom/speech_api.dart
@@ -16,11 +16,14 @@ typedef SpeechSynthesisErrorCode = JSString;
 
 @JS('SpeechRecognition')
 @staticInterop
-class SpeechRecognition extends EventTarget {
-  external factory SpeechRecognition.a0();
+class SpeechRecognition implements EventTarget {
+  external factory SpeechRecognition();
 }
 
 extension SpeechRecognitionExtension on SpeechRecognition {
+  external JSVoid start();
+  external JSVoid stop();
+  external JSVoid abort();
   external set grammars(SpeechGrammarList value);
   external SpeechGrammarList get grammars;
   external set lang(JSString value);
@@ -31,9 +34,6 @@ extension SpeechRecognitionExtension on SpeechRecognition {
   external JSBoolean get interimResults;
   external set maxAlternatives(JSNumber value);
   external JSNumber get maxAlternatives;
-  external JSVoid start();
-  external JSVoid stop();
-  external JSVoid abort();
   external set onaudiostart(EventHandler value);
   external EventHandler get onaudiostart;
   external set onsoundstart(EventHandler value);
@@ -60,10 +60,8 @@ extension SpeechRecognitionExtension on SpeechRecognition {
 
 @JS('SpeechRecognitionErrorEvent')
 @staticInterop
-class SpeechRecognitionErrorEvent extends Event {
-  external factory SpeechRecognitionErrorEvent();
-
-  external factory SpeechRecognitionErrorEvent.a1(
+class SpeechRecognitionErrorEvent implements Event {
+  external factory SpeechRecognitionErrorEvent(
     JSString type,
     SpeechRecognitionErrorEventInit eventInitDict,
   );
@@ -77,7 +75,7 @@ extension SpeechRecognitionErrorEventExtension on SpeechRecognitionErrorEvent {
 @JS()
 @staticInterop
 @anonymous
-class SpeechRecognitionErrorEventInit extends EventInit {
+class SpeechRecognitionErrorEventInit implements EventInit {
   external factory SpeechRecognitionErrorEventInit({
     required SpeechRecognitionErrorCode error,
     JSString message = '',
@@ -94,9 +92,7 @@ extension SpeechRecognitionErrorEventInitExtension
 
 @JS('SpeechRecognitionAlternative')
 @staticInterop
-class SpeechRecognitionAlternative {
-  external factory SpeechRecognitionAlternative();
-}
+class SpeechRecognitionAlternative {}
 
 extension SpeechRecognitionAlternativeExtension
     on SpeechRecognitionAlternative {
@@ -106,33 +102,27 @@ extension SpeechRecognitionAlternativeExtension
 
 @JS('SpeechRecognitionResult')
 @staticInterop
-class SpeechRecognitionResult {
-  external factory SpeechRecognitionResult();
-}
+class SpeechRecognitionResult {}
 
 extension SpeechRecognitionResultExtension on SpeechRecognitionResult {
-  external JSNumber get length;
   external SpeechRecognitionAlternative item(JSNumber index);
+  external JSNumber get length;
   external JSBoolean get isFinal;
 }
 
 @JS('SpeechRecognitionResultList')
 @staticInterop
-class SpeechRecognitionResultList {
-  external factory SpeechRecognitionResultList();
-}
+class SpeechRecognitionResultList {}
 
 extension SpeechRecognitionResultListExtension on SpeechRecognitionResultList {
-  external JSNumber get length;
   external SpeechRecognitionResult item(JSNumber index);
+  external JSNumber get length;
 }
 
 @JS('SpeechRecognitionEvent')
 @staticInterop
-class SpeechRecognitionEvent extends Event {
-  external factory SpeechRecognitionEvent();
-
-  external factory SpeechRecognitionEvent.a1(
+class SpeechRecognitionEvent implements Event {
+  external factory SpeechRecognitionEvent(
     JSString type,
     SpeechRecognitionEventInit eventInitDict,
   );
@@ -146,7 +136,7 @@ extension SpeechRecognitionEventExtension on SpeechRecognitionEvent {
 @JS()
 @staticInterop
 @anonymous
-class SpeechRecognitionEventInit extends EventInit {
+class SpeechRecognitionEventInit implements EventInit {
   external factory SpeechRecognitionEventInit({
     JSNumber resultIndex = 0,
     required SpeechRecognitionResultList results,
@@ -162,9 +152,7 @@ extension SpeechRecognitionEventInitExtension on SpeechRecognitionEventInit {
 
 @JS('SpeechGrammar')
 @staticInterop
-class SpeechGrammar {
-  external factory SpeechGrammar();
-}
+class SpeechGrammar {}
 
 extension SpeechGrammarExtension on SpeechGrammar {
   external set src(JSString value);
@@ -176,51 +164,43 @@ extension SpeechGrammarExtension on SpeechGrammar {
 @JS('SpeechGrammarList')
 @staticInterop
 class SpeechGrammarList {
-  external factory SpeechGrammarList.a0();
+  external factory SpeechGrammarList();
 }
 
 extension SpeechGrammarListExtension on SpeechGrammarList {
-  external JSNumber get length;
   external SpeechGrammar item(JSNumber index);
-  external JSVoid addFromURI(JSString src);
-  external JSVoid addFromURI1(
-    JSString src,
+  external JSVoid addFromURI(
+    JSString src, [
     JSNumber weight,
-  );
-  external JSVoid addFromString(JSString string);
-  external JSVoid addFromString1(
-    JSString string,
+  ]);
+  external JSVoid addFromString(
+    JSString string, [
     JSNumber weight,
-  );
+  ]);
+  external JSNumber get length;
 }
 
 @JS('SpeechSynthesis')
 @staticInterop
-class SpeechSynthesis extends EventTarget {
-  external factory SpeechSynthesis();
-}
+class SpeechSynthesis implements EventTarget {}
 
 extension SpeechSynthesisExtension on SpeechSynthesis {
-  external JSBoolean get pending;
-  external JSBoolean get speaking;
-  external JSBoolean get paused;
-  external set onvoiceschanged(EventHandler value);
-  external EventHandler get onvoiceschanged;
   external JSVoid speak(SpeechSynthesisUtterance utterance);
   external JSVoid cancel();
   external JSVoid pause();
   external JSVoid resume();
   external JSArray getVoices();
+  external JSBoolean get pending;
+  external JSBoolean get speaking;
+  external JSBoolean get paused;
+  external set onvoiceschanged(EventHandler value);
+  external EventHandler get onvoiceschanged;
 }
 
 @JS('SpeechSynthesisUtterance')
 @staticInterop
-class SpeechSynthesisUtterance extends EventTarget {
-  external factory SpeechSynthesisUtterance();
-
-  external factory SpeechSynthesisUtterance.a1();
-
-  external factory SpeechSynthesisUtterance.a2(JSString text);
+class SpeechSynthesisUtterance implements EventTarget {
+  external factory SpeechSynthesisUtterance([JSString text]);
 }
 
 extension SpeechSynthesisUtteranceExtension on SpeechSynthesisUtterance {
@@ -254,10 +234,8 @@ extension SpeechSynthesisUtteranceExtension on SpeechSynthesisUtterance {
 
 @JS('SpeechSynthesisEvent')
 @staticInterop
-class SpeechSynthesisEvent extends Event {
-  external factory SpeechSynthesisEvent();
-
-  external factory SpeechSynthesisEvent.a1(
+class SpeechSynthesisEvent implements Event {
+  external factory SpeechSynthesisEvent(
     JSString type,
     SpeechSynthesisEventInit eventInitDict,
   );
@@ -274,7 +252,7 @@ extension SpeechSynthesisEventExtension on SpeechSynthesisEvent {
 @JS()
 @staticInterop
 @anonymous
-class SpeechSynthesisEventInit extends EventInit {
+class SpeechSynthesisEventInit implements EventInit {
   external factory SpeechSynthesisEventInit({
     required SpeechSynthesisUtterance utterance,
     JSNumber charIndex = 0,
@@ -299,10 +277,8 @@ extension SpeechSynthesisEventInitExtension on SpeechSynthesisEventInit {
 
 @JS('SpeechSynthesisErrorEvent')
 @staticInterop
-class SpeechSynthesisErrorEvent extends SpeechSynthesisEvent {
-  external factory SpeechSynthesisErrorEvent();
-
-  external factory SpeechSynthesisErrorEvent.a1(
+class SpeechSynthesisErrorEvent implements SpeechSynthesisEvent {
+  external factory SpeechSynthesisErrorEvent(
     JSString type,
     SpeechSynthesisErrorEventInit eventInitDict,
   );
@@ -315,7 +291,7 @@ extension SpeechSynthesisErrorEventExtension on SpeechSynthesisErrorEvent {
 @JS()
 @staticInterop
 @anonymous
-class SpeechSynthesisErrorEventInit extends SpeechSynthesisEventInit {
+class SpeechSynthesisErrorEventInit implements SpeechSynthesisEventInit {
   external factory SpeechSynthesisErrorEventInit(
       {required SpeechSynthesisErrorCode error});
 }
@@ -328,9 +304,7 @@ extension SpeechSynthesisErrorEventInitExtension
 
 @JS('SpeechSynthesisVoice')
 @staticInterop
-class SpeechSynthesisVoice {
-  external factory SpeechSynthesisVoice();
-}
+class SpeechSynthesisVoice {}
 
 extension SpeechSynthesisVoiceExtension on SpeechSynthesisVoice {
   external JSString get voiceURI;
@@ -338,5 +312,5 @@ extension SpeechSynthesisVoiceExtension on SpeechSynthesisVoice {
   external JSString get lang;
   external JSBoolean get localService;
   @JS('default')
-  external JSBoolean get default_0_;
+  external JSBoolean get default_;
 }

--- a/lib/src/dom/storage.dart
+++ b/lib/src/dom/storage.dart
@@ -10,9 +10,7 @@ import 'package:js/js.dart' hide JS;
 
 @JS('NavigatorStorage')
 @staticInterop
-class NavigatorStorage {
-  external factory NavigatorStorage();
-}
+class NavigatorStorage {}
 
 extension NavigatorStorageExtension on NavigatorStorage {
   external StorageManager get storage;
@@ -20,9 +18,7 @@ extension NavigatorStorageExtension on NavigatorStorage {
 
 @JS('StorageManager')
 @staticInterop
-class StorageManager {
-  external factory StorageManager();
-}
+class StorageManager {}
 
 extension StorageManagerExtension on StorageManager {
   external JSPromise getDirectory();

--- a/lib/src/dom/streams.dart
+++ b/lib/src/dom/streams.dart
@@ -30,36 +30,26 @@ typedef ReadableStreamType = JSString;
 @JS('ReadableStream')
 @staticInterop
 class ReadableStream {
-  external factory ReadableStream();
-
-  external factory ReadableStream.a1();
-
-  external factory ReadableStream.a2(JSObject underlyingSource);
-
-  external factory ReadableStream.a3(
+  external factory ReadableStream([
     JSObject underlyingSource,
     QueuingStrategy strategy,
-  );
+  ]);
 }
 
 extension ReadableStreamExtension on ReadableStream {
-  external JSBoolean get locked;
-  external JSPromise cancel();
-  external JSPromise cancel1(JSAny reason);
-  external ReadableStreamReader getReader();
-  external ReadableStreamReader getReader1(
-      ReadableStreamGetReaderOptions options);
-  external ReadableStream pipeThrough(ReadableWritablePair transform);
-  external ReadableStream pipeThrough1(
-    ReadableWritablePair transform,
+  external JSPromise cancel([JSAny reason]);
+  external ReadableStreamReader getReader(
+      [ReadableStreamGetReaderOptions options]);
+  external ReadableStream pipeThrough(
+    ReadableWritablePair transform, [
     StreamPipeOptions options,
-  );
-  external JSPromise pipeTo(WritableStream destination);
-  external JSPromise pipeTo1(
-    WritableStream destination,
+  ]);
+  external JSPromise pipeTo(
+    WritableStream destination, [
     StreamPipeOptions options,
-  );
+  ]);
   external JSArray tee();
+  external JSBoolean get locked;
 }
 
 @JS()
@@ -158,22 +148,17 @@ extension UnderlyingSourceExtension on UnderlyingSource {
 
 @JS('ReadableStreamGenericReader')
 @staticInterop
-class ReadableStreamGenericReader {
-  external factory ReadableStreamGenericReader();
-}
+class ReadableStreamGenericReader {}
 
 extension ReadableStreamGenericReaderExtension on ReadableStreamGenericReader {
+  external JSPromise cancel([JSAny reason]);
   external JSPromise get closed;
-  external JSPromise cancel();
-  external JSPromise cancel1(JSAny reason);
 }
 
 @JS('ReadableStreamDefaultReader')
 @staticInterop
 class ReadableStreamDefaultReader implements ReadableStreamGenericReader {
-  external factory ReadableStreamDefaultReader();
-
-  external factory ReadableStreamDefaultReader.a1(ReadableStream stream);
+  external factory ReadableStreamDefaultReader(ReadableStream stream);
 }
 
 extension ReadableStreamDefaultReaderExtension on ReadableStreamDefaultReader {
@@ -201,9 +186,7 @@ extension ReadableStreamReadResultExtension on ReadableStreamReadResult {
 @JS('ReadableStreamBYOBReader')
 @staticInterop
 class ReadableStreamBYOBReader implements ReadableStreamGenericReader {
-  external factory ReadableStreamBYOBReader();
-
-  external factory ReadableStreamBYOBReader.a1(ReadableStream stream);
+  external factory ReadableStreamBYOBReader(ReadableStream stream);
 }
 
 extension ReadableStreamBYOBReaderExtension on ReadableStreamBYOBReader {
@@ -213,69 +196,53 @@ extension ReadableStreamBYOBReaderExtension on ReadableStreamBYOBReader {
 
 @JS('ReadableStreamDefaultController')
 @staticInterop
-class ReadableStreamDefaultController {
-  external factory ReadableStreamDefaultController();
-}
+class ReadableStreamDefaultController {}
 
 extension ReadableStreamDefaultControllerExtension
     on ReadableStreamDefaultController {
-  external JSNumber? get desiredSize;
   external JSVoid close();
-  external JSVoid enqueue();
-  external JSVoid enqueue1(JSAny chunk);
-  external JSVoid error();
-  external JSVoid error1(JSAny e);
+  external JSVoid enqueue([JSAny chunk]);
+  external JSVoid error([JSAny e]);
+  external JSNumber? get desiredSize;
 }
 
 @JS('ReadableByteStreamController')
 @staticInterop
-class ReadableByteStreamController {
-  external factory ReadableByteStreamController();
-}
+class ReadableByteStreamController {}
 
 extension ReadableByteStreamControllerExtension
     on ReadableByteStreamController {
-  external ReadableStreamBYOBRequest? get byobRequest;
-  external JSNumber? get desiredSize;
   external JSVoid close();
   external JSVoid enqueue(ArrayBufferView chunk);
-  external JSVoid error();
-  external JSVoid error1(JSAny e);
+  external JSVoid error([JSAny e]);
+  external ReadableStreamBYOBRequest? get byobRequest;
+  external JSNumber? get desiredSize;
 }
 
 @JS('ReadableStreamBYOBRequest')
 @staticInterop
-class ReadableStreamBYOBRequest {
-  external factory ReadableStreamBYOBRequest();
-}
+class ReadableStreamBYOBRequest {}
 
 extension ReadableStreamBYOBRequestExtension on ReadableStreamBYOBRequest {
-  external ArrayBufferView? get view;
   external JSVoid respond(JSNumber bytesWritten);
   external JSVoid respondWithNewView(ArrayBufferView view);
+  external ArrayBufferView? get view;
 }
 
 @JS('WritableStream')
 @staticInterop
 class WritableStream {
-  external factory WritableStream();
-
-  external factory WritableStream.a1();
-
-  external factory WritableStream.a2(JSObject underlyingSink);
-
-  external factory WritableStream.a3(
+  external factory WritableStream([
     JSObject underlyingSink,
     QueuingStrategy strategy,
-  );
+  ]);
 }
 
 extension WritableStreamExtension on WritableStream {
-  external JSBoolean get locked;
-  external JSPromise abort();
-  external JSPromise abort1(JSAny reason);
+  external JSPromise abort([JSAny reason]);
   external JSPromise close();
   external WritableStreamDefaultWriter getWriter();
+  external JSBoolean get locked;
 }
 
 @JS()
@@ -307,55 +274,37 @@ extension UnderlyingSinkExtension on UnderlyingSink {
 @JS('WritableStreamDefaultWriter')
 @staticInterop
 class WritableStreamDefaultWriter {
-  external factory WritableStreamDefaultWriter();
-
-  external factory WritableStreamDefaultWriter.a1(WritableStream stream);
+  external factory WritableStreamDefaultWriter(WritableStream stream);
 }
 
 extension WritableStreamDefaultWriterExtension on WritableStreamDefaultWriter {
+  external JSPromise abort([JSAny reason]);
+  external JSPromise close();
+  external JSVoid releaseLock();
+  external JSPromise write([JSAny chunk]);
   external JSPromise get closed;
   external JSNumber? get desiredSize;
   external JSPromise get ready;
-  external JSPromise abort();
-  external JSPromise abort1(JSAny reason);
-  external JSPromise close();
-  external JSVoid releaseLock();
-  external JSPromise write();
-  external JSPromise write1(JSAny chunk);
 }
 
 @JS('WritableStreamDefaultController')
 @staticInterop
-class WritableStreamDefaultController {
-  external factory WritableStreamDefaultController();
-}
+class WritableStreamDefaultController {}
 
 extension WritableStreamDefaultControllerExtension
     on WritableStreamDefaultController {
+  external JSVoid error([JSAny e]);
   external AbortSignal get signal;
-  external JSVoid error();
-  external JSVoid error1(JSAny e);
 }
 
 @JS('TransformStream')
 @staticInterop
 class TransformStream {
-  external factory TransformStream();
-
-  external factory TransformStream.a1();
-
-  external factory TransformStream.a2(JSObject transformer);
-
-  external factory TransformStream.a3(
-    JSObject transformer,
-    QueuingStrategy writableStrategy,
-  );
-
-  external factory TransformStream.a4(
+  external factory TransformStream([
     JSObject transformer,
     QueuingStrategy writableStrategy,
     QueuingStrategy readableStrategy,
-  );
+  ]);
 }
 
 extension TransformStreamExtension on TransformStream {
@@ -391,18 +340,14 @@ extension TransformerExtension on Transformer {
 
 @JS('TransformStreamDefaultController')
 @staticInterop
-class TransformStreamDefaultController {
-  external factory TransformStreamDefaultController();
-}
+class TransformStreamDefaultController {}
 
 extension TransformStreamDefaultControllerExtension
     on TransformStreamDefaultController {
-  external JSNumber? get desiredSize;
-  external JSVoid enqueue();
-  external JSVoid enqueue1(JSAny chunk);
-  external JSVoid error();
-  external JSVoid error1(JSAny reason);
+  external JSVoid enqueue([JSAny chunk]);
+  external JSVoid error([JSAny reason]);
   external JSVoid terminate();
+  external JSNumber? get desiredSize;
 }
 
 @JS()
@@ -437,9 +382,7 @@ extension QueuingStrategyInitExtension on QueuingStrategyInit {
 @JS('ByteLengthQueuingStrategy')
 @staticInterop
 class ByteLengthQueuingStrategy {
-  external factory ByteLengthQueuingStrategy();
-
-  external factory ByteLengthQueuingStrategy.a1(QueuingStrategyInit init);
+  external factory ByteLengthQueuingStrategy(QueuingStrategyInit init);
 }
 
 extension ByteLengthQueuingStrategyExtension on ByteLengthQueuingStrategy {
@@ -450,9 +393,7 @@ extension ByteLengthQueuingStrategyExtension on ByteLengthQueuingStrategy {
 @JS('CountQueuingStrategy')
 @staticInterop
 class CountQueuingStrategy {
-  external factory CountQueuingStrategy();
-
-  external factory CountQueuingStrategy.a1(QueuingStrategyInit init);
+  external factory CountQueuingStrategy(QueuingStrategyInit init);
 }
 
 extension CountQueuingStrategyExtension on CountQueuingStrategy {
@@ -462,9 +403,7 @@ extension CountQueuingStrategyExtension on CountQueuingStrategy {
 
 @JS('GenericTransformStream')
 @staticInterop
-class GenericTransformStream {
-  external factory GenericTransformStream();
-}
+class GenericTransformStream {}
 
 extension GenericTransformStreamExtension on GenericTransformStream {
   external ReadableStream get readable;

--- a/lib/src/dom/svg.dart
+++ b/lib/src/dom/svg.dart
@@ -16,14 +16,13 @@ import 'web_animations.dart';
 
 @JS('SVGElement')
 @staticInterop
-class SVGElement extends Element
+class SVGElement
     implements
+        Element,
         GlobalEventHandlers,
         SVGElementInstance,
         HTMLOrSVGElement,
-        ElementCSSInlineStyle {
-  external factory SVGElement();
-}
+        ElementCSSInlineStyle {}
 
 extension SVGElementExtension on SVGElement {
   external SVGAnimatedString get className;
@@ -56,39 +55,30 @@ extension SVGBoundingBoxOptionsExtension on SVGBoundingBoxOptions {
 
 @JS('SVGGraphicsElement')
 @staticInterop
-class SVGGraphicsElement extends SVGElement implements SVGTests {
-  external factory SVGGraphicsElement();
-}
+class SVGGraphicsElement implements SVGElement, SVGTests {}
 
 extension SVGGraphicsElementExtension on SVGGraphicsElement {
-  external SVGAnimatedTransformList get transform;
-  external DOMRect getBBox();
-  external DOMRect getBBox1(SVGBoundingBoxOptions options);
+  external DOMRect getBBox([SVGBoundingBoxOptions options]);
   external DOMMatrix? getCTM();
   external DOMMatrix? getScreenCTM();
+  external SVGAnimatedTransformList get transform;
 }
 
 @JS('SVGGeometryElement')
 @staticInterop
-class SVGGeometryElement extends SVGGraphicsElement {
-  external factory SVGGeometryElement();
-}
+class SVGGeometryElement implements SVGGraphicsElement {}
 
 extension SVGGeometryElementExtension on SVGGeometryElement {
-  external SVGAnimatedNumber get pathLength;
-  external JSBoolean isPointInFill();
-  external JSBoolean isPointInFill1(DOMPointInit point);
-  external JSBoolean isPointInStroke();
-  external JSBoolean isPointInStroke1(DOMPointInit point);
+  external JSBoolean isPointInFill([DOMPointInit point]);
+  external JSBoolean isPointInStroke([DOMPointInit point]);
   external JSNumber getTotalLength();
   external DOMPoint getPointAtLength(JSNumber distance);
+  external SVGAnimatedNumber get pathLength;
 }
 
 @JS('SVGNumber')
 @staticInterop
-class SVGNumber {
-  external factory SVGNumber();
-}
+class SVGNumber {}
 
 extension SVGNumberExtension on SVGNumber {
   external set value(JSNumber value);
@@ -98,8 +88,6 @@ extension SVGNumberExtension on SVGNumber {
 @JS('SVGLength')
 @staticInterop
 class SVGLength {
-  external factory SVGLength();
-
   external static JSNumber get SVG_LENGTHTYPE_UNKNOWN;
   external static JSNumber get SVG_LENGTHTYPE_NUMBER;
   external static JSNumber get SVG_LENGTHTYPE_PERCENTAGE;
@@ -114,6 +102,11 @@ class SVGLength {
 }
 
 extension SVGLengthExtension on SVGLength {
+  external JSVoid newValueSpecifiedUnits(
+    JSNumber unitType,
+    JSNumber valueInSpecifiedUnits,
+  );
+  external JSVoid convertToSpecifiedUnits(JSNumber unitType);
   external JSNumber get unitType;
   external set value(JSNumber value);
   external JSNumber get value;
@@ -121,18 +114,11 @@ extension SVGLengthExtension on SVGLength {
   external JSNumber get valueInSpecifiedUnits;
   external set valueAsString(JSString value);
   external JSString get valueAsString;
-  external JSVoid newValueSpecifiedUnits(
-    JSNumber unitType,
-    JSNumber valueInSpecifiedUnits,
-  );
-  external JSVoid convertToSpecifiedUnits(JSNumber unitType);
 }
 
 @JS('SVGAngle')
 @staticInterop
 class SVGAngle {
-  external factory SVGAngle();
-
   external static JSNumber get SVG_ANGLETYPE_UNKNOWN;
   external static JSNumber get SVG_ANGLETYPE_UNSPECIFIED;
   external static JSNumber get SVG_ANGLETYPE_DEG;
@@ -141,6 +127,11 @@ class SVGAngle {
 }
 
 extension SVGAngleExtension on SVGAngle {
+  external JSVoid newValueSpecifiedUnits(
+    JSNumber unitType,
+    JSNumber valueInSpecifiedUnits,
+  );
+  external JSVoid convertToSpecifiedUnits(JSNumber unitType);
   external JSNumber get unitType;
   external set value(JSNumber value);
   external JSNumber get value;
@@ -148,22 +139,13 @@ extension SVGAngleExtension on SVGAngle {
   external JSNumber get valueInSpecifiedUnits;
   external set valueAsString(JSString value);
   external JSString get valueAsString;
-  external JSVoid newValueSpecifiedUnits(
-    JSNumber unitType,
-    JSNumber valueInSpecifiedUnits,
-  );
-  external JSVoid convertToSpecifiedUnits(JSNumber unitType);
 }
 
 @JS('SVGNumberList')
 @staticInterop
-class SVGNumberList {
-  external factory SVGNumberList();
-}
+class SVGNumberList {}
 
 extension SVGNumberListExtension on SVGNumberList {
-  external JSNumber get length;
-  external JSNumber get numberOfItems;
   external JSVoid clear();
   external SVGNumber initialize(SVGNumber newItem);
   external SVGNumber getItem(JSNumber index);
@@ -177,17 +159,15 @@ extension SVGNumberListExtension on SVGNumberList {
   );
   external SVGNumber removeItem(JSNumber index);
   external SVGNumber appendItem(SVGNumber newItem);
+  external JSNumber get length;
+  external JSNumber get numberOfItems;
 }
 
 @JS('SVGLengthList')
 @staticInterop
-class SVGLengthList {
-  external factory SVGLengthList();
-}
+class SVGLengthList {}
 
 extension SVGLengthListExtension on SVGLengthList {
-  external JSNumber get length;
-  external JSNumber get numberOfItems;
   external JSVoid clear();
   external SVGLength initialize(SVGLength newItem);
   external SVGLength getItem(JSNumber index);
@@ -201,17 +181,15 @@ extension SVGLengthListExtension on SVGLengthList {
   );
   external SVGLength removeItem(JSNumber index);
   external SVGLength appendItem(SVGLength newItem);
+  external JSNumber get length;
+  external JSNumber get numberOfItems;
 }
 
 @JS('SVGStringList')
 @staticInterop
-class SVGStringList {
-  external factory SVGStringList();
-}
+class SVGStringList {}
 
 extension SVGStringListExtension on SVGStringList {
-  external JSNumber get length;
-  external JSNumber get numberOfItems;
   external JSVoid clear();
   external JSString initialize(JSString newItem);
   external JSString getItem(JSNumber index);
@@ -225,13 +203,13 @@ extension SVGStringListExtension on SVGStringList {
   );
   external JSString removeItem(JSNumber index);
   external JSString appendItem(JSString newItem);
+  external JSNumber get length;
+  external JSNumber get numberOfItems;
 }
 
 @JS('SVGAnimatedBoolean')
 @staticInterop
-class SVGAnimatedBoolean {
-  external factory SVGAnimatedBoolean();
-}
+class SVGAnimatedBoolean {}
 
 extension SVGAnimatedBooleanExtension on SVGAnimatedBoolean {
   external set baseVal(JSBoolean value);
@@ -241,9 +219,7 @@ extension SVGAnimatedBooleanExtension on SVGAnimatedBoolean {
 
 @JS('SVGAnimatedEnumeration')
 @staticInterop
-class SVGAnimatedEnumeration {
-  external factory SVGAnimatedEnumeration();
-}
+class SVGAnimatedEnumeration {}
 
 extension SVGAnimatedEnumerationExtension on SVGAnimatedEnumeration {
   external set baseVal(JSNumber value);
@@ -253,9 +229,7 @@ extension SVGAnimatedEnumerationExtension on SVGAnimatedEnumeration {
 
 @JS('SVGAnimatedInteger')
 @staticInterop
-class SVGAnimatedInteger {
-  external factory SVGAnimatedInteger();
-}
+class SVGAnimatedInteger {}
 
 extension SVGAnimatedIntegerExtension on SVGAnimatedInteger {
   external set baseVal(JSNumber value);
@@ -265,9 +239,7 @@ extension SVGAnimatedIntegerExtension on SVGAnimatedInteger {
 
 @JS('SVGAnimatedNumber')
 @staticInterop
-class SVGAnimatedNumber {
-  external factory SVGAnimatedNumber();
-}
+class SVGAnimatedNumber {}
 
 extension SVGAnimatedNumberExtension on SVGAnimatedNumber {
   external set baseVal(JSNumber value);
@@ -277,9 +249,7 @@ extension SVGAnimatedNumberExtension on SVGAnimatedNumber {
 
 @JS('SVGAnimatedLength')
 @staticInterop
-class SVGAnimatedLength {
-  external factory SVGAnimatedLength();
-}
+class SVGAnimatedLength {}
 
 extension SVGAnimatedLengthExtension on SVGAnimatedLength {
   external SVGLength get baseVal;
@@ -288,9 +258,7 @@ extension SVGAnimatedLengthExtension on SVGAnimatedLength {
 
 @JS('SVGAnimatedAngle')
 @staticInterop
-class SVGAnimatedAngle {
-  external factory SVGAnimatedAngle();
-}
+class SVGAnimatedAngle {}
 
 extension SVGAnimatedAngleExtension on SVGAnimatedAngle {
   external SVGAngle get baseVal;
@@ -299,9 +267,7 @@ extension SVGAnimatedAngleExtension on SVGAnimatedAngle {
 
 @JS('SVGAnimatedString')
 @staticInterop
-class SVGAnimatedString {
-  external factory SVGAnimatedString();
-}
+class SVGAnimatedString {}
 
 extension SVGAnimatedStringExtension on SVGAnimatedString {
   external set baseVal(JSString value);
@@ -311,9 +277,7 @@ extension SVGAnimatedStringExtension on SVGAnimatedString {
 
 @JS('SVGAnimatedRect')
 @staticInterop
-class SVGAnimatedRect {
-  external factory SVGAnimatedRect();
-}
+class SVGAnimatedRect {}
 
 extension SVGAnimatedRectExtension on SVGAnimatedRect {
   external DOMRect get baseVal;
@@ -322,9 +286,7 @@ extension SVGAnimatedRectExtension on SVGAnimatedRect {
 
 @JS('SVGAnimatedNumberList')
 @staticInterop
-class SVGAnimatedNumberList {
-  external factory SVGAnimatedNumberList();
-}
+class SVGAnimatedNumberList {}
 
 extension SVGAnimatedNumberListExtension on SVGAnimatedNumberList {
   external SVGNumberList get baseVal;
@@ -333,9 +295,7 @@ extension SVGAnimatedNumberListExtension on SVGAnimatedNumberList {
 
 @JS('SVGAnimatedLengthList')
 @staticInterop
-class SVGAnimatedLengthList {
-  external factory SVGAnimatedLengthList();
-}
+class SVGAnimatedLengthList {}
 
 extension SVGAnimatedLengthListExtension on SVGAnimatedLengthList {
   external SVGLengthList get baseVal;
@@ -345,8 +305,6 @@ extension SVGAnimatedLengthListExtension on SVGAnimatedLengthList {
 @JS('SVGUnitTypes')
 @staticInterop
 class SVGUnitTypes {
-  external factory SVGUnitTypes();
-
   external static JSNumber get SVG_UNIT_TYPE_UNKNOWN;
   external static JSNumber get SVG_UNIT_TYPE_USERSPACEONUSE;
   external static JSNumber get SVG_UNIT_TYPE_OBJECTBOUNDINGBOX;
@@ -354,9 +312,7 @@ class SVGUnitTypes {
 
 @JS('SVGTests')
 @staticInterop
-class SVGTests {
-  external factory SVGTests();
-}
+class SVGTests {}
 
 extension SVGTestsExtension on SVGTests {
   external SVGStringList get requiredExtensions;
@@ -365,9 +321,7 @@ extension SVGTestsExtension on SVGTests {
 
 @JS('SVGFitToViewBox')
 @staticInterop
-class SVGFitToViewBox {
-  external factory SVGFitToViewBox();
-}
+class SVGFitToViewBox {}
 
 extension SVGFitToViewBoxExtension on SVGFitToViewBox {
   external SVGAnimatedRect get viewBox;
@@ -376,9 +330,7 @@ extension SVGFitToViewBoxExtension on SVGFitToViewBox {
 
 @JS('SVGURIReference')
 @staticInterop
-class SVGURIReference {
-  external factory SVGURIReference();
-}
+class SVGURIReference {}
 
 extension SVGURIReferenceExtension on SVGURIReference {
   external SVGAnimatedString get href;
@@ -386,19 +338,10 @@ extension SVGURIReferenceExtension on SVGURIReference {
 
 @JS('SVGSVGElement')
 @staticInterop
-class SVGSVGElement extends SVGGraphicsElement
-    implements SVGFitToViewBox, WindowEventHandlers {
-  external factory SVGSVGElement();
-}
+class SVGSVGElement
+    implements SVGGraphicsElement, SVGFitToViewBox, WindowEventHandlers {}
 
 extension SVGSVGElementExtension on SVGSVGElement {
-  external SVGAnimatedLength get x;
-  external SVGAnimatedLength get y;
-  external SVGAnimatedLength get width;
-  external SVGAnimatedLength get height;
-  external set currentScale(JSNumber value);
-  external JSNumber get currentScale;
-  external DOMPointReadOnly get currentTranslate;
   external NodeList getIntersectionList(
     DOMRectReadOnly rect,
     SVGElement? referenceElement,
@@ -423,8 +366,7 @@ extension SVGSVGElementExtension on SVGSVGElement {
   external DOMMatrix createSVGMatrix();
   external DOMRect createSVGRect();
   external SVGTransform createSVGTransform();
-  external SVGTransform createSVGTransformFromMatrix();
-  external SVGTransform createSVGTransformFromMatrix1(DOMMatrix2DInit matrix);
+  external SVGTransform createSVGTransformFromMatrix([DOMMatrix2DInit matrix]);
   external Element getElementById(JSString elementId);
   external JSNumber suspendRedraw(JSNumber maxWaitMilliseconds);
   external JSVoid unsuspendRedraw(JSNumber suspendHandleID);
@@ -435,49 +377,42 @@ extension SVGSVGElementExtension on SVGSVGElement {
   external JSBoolean animationsPaused();
   external JSNumber getCurrentTime();
   external JSVoid setCurrentTime(JSNumber seconds);
+  external SVGAnimatedLength get x;
+  external SVGAnimatedLength get y;
+  external SVGAnimatedLength get width;
+  external SVGAnimatedLength get height;
+  external set currentScale(JSNumber value);
+  external JSNumber get currentScale;
+  external DOMPointReadOnly get currentTranslate;
 }
 
 @JS('SVGGElement')
 @staticInterop
-class SVGGElement extends SVGGraphicsElement {
-  external factory SVGGElement();
-}
+class SVGGElement implements SVGGraphicsElement {}
 
 @JS('SVGDefsElement')
 @staticInterop
-class SVGDefsElement extends SVGGraphicsElement {
-  external factory SVGDefsElement();
-}
+class SVGDefsElement implements SVGGraphicsElement {}
 
 @JS('SVGDescElement')
 @staticInterop
-class SVGDescElement extends SVGElement {
-  external factory SVGDescElement();
-}
+class SVGDescElement implements SVGElement {}
 
 @JS('SVGMetadataElement')
 @staticInterop
-class SVGMetadataElement extends SVGElement {
-  external factory SVGMetadataElement();
-}
+class SVGMetadataElement implements SVGElement {}
 
 @JS('SVGTitleElement')
 @staticInterop
-class SVGTitleElement extends SVGElement {
-  external factory SVGTitleElement();
-}
+class SVGTitleElement implements SVGElement {}
 
 @JS('SVGSymbolElement')
 @staticInterop
-class SVGSymbolElement extends SVGGraphicsElement implements SVGFitToViewBox {
-  external factory SVGSymbolElement();
-}
+class SVGSymbolElement implements SVGGraphicsElement, SVGFitToViewBox {}
 
 @JS('SVGUseElement')
 @staticInterop
-class SVGUseElement extends SVGGraphicsElement implements SVGURIReference {
-  external factory SVGUseElement();
-}
+class SVGUseElement implements SVGGraphicsElement, SVGURIReference {}
 
 extension SVGUseElementExtension on SVGUseElement {
   external SVGAnimatedLength get x;
@@ -490,15 +425,11 @@ extension SVGUseElementExtension on SVGUseElement {
 
 @JS('SVGUseElementShadowRoot')
 @staticInterop
-class SVGUseElementShadowRoot extends ShadowRoot {
-  external factory SVGUseElementShadowRoot();
-}
+class SVGUseElementShadowRoot implements ShadowRoot {}
 
 @JS('SVGElementInstance')
 @staticInterop
-class SVGElementInstance {
-  external factory SVGElementInstance();
-}
+class SVGElementInstance {}
 
 extension SVGElementInstanceExtension on SVGElementInstance {
   external SVGElement? get correspondingElement;
@@ -507,10 +438,8 @@ extension SVGElementInstanceExtension on SVGElementInstance {
 
 @JS('ShadowAnimation')
 @staticInterop
-class ShadowAnimation extends Animation {
-  external factory ShadowAnimation();
-
-  external factory ShadowAnimation.a1(
+class ShadowAnimation implements Animation {
+  external factory ShadowAnimation(
     Animation source,
     JSAny newTarget,
   );
@@ -522,15 +451,11 @@ extension ShadowAnimationExtension on ShadowAnimation {
 
 @JS('SVGSwitchElement')
 @staticInterop
-class SVGSwitchElement extends SVGGraphicsElement {
-  external factory SVGSwitchElement();
-}
+class SVGSwitchElement implements SVGGraphicsElement {}
 
 @JS('GetSVGDocument')
 @staticInterop
-class GetSVGDocument {
-  external factory GetSVGDocument();
-}
+class GetSVGDocument {}
 
 extension GetSVGDocumentExtension on GetSVGDocument {
   external Document getSVGDocument();
@@ -538,9 +463,7 @@ extension GetSVGDocumentExtension on GetSVGDocument {
 
 @JS('SVGStyleElement')
 @staticInterop
-class SVGStyleElement extends SVGElement implements LinkStyle {
-  external factory SVGStyleElement();
-}
+class SVGStyleElement implements SVGElement, LinkStyle {}
 
 extension SVGStyleElementExtension on SVGStyleElement {
   external set type(JSString value);
@@ -554,8 +477,6 @@ extension SVGStyleElementExtension on SVGStyleElement {
 @JS('SVGTransform')
 @staticInterop
 class SVGTransform {
-  external factory SVGTransform();
-
   external static JSNumber get SVG_TRANSFORM_UNKNOWN;
   external static JSNumber get SVG_TRANSFORM_MATRIX;
   external static JSNumber get SVG_TRANSFORM_TRANSLATE;
@@ -566,11 +487,7 @@ class SVGTransform {
 }
 
 extension SVGTransformExtension on SVGTransform {
-  external JSNumber get type;
-  external DOMMatrix get matrix;
-  external JSNumber get angle;
-  external JSVoid setMatrix();
-  external JSVoid setMatrix1(DOMMatrix2DInit matrix);
+  external JSVoid setMatrix([DOMMatrix2DInit matrix]);
   external JSVoid setTranslate(
     JSNumber tx,
     JSNumber ty,
@@ -586,17 +503,16 @@ extension SVGTransformExtension on SVGTransform {
   );
   external JSVoid setSkewX(JSNumber angle);
   external JSVoid setSkewY(JSNumber angle);
+  external JSNumber get type;
+  external DOMMatrix get matrix;
+  external JSNumber get angle;
 }
 
 @JS('SVGTransformList')
 @staticInterop
-class SVGTransformList {
-  external factory SVGTransformList();
-}
+class SVGTransformList {}
 
 extension SVGTransformListExtension on SVGTransformList {
-  external JSNumber get length;
-  external JSNumber get numberOfItems;
   external JSVoid clear();
   external SVGTransform initialize(SVGTransform newItem);
   external SVGTransform getItem(JSNumber index);
@@ -610,16 +526,15 @@ extension SVGTransformListExtension on SVGTransformList {
   );
   external SVGTransform removeItem(JSNumber index);
   external SVGTransform appendItem(SVGTransform newItem);
-  external SVGTransform createSVGTransformFromMatrix();
-  external SVGTransform createSVGTransformFromMatrix1(DOMMatrix2DInit matrix);
+  external SVGTransform createSVGTransformFromMatrix([DOMMatrix2DInit matrix]);
   external SVGTransform? consolidate();
+  external JSNumber get length;
+  external JSNumber get numberOfItems;
 }
 
 @JS('SVGAnimatedTransformList')
 @staticInterop
-class SVGAnimatedTransformList {
-  external factory SVGAnimatedTransformList();
-}
+class SVGAnimatedTransformList {}
 
 extension SVGAnimatedTransformListExtension on SVGAnimatedTransformList {
   external SVGTransformList get baseVal;
@@ -629,8 +544,6 @@ extension SVGAnimatedTransformListExtension on SVGAnimatedTransformList {
 @JS('SVGPreserveAspectRatio')
 @staticInterop
 class SVGPreserveAspectRatio {
-  external factory SVGPreserveAspectRatio();
-
   external static JSNumber get SVG_PRESERVEASPECTRATIO_UNKNOWN;
   external static JSNumber get SVG_PRESERVEASPECTRATIO_NONE;
   external static JSNumber get SVG_PRESERVEASPECTRATIO_XMINYMIN;
@@ -656,9 +569,7 @@ extension SVGPreserveAspectRatioExtension on SVGPreserveAspectRatio {
 
 @JS('SVGAnimatedPreserveAspectRatio')
 @staticInterop
-class SVGAnimatedPreserveAspectRatio {
-  external factory SVGAnimatedPreserveAspectRatio();
-}
+class SVGAnimatedPreserveAspectRatio {}
 
 extension SVGAnimatedPreserveAspectRatioExtension
     on SVGAnimatedPreserveAspectRatio {
@@ -668,15 +579,11 @@ extension SVGAnimatedPreserveAspectRatioExtension
 
 @JS('SVGPathElement')
 @staticInterop
-class SVGPathElement extends SVGGeometryElement {
-  external factory SVGPathElement();
-}
+class SVGPathElement implements SVGGeometryElement {}
 
 @JS('SVGRectElement')
 @staticInterop
-class SVGRectElement extends SVGGeometryElement {
-  external factory SVGRectElement();
-}
+class SVGRectElement implements SVGGeometryElement {}
 
 extension SVGRectElementExtension on SVGRectElement {
   external SVGAnimatedLength get x;
@@ -689,9 +596,7 @@ extension SVGRectElementExtension on SVGRectElement {
 
 @JS('SVGCircleElement')
 @staticInterop
-class SVGCircleElement extends SVGGeometryElement {
-  external factory SVGCircleElement();
-}
+class SVGCircleElement implements SVGGeometryElement {}
 
 extension SVGCircleElementExtension on SVGCircleElement {
   external SVGAnimatedLength get cx;
@@ -701,9 +606,7 @@ extension SVGCircleElementExtension on SVGCircleElement {
 
 @JS('SVGEllipseElement')
 @staticInterop
-class SVGEllipseElement extends SVGGeometryElement {
-  external factory SVGEllipseElement();
-}
+class SVGEllipseElement implements SVGGeometryElement {}
 
 extension SVGEllipseElementExtension on SVGEllipseElement {
   external SVGAnimatedLength get cx;
@@ -714,9 +617,7 @@ extension SVGEllipseElementExtension on SVGEllipseElement {
 
 @JS('SVGLineElement')
 @staticInterop
-class SVGLineElement extends SVGGeometryElement {
-  external factory SVGLineElement();
-}
+class SVGLineElement implements SVGGeometryElement {}
 
 extension SVGLineElementExtension on SVGLineElement {
   external SVGAnimatedLength get x1;
@@ -727,9 +628,7 @@ extension SVGLineElementExtension on SVGLineElement {
 
 @JS('SVGAnimatedPoints')
 @staticInterop
-class SVGAnimatedPoints {
-  external factory SVGAnimatedPoints();
-}
+class SVGAnimatedPoints {}
 
 extension SVGAnimatedPointsExtension on SVGAnimatedPoints {
   external SVGPointList get points;
@@ -738,13 +637,9 @@ extension SVGAnimatedPointsExtension on SVGAnimatedPoints {
 
 @JS('SVGPointList')
 @staticInterop
-class SVGPointList {
-  external factory SVGPointList();
-}
+class SVGPointList {}
 
 extension SVGPointListExtension on SVGPointList {
-  external JSNumber get length;
-  external JSNumber get numberOfItems;
   external JSVoid clear();
   external DOMPoint initialize(DOMPoint newItem);
   external DOMPoint getItem(JSNumber index);
@@ -758,35 +653,27 @@ extension SVGPointListExtension on SVGPointList {
   );
   external DOMPoint removeItem(JSNumber index);
   external DOMPoint appendItem(DOMPoint newItem);
+  external JSNumber get length;
+  external JSNumber get numberOfItems;
 }
 
 @JS('SVGPolylineElement')
 @staticInterop
-class SVGPolylineElement extends SVGGeometryElement
-    implements SVGAnimatedPoints {
-  external factory SVGPolylineElement();
-}
+class SVGPolylineElement implements SVGGeometryElement, SVGAnimatedPoints {}
 
 @JS('SVGPolygonElement')
 @staticInterop
-class SVGPolygonElement extends SVGGeometryElement
-    implements SVGAnimatedPoints {
-  external factory SVGPolygonElement();
-}
+class SVGPolygonElement implements SVGGeometryElement, SVGAnimatedPoints {}
 
 @JS('SVGTextContentElement')
 @staticInterop
-class SVGTextContentElement extends SVGGraphicsElement {
-  external factory SVGTextContentElement();
-
+class SVGTextContentElement implements SVGGraphicsElement {
   external static JSNumber get LENGTHADJUST_UNKNOWN;
   external static JSNumber get LENGTHADJUST_SPACING;
   external static JSNumber get LENGTHADJUST_SPACINGANDGLYPHS;
 }
 
 extension SVGTextContentElementExtension on SVGTextContentElement {
-  external SVGAnimatedLength get textLength;
-  external SVGAnimatedEnumeration get lengthAdjust;
   external JSNumber getNumberOfChars();
   external JSNumber getComputedTextLength();
   external JSNumber getSubStringLength(
@@ -797,19 +684,18 @@ extension SVGTextContentElementExtension on SVGTextContentElement {
   external DOMPoint getEndPositionOfChar(JSNumber charnum);
   external DOMRect getExtentOfChar(JSNumber charnum);
   external JSNumber getRotationOfChar(JSNumber charnum);
-  external JSNumber getCharNumAtPosition();
-  external JSNumber getCharNumAtPosition1(DOMPointInit point);
+  external JSNumber getCharNumAtPosition([DOMPointInit point]);
   external JSVoid selectSubString(
     JSNumber charnum,
     JSNumber nchars,
   );
+  external SVGAnimatedLength get textLength;
+  external SVGAnimatedEnumeration get lengthAdjust;
 }
 
 @JS('SVGTextPositioningElement')
 @staticInterop
-class SVGTextPositioningElement extends SVGTextContentElement {
-  external factory SVGTextPositioningElement();
-}
+class SVGTextPositioningElement implements SVGTextContentElement {}
 
 extension SVGTextPositioningElementExtension on SVGTextPositioningElement {
   external SVGAnimatedLengthList get x;
@@ -821,22 +707,15 @@ extension SVGTextPositioningElementExtension on SVGTextPositioningElement {
 
 @JS('SVGTextElement')
 @staticInterop
-class SVGTextElement extends SVGTextPositioningElement {
-  external factory SVGTextElement();
-}
+class SVGTextElement implements SVGTextPositioningElement {}
 
 @JS('SVGTSpanElement')
 @staticInterop
-class SVGTSpanElement extends SVGTextPositioningElement {
-  external factory SVGTSpanElement();
-}
+class SVGTSpanElement implements SVGTextPositioningElement {}
 
 @JS('SVGTextPathElement')
 @staticInterop
-class SVGTextPathElement extends SVGTextContentElement
-    implements SVGURIReference {
-  external factory SVGTextPathElement();
-
+class SVGTextPathElement implements SVGTextContentElement, SVGURIReference {
   external static JSNumber get TEXTPATH_METHODTYPE_UNKNOWN;
   external static JSNumber get TEXTPATH_METHODTYPE_ALIGN;
   external static JSNumber get TEXTPATH_METHODTYPE_STRETCH;
@@ -853,9 +732,7 @@ extension SVGTextPathElementExtension on SVGTextPathElement {
 
 @JS('SVGImageElement')
 @staticInterop
-class SVGImageElement extends SVGGraphicsElement implements SVGURIReference {
-  external factory SVGImageElement();
-}
+class SVGImageElement implements SVGGraphicsElement, SVGURIReference {}
 
 extension SVGImageElementExtension on SVGImageElement {
   external SVGAnimatedLength get x;
@@ -869,9 +746,7 @@ extension SVGImageElementExtension on SVGImageElement {
 
 @JS('SVGForeignObjectElement')
 @staticInterop
-class SVGForeignObjectElement extends SVGGraphicsElement {
-  external factory SVGForeignObjectElement();
-}
+class SVGForeignObjectElement implements SVGGraphicsElement {}
 
 extension SVGForeignObjectElementExtension on SVGForeignObjectElement {
   external SVGAnimatedLength get x;
@@ -882,9 +757,7 @@ extension SVGForeignObjectElementExtension on SVGForeignObjectElement {
 
 @JS('SVGMarkerElement')
 @staticInterop
-class SVGMarkerElement extends SVGElement implements SVGFitToViewBox {
-  external factory SVGMarkerElement();
-
+class SVGMarkerElement implements SVGElement, SVGFitToViewBox {
   external static JSNumber get SVG_MARKERUNITS_UNKNOWN;
   external static JSNumber get SVG_MARKERUNITS_USERSPACEONUSE;
   external static JSNumber get SVG_MARKERUNITS_STROKEWIDTH;
@@ -894,6 +767,8 @@ class SVGMarkerElement extends SVGElement implements SVGFitToViewBox {
 }
 
 extension SVGMarkerElementExtension on SVGMarkerElement {
+  external JSVoid setOrientToAuto();
+  external JSVoid setOrientToAngle(SVGAngle angle);
   external SVGAnimatedLength get refX;
   external SVGAnimatedLength get refY;
   external SVGAnimatedEnumeration get markerUnits;
@@ -903,15 +778,11 @@ extension SVGMarkerElementExtension on SVGMarkerElement {
   external SVGAnimatedAngle get orientAngle;
   external set orient(JSString value);
   external JSString get orient;
-  external JSVoid setOrientToAuto();
-  external JSVoid setOrientToAngle(SVGAngle angle);
 }
 
 @JS('SVGGradientElement')
 @staticInterop
-class SVGGradientElement extends SVGElement implements SVGURIReference {
-  external factory SVGGradientElement();
-
+class SVGGradientElement implements SVGElement, SVGURIReference {
   external static JSNumber get SVG_SPREADMETHOD_UNKNOWN;
   external static JSNumber get SVG_SPREADMETHOD_PAD;
   external static JSNumber get SVG_SPREADMETHOD_REFLECT;
@@ -926,9 +797,7 @@ extension SVGGradientElementExtension on SVGGradientElement {
 
 @JS('SVGLinearGradientElement')
 @staticInterop
-class SVGLinearGradientElement extends SVGGradientElement {
-  external factory SVGLinearGradientElement();
-}
+class SVGLinearGradientElement implements SVGGradientElement {}
 
 extension SVGLinearGradientElementExtension on SVGLinearGradientElement {
   external SVGAnimatedLength get x1;
@@ -939,9 +808,7 @@ extension SVGLinearGradientElementExtension on SVGLinearGradientElement {
 
 @JS('SVGRadialGradientElement')
 @staticInterop
-class SVGRadialGradientElement extends SVGGradientElement {
-  external factory SVGRadialGradientElement();
-}
+class SVGRadialGradientElement implements SVGGradientElement {}
 
 extension SVGRadialGradientElementExtension on SVGRadialGradientElement {
   external SVGAnimatedLength get cx;
@@ -954,9 +821,7 @@ extension SVGRadialGradientElementExtension on SVGRadialGradientElement {
 
 @JS('SVGStopElement')
 @staticInterop
-class SVGStopElement extends SVGElement {
-  external factory SVGStopElement();
-}
+class SVGStopElement implements SVGElement {}
 
 extension SVGStopElementExtension on SVGStopElement {
   external SVGAnimatedNumber get offset;
@@ -964,10 +829,8 @@ extension SVGStopElementExtension on SVGStopElement {
 
 @JS('SVGPatternElement')
 @staticInterop
-class SVGPatternElement extends SVGElement
-    implements SVGFitToViewBox, SVGURIReference {
-  external factory SVGPatternElement();
-}
+class SVGPatternElement
+    implements SVGElement, SVGFitToViewBox, SVGURIReference {}
 
 extension SVGPatternElementExtension on SVGPatternElement {
   external SVGAnimatedEnumeration get patternUnits;
@@ -981,9 +844,7 @@ extension SVGPatternElementExtension on SVGPatternElement {
 
 @JS('SVGScriptElement')
 @staticInterop
-class SVGScriptElement extends SVGElement implements SVGURIReference {
-  external factory SVGScriptElement();
-}
+class SVGScriptElement implements SVGElement, SVGURIReference {}
 
 extension SVGScriptElementExtension on SVGScriptElement {
   external set type(JSString value);
@@ -994,9 +855,7 @@ extension SVGScriptElementExtension on SVGScriptElement {
 
 @JS('SVGAElement')
 @staticInterop
-class SVGAElement extends SVGGraphicsElement implements SVGURIReference {
-  external factory SVGAElement();
-}
+class SVGAElement implements SVGGraphicsElement, SVGURIReference {}
 
 extension SVGAElementExtension on SVGAElement {
   external SVGAnimatedString get target;
@@ -1038,6 +897,4 @@ extension SVGAElementExtension on SVGAElement {
 
 @JS('SVGViewElement')
 @staticInterop
-class SVGViewElement extends SVGElement implements SVGFitToViewBox {
-  external factory SVGViewElement();
-}
+class SVGViewElement implements SVGElement, SVGFitToViewBox {}

--- a/lib/src/dom/svg_animations.dart
+++ b/lib/src/dom/svg_animations.dart
@@ -14,34 +14,23 @@ import 'svg.dart';
 
 @JS('TimeEvent')
 @staticInterop
-class TimeEvent extends Event {
-  external factory TimeEvent();
-}
+class TimeEvent implements Event {}
 
 extension TimeEventExtension on TimeEvent {
-  external Window? get view;
-  external JSNumber get detail;
   external JSVoid initTimeEvent(
     JSString typeArg,
     Window? viewArg,
     JSNumber detailArg,
   );
+  external Window? get view;
+  external JSNumber get detail;
 }
 
 @JS('SVGAnimationElement')
 @staticInterop
-class SVGAnimationElement extends SVGElement implements SVGTests {
-  external factory SVGAnimationElement();
-}
+class SVGAnimationElement implements SVGElement, SVGTests {}
 
 extension SVGAnimationElementExtension on SVGAnimationElement {
-  external SVGElement? get targetElement;
-  external set onbegin(EventHandler value);
-  external EventHandler get onbegin;
-  external set onend(EventHandler value);
-  external EventHandler get onend;
-  external set onrepeat(EventHandler value);
-  external EventHandler get onrepeat;
   external JSNumber getStartTime();
   external JSNumber getCurrentTime();
   external JSNumber getSimpleDuration();
@@ -49,40 +38,35 @@ extension SVGAnimationElementExtension on SVGAnimationElement {
   external JSVoid beginElementAt(JSNumber offset);
   external JSVoid endElement();
   external JSVoid endElementAt(JSNumber offset);
+  external SVGElement? get targetElement;
+  external set onbegin(EventHandler value);
+  external EventHandler get onbegin;
+  external set onend(EventHandler value);
+  external EventHandler get onend;
+  external set onrepeat(EventHandler value);
+  external EventHandler get onrepeat;
 }
 
 @JS('SVGAnimateElement')
 @staticInterop
-class SVGAnimateElement extends SVGAnimationElement {
-  external factory SVGAnimateElement();
-}
+class SVGAnimateElement implements SVGAnimationElement {}
 
 @JS('SVGSetElement')
 @staticInterop
-class SVGSetElement extends SVGAnimationElement {
-  external factory SVGSetElement();
-}
+class SVGSetElement implements SVGAnimationElement {}
 
 @JS('SVGAnimateMotionElement')
 @staticInterop
-class SVGAnimateMotionElement extends SVGAnimationElement {
-  external factory SVGAnimateMotionElement();
-}
+class SVGAnimateMotionElement implements SVGAnimationElement {}
 
 @JS('SVGMPathElement')
 @staticInterop
-class SVGMPathElement extends SVGElement implements SVGURIReference {
-  external factory SVGMPathElement();
-}
+class SVGMPathElement implements SVGElement, SVGURIReference {}
 
 @JS('SVGAnimateTransformElement')
 @staticInterop
-class SVGAnimateTransformElement extends SVGAnimationElement {
-  external factory SVGAnimateTransformElement();
-}
+class SVGAnimateTransformElement implements SVGAnimationElement {}
 
 @JS('SVGDiscardElement')
 @staticInterop
-class SVGDiscardElement extends SVGAnimationElement {
-  external factory SVGDiscardElement();
-}
+class SVGDiscardElement implements SVGAnimationElement {}

--- a/lib/src/dom/testutils.dart
+++ b/lib/src/dom/testutils.dart
@@ -13,9 +13,7 @@ external $TestUtils get TestUtils;
 
 @JS('TestUtils')
 @staticInterop
-abstract class $TestUtils {
-  external factory $TestUtils();
-}
+abstract class $TestUtils {}
 
 extension $TestUtilsExtension on $TestUtils {
   external JSPromise gc();

--- a/lib/src/dom/text_detection_api.dart
+++ b/lib/src/dom/text_detection_api.dart
@@ -14,7 +14,7 @@ import 'html.dart';
 @JS('TextDetector')
 @staticInterop
 class TextDetector {
-  external factory TextDetector.a0();
+  external factory TextDetector();
 }
 
 extension TextDetectorExtension on TextDetector {

--- a/lib/src/dom/touch_events.dart
+++ b/lib/src/dom/touch_events.dart
@@ -72,9 +72,7 @@ extension TouchInitExtension on TouchInit {
 @JS('Touch')
 @staticInterop
 class Touch {
-  external factory Touch();
-
-  external factory Touch.a1(TouchInit touchInitDict);
+  external factory Touch(TouchInit touchInitDict);
 }
 
 extension TouchExtension on Touch {
@@ -97,19 +95,17 @@ extension TouchExtension on Touch {
 
 @JS('TouchList')
 @staticInterop
-class TouchList {
-  external factory TouchList();
-}
+class TouchList {}
 
 extension TouchListExtension on TouchList {
-  external JSNumber get length;
   external Touch? item(JSNumber index);
+  external JSNumber get length;
 }
 
 @JS()
 @staticInterop
 @anonymous
-class TouchEventInit extends EventModifierInit {
+class TouchEventInit implements EventModifierInit {
   external factory TouchEventInit({
     JSArray touches = const [],
     JSArray targetTouches = const [],
@@ -128,18 +124,15 @@ extension TouchEventInitExtension on TouchEventInit {
 
 @JS('TouchEvent')
 @staticInterop
-class TouchEvent extends UIEvent {
-  external factory TouchEvent();
-
-  external factory TouchEvent.a1(JSString type);
-
-  external factory TouchEvent.a2(
-    JSString type,
+class TouchEvent implements UIEvent {
+  external factory TouchEvent(
+    JSString type, [
     TouchEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension TouchEventExtension on TouchEvent {
+  external JSBoolean getModifierState(JSString keyArg);
   external TouchList get touches;
   external TouchList get targetTouches;
   external TouchList get changedTouches;
@@ -147,5 +140,4 @@ extension TouchEventExtension on TouchEvent {
   external JSBoolean get metaKey;
   external JSBoolean get ctrlKey;
   external JSBoolean get shiftKey;
-  external JSBoolean getModifierState(JSString keyArg);
 }

--- a/lib/src/dom/trusted_types.dart
+++ b/lib/src/dom/trusted_types.dart
@@ -19,8 +19,6 @@ typedef CreateScriptURLCallback = JSFunction;
 @JS('TrustedHTML')
 @staticInterop
 class TrustedHTML {
-  external factory TrustedHTML();
-
   external static TrustedHTML fromLiteral(JSObject templateStringsArray);
 }
 
@@ -31,8 +29,6 @@ extension TrustedHTMLExtension on TrustedHTML {
 @JS('TrustedScript')
 @staticInterop
 class TrustedScript {
-  external factory TrustedScript();
-
   external static TrustedScript fromLiteral(JSObject templateStringsArray);
 }
 
@@ -43,8 +39,6 @@ extension TrustedScriptExtension on TrustedScript {
 @JS('TrustedScriptURL')
 @staticInterop
 class TrustedScriptURL {
-  external factory TrustedScriptURL();
-
   external static TrustedScriptURL fromLiteral(JSObject templateStringsArray);
 }
 
@@ -54,56 +48,37 @@ extension TrustedScriptURLExtension on TrustedScriptURL {
 
 @JS('TrustedTypePolicyFactory')
 @staticInterop
-class TrustedTypePolicyFactory {
-  external factory TrustedTypePolicyFactory();
-}
+class TrustedTypePolicyFactory {}
 
 extension TrustedTypePolicyFactoryExtension on TrustedTypePolicyFactory {
-  external TrustedTypePolicy createPolicy(JSString policyName);
-  external TrustedTypePolicy createPolicy1(
-    JSString policyName,
+  external TrustedTypePolicy createPolicy(
+    JSString policyName, [
     TrustedTypePolicyOptions policyOptions,
-  );
+  ]);
   external JSBoolean isHTML(JSAny value);
   external JSBoolean isScript(JSAny value);
   external JSBoolean isScriptURL(JSAny value);
-  external TrustedHTML get emptyHTML;
-  external TrustedScript get emptyScript;
   external JSString? getAttributeType(
     JSString tagName,
-    JSString attribute,
-  );
-  external JSString? getAttributeType1(
-    JSString tagName,
-    JSString attribute,
-    JSString elementNs,
-  );
-  external JSString? getAttributeType2(
-    JSString tagName,
-    JSString attribute,
+    JSString attribute, [
     JSString elementNs,
     JSString attrNs,
-  );
+  ]);
   external JSString? getPropertyType(
     JSString tagName,
-    JSString property,
-  );
-  external JSString? getPropertyType1(
-    JSString tagName,
-    JSString property,
+    JSString property, [
     JSString elementNs,
-  );
+  ]);
+  external TrustedHTML get emptyHTML;
+  external TrustedScript get emptyScript;
   external TrustedTypePolicy? get defaultPolicy;
 }
 
 @JS('TrustedTypePolicy')
 @staticInterop
-class TrustedTypePolicy {
-  external factory TrustedTypePolicy();
-}
+class TrustedTypePolicy {}
 
 extension TrustedTypePolicyExtension on TrustedTypePolicy {
-  external JSString get name;
   external TrustedHTML createHTML(
     JSString input,
     JSAny arguments,
@@ -116,6 +91,7 @@ extension TrustedTypePolicyExtension on TrustedTypePolicy {
     JSString input,
     JSAny arguments,
   );
+  external JSString get name;
 }
 
 @JS()

--- a/lib/src/dom/ua_client_hints.dart
+++ b/lib/src/dom/ua_client_hints.dart
@@ -88,23 +88,19 @@ extension UALowEntropyJSONExtension on UALowEntropyJSON {
 
 @JS('NavigatorUAData')
 @staticInterop
-class NavigatorUAData {
-  external factory NavigatorUAData();
-}
+class NavigatorUAData {}
 
 extension NavigatorUADataExtension on NavigatorUAData {
+  external JSPromise getHighEntropyValues(JSArray hints);
+  external UALowEntropyJSON toJSON();
   external JSArray get brands;
   external JSBoolean get mobile;
   external JSString get platform;
-  external JSPromise getHighEntropyValues(JSArray hints);
-  external UALowEntropyJSON toJSON();
 }
 
 @JS('NavigatorUA')
 @staticInterop
-class NavigatorUA {
-  external factory NavigatorUA();
-}
+class NavigatorUA {}
 
 extension NavigatorUAExtension on NavigatorUA {
   external NavigatorUAData get userAgentData;

--- a/lib/src/dom/uievents.dart
+++ b/lib/src/dom/uievents.dart
@@ -14,51 +14,31 @@ import 'input_device_capabilities.dart';
 
 @JS('UIEvent')
 @staticInterop
-class UIEvent extends Event {
-  external factory UIEvent();
-
-  external factory UIEvent.a1(JSString type);
-
-  external factory UIEvent.a2(
-    JSString type,
+class UIEvent implements Event {
+  external factory UIEvent(
+    JSString type, [
     UIEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension UIEventExtension on UIEvent {
-  external InputDeviceCapabilities? get sourceCapabilities;
-  external Window? get view;
-  external JSNumber get detail;
-  external JSVoid initUIEvent(JSString typeArg);
-  external JSVoid initUIEvent1(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-  );
-  external JSVoid initUIEvent2(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-  );
-  external JSVoid initUIEvent3(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-    Window? viewArg,
-  );
-  external JSVoid initUIEvent4(
-    JSString typeArg,
+  external JSVoid initUIEvent(
+    JSString typeArg, [
     JSBoolean bubblesArg,
     JSBoolean cancelableArg,
     Window? viewArg,
     JSNumber detailArg,
-  );
+  ]);
+  external InputDeviceCapabilities? get sourceCapabilities;
+  external Window? get view;
+  external JSNumber get detail;
   external JSNumber get which;
 }
 
 @JS()
 @staticInterop
 @anonymous
-class UIEventInit extends EventInit {
+class UIEventInit implements EventInit {
   external factory UIEventInit({
     InputDeviceCapabilities? sourceCapabilities,
     Window? view,
@@ -80,15 +60,11 @@ extension UIEventInitExtension on UIEventInit {
 
 @JS('FocusEvent')
 @staticInterop
-class FocusEvent extends UIEvent {
-  external factory FocusEvent();
-
-  external factory FocusEvent.a1(JSString type);
-
-  external factory FocusEvent.a2(
-    JSString type,
+class FocusEvent implements UIEvent {
+  external factory FocusEvent(
+    JSString type, [
     FocusEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension FocusEventExtension on FocusEvent {
@@ -98,7 +74,7 @@ extension FocusEventExtension on FocusEvent {
 @JS()
 @staticInterop
 @anonymous
-class FocusEventInit extends UIEventInit {
+class FocusEventInit implements UIEventInit {
   external factory FocusEventInit({EventTarget? relatedTarget});
 }
 
@@ -109,18 +85,32 @@ extension FocusEventInitExtension on FocusEventInit {
 
 @JS('MouseEvent')
 @staticInterop
-class MouseEvent extends UIEvent {
-  external factory MouseEvent();
-
-  external factory MouseEvent.a1(JSString type);
-
-  external factory MouseEvent.a2(
-    JSString type,
+class MouseEvent implements UIEvent {
+  external factory MouseEvent(
+    JSString type, [
     MouseEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension MouseEventExtension on MouseEvent {
+  external JSBoolean getModifierState(JSString keyArg);
+  external JSVoid initMouseEvent(
+    JSString typeArg, [
+    JSBoolean bubblesArg,
+    JSBoolean cancelableArg,
+    Window? viewArg,
+    JSNumber detailArg,
+    JSNumber screenXArg,
+    JSNumber screenYArg,
+    JSNumber clientXArg,
+    JSNumber clientYArg,
+    JSBoolean ctrlKeyArg,
+    JSBoolean altKeyArg,
+    JSBoolean shiftKeyArg,
+    JSBoolean metaKeyArg,
+    JSNumber buttonArg,
+    EventTarget? relatedTargetArg,
+  ]);
   external JSNumber get pageX;
   external JSNumber get pageY;
   external JSNumber get x;
@@ -140,161 +130,12 @@ extension MouseEventExtension on MouseEvent {
   external JSNumber get button;
   external JSNumber get buttons;
   external EventTarget? get relatedTarget;
-  external JSBoolean getModifierState(JSString keyArg);
-  external JSVoid initMouseEvent(JSString typeArg);
-  external JSVoid initMouseEvent1(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-  );
-  external JSVoid initMouseEvent2(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-  );
-  external JSVoid initMouseEvent3(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-    Window? viewArg,
-  );
-  external JSVoid initMouseEvent4(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-    Window? viewArg,
-    JSNumber detailArg,
-  );
-  external JSVoid initMouseEvent5(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-    Window? viewArg,
-    JSNumber detailArg,
-    JSNumber screenXArg,
-  );
-  external JSVoid initMouseEvent6(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-    Window? viewArg,
-    JSNumber detailArg,
-    JSNumber screenXArg,
-    JSNumber screenYArg,
-  );
-  external JSVoid initMouseEvent7(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-    Window? viewArg,
-    JSNumber detailArg,
-    JSNumber screenXArg,
-    JSNumber screenYArg,
-    JSNumber clientXArg,
-  );
-  external JSVoid initMouseEvent8(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-    Window? viewArg,
-    JSNumber detailArg,
-    JSNumber screenXArg,
-    JSNumber screenYArg,
-    JSNumber clientXArg,
-    JSNumber clientYArg,
-  );
-  external JSVoid initMouseEvent9(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-    Window? viewArg,
-    JSNumber detailArg,
-    JSNumber screenXArg,
-    JSNumber screenYArg,
-    JSNumber clientXArg,
-    JSNumber clientYArg,
-    JSBoolean ctrlKeyArg,
-  );
-  external JSVoid initMouseEvent10(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-    Window? viewArg,
-    JSNumber detailArg,
-    JSNumber screenXArg,
-    JSNumber screenYArg,
-    JSNumber clientXArg,
-    JSNumber clientYArg,
-    JSBoolean ctrlKeyArg,
-    JSBoolean altKeyArg,
-  );
-  external JSVoid initMouseEvent11(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-    Window? viewArg,
-    JSNumber detailArg,
-    JSNumber screenXArg,
-    JSNumber screenYArg,
-    JSNumber clientXArg,
-    JSNumber clientYArg,
-    JSBoolean ctrlKeyArg,
-    JSBoolean altKeyArg,
-    JSBoolean shiftKeyArg,
-  );
-  external JSVoid initMouseEvent12(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-    Window? viewArg,
-    JSNumber detailArg,
-    JSNumber screenXArg,
-    JSNumber screenYArg,
-    JSNumber clientXArg,
-    JSNumber clientYArg,
-    JSBoolean ctrlKeyArg,
-    JSBoolean altKeyArg,
-    JSBoolean shiftKeyArg,
-    JSBoolean metaKeyArg,
-  );
-  external JSVoid initMouseEvent13(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-    Window? viewArg,
-    JSNumber detailArg,
-    JSNumber screenXArg,
-    JSNumber screenYArg,
-    JSNumber clientXArg,
-    JSNumber clientYArg,
-    JSBoolean ctrlKeyArg,
-    JSBoolean altKeyArg,
-    JSBoolean shiftKeyArg,
-    JSBoolean metaKeyArg,
-    JSNumber buttonArg,
-  );
-  external JSVoid initMouseEvent14(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-    Window? viewArg,
-    JSNumber detailArg,
-    JSNumber screenXArg,
-    JSNumber screenYArg,
-    JSNumber clientXArg,
-    JSNumber clientYArg,
-    JSBoolean ctrlKeyArg,
-    JSBoolean altKeyArg,
-    JSBoolean shiftKeyArg,
-    JSBoolean metaKeyArg,
-    JSNumber buttonArg,
-    EventTarget? relatedTargetArg,
-  );
 }
 
 @JS()
 @staticInterop
 @anonymous
-class MouseEventInit extends EventModifierInit {
+class MouseEventInit implements EventModifierInit {
   external factory MouseEventInit({
     JSNumber movementX = 0,
     JSNumber movementY = 0,
@@ -332,7 +173,7 @@ extension MouseEventInitExtension on MouseEventInit {
 @JS()
 @staticInterop
 @anonymous
-class EventModifierInit extends UIEventInit {
+class EventModifierInit implements UIEventInit {
   external factory EventModifierInit({
     JSBoolean ctrlKey = false,
     JSBoolean shiftKey = false,
@@ -384,15 +225,11 @@ extension EventModifierInitExtension on EventModifierInit {
 
 @JS('WheelEvent')
 @staticInterop
-class WheelEvent extends MouseEvent {
-  external factory WheelEvent();
-
-  external factory WheelEvent.a1(JSString type);
-
-  external factory WheelEvent.a2(
-    JSString type,
+class WheelEvent implements MouseEvent {
+  external factory WheelEvent(
+    JSString type, [
     WheelEventInit eventInitDict,
-  );
+  ]);
 
   external static JSNumber get DOM_DELTA_PIXEL;
   external static JSNumber get DOM_DELTA_LINE;
@@ -409,7 +246,7 @@ extension WheelEventExtension on WheelEvent {
 @JS()
 @staticInterop
 @anonymous
-class WheelEventInit extends MouseEventInit {
+class WheelEventInit implements MouseEventInit {
   external factory WheelEventInit({
     JSNumber deltaX = 0.0,
     JSNumber deltaY = 0.0,
@@ -431,20 +268,16 @@ extension WheelEventInitExtension on WheelEventInit {
 
 @JS('InputEvent')
 @staticInterop
-class InputEvent extends UIEvent {
-  external factory InputEvent();
-
-  external factory InputEvent.a1(JSString type);
-
-  external factory InputEvent.a2(
-    JSString type,
+class InputEvent implements UIEvent {
+  external factory InputEvent(
+    JSString type, [
     InputEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension InputEventExtension on InputEvent {
-  external DataTransfer? get dataTransfer;
   external JSArray getTargetRanges();
+  external DataTransfer? get dataTransfer;
   external JSString? get data;
   external JSBoolean get isComposing;
   external JSString get inputType;
@@ -453,7 +286,7 @@ extension InputEventExtension on InputEvent {
 @JS()
 @staticInterop
 @anonymous
-class InputEventInit extends UIEventInit {
+class InputEventInit implements UIEventInit {
   external factory InputEventInit({
     DataTransfer? dataTransfer,
     JSArray targetRanges = const [],
@@ -478,15 +311,11 @@ extension InputEventInitExtension on InputEventInit {
 
 @JS('KeyboardEvent')
 @staticInterop
-class KeyboardEvent extends UIEvent {
-  external factory KeyboardEvent();
-
-  external factory KeyboardEvent.a1(JSString type);
-
-  external factory KeyboardEvent.a2(
-    JSString type,
+class KeyboardEvent implements UIEvent {
+  external factory KeyboardEvent(
+    JSString type, [
     KeyboardEventInit eventInitDict,
-  );
+  ]);
 
   external static JSNumber get DOM_KEY_LOCATION_STANDARD;
   external static JSNumber get DOM_KEY_LOCATION_LEFT;
@@ -495,79 +324,9 @@ class KeyboardEvent extends UIEvent {
 }
 
 extension KeyboardEventExtension on KeyboardEvent {
-  external JSString get key;
-  external JSString get code;
-  external JSNumber get location;
-  external JSBoolean get ctrlKey;
-  external JSBoolean get shiftKey;
-  external JSBoolean get altKey;
-  external JSBoolean get metaKey;
-  external JSBoolean get repeat;
-  external JSBoolean get isComposing;
   external JSBoolean getModifierState(JSString keyArg);
-  external JSVoid initKeyboardEvent(JSString typeArg);
-  external JSVoid initKeyboardEvent1(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-  );
-  external JSVoid initKeyboardEvent2(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-  );
-  external JSVoid initKeyboardEvent3(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-    Window? viewArg,
-  );
-  external JSVoid initKeyboardEvent4(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-    Window? viewArg,
-    JSString keyArg,
-  );
-  external JSVoid initKeyboardEvent5(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-    Window? viewArg,
-    JSString keyArg,
-    JSNumber locationArg,
-  );
-  external JSVoid initKeyboardEvent6(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-    Window? viewArg,
-    JSString keyArg,
-    JSNumber locationArg,
-    JSBoolean ctrlKey,
-  );
-  external JSVoid initKeyboardEvent7(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-    Window? viewArg,
-    JSString keyArg,
-    JSNumber locationArg,
-    JSBoolean ctrlKey,
-    JSBoolean altKey,
-  );
-  external JSVoid initKeyboardEvent8(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-    Window? viewArg,
-    JSString keyArg,
-    JSNumber locationArg,
-    JSBoolean ctrlKey,
-    JSBoolean altKey,
-    JSBoolean shiftKey,
-  );
-  external JSVoid initKeyboardEvent9(
-    JSString typeArg,
+  external JSVoid initKeyboardEvent(
+    JSString typeArg, [
     JSBoolean bubblesArg,
     JSBoolean cancelableArg,
     Window? viewArg,
@@ -577,7 +336,16 @@ extension KeyboardEventExtension on KeyboardEvent {
     JSBoolean altKey,
     JSBoolean shiftKey,
     JSBoolean metaKey,
-  );
+  ]);
+  external JSString get key;
+  external JSString get code;
+  external JSNumber get location;
+  external JSBoolean get ctrlKey;
+  external JSBoolean get shiftKey;
+  external JSBoolean get altKey;
+  external JSBoolean get metaKey;
+  external JSBoolean get repeat;
+  external JSBoolean get isComposing;
   external JSNumber get charCode;
   external JSNumber get keyCode;
 }
@@ -585,7 +353,7 @@ extension KeyboardEventExtension on KeyboardEvent {
 @JS()
 @staticInterop
 @anonymous
-class KeyboardEventInit extends EventModifierInit {
+class KeyboardEventInit implements EventModifierInit {
   external factory KeyboardEventInit({
     JSString key = '',
     JSString code = '',
@@ -616,48 +384,28 @@ extension KeyboardEventInitExtension on KeyboardEventInit {
 
 @JS('CompositionEvent')
 @staticInterop
-class CompositionEvent extends UIEvent {
-  external factory CompositionEvent();
-
-  external factory CompositionEvent.a1(JSString type);
-
-  external factory CompositionEvent.a2(
-    JSString type,
+class CompositionEvent implements UIEvent {
+  external factory CompositionEvent(
+    JSString type, [
     CompositionEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension CompositionEventExtension on CompositionEvent {
-  external JSString get data;
-  external JSVoid initCompositionEvent(JSString typeArg);
-  external JSVoid initCompositionEvent1(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-  );
-  external JSVoid initCompositionEvent2(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-  );
-  external JSVoid initCompositionEvent3(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-    Window? viewArg,
-  );
-  external JSVoid initCompositionEvent4(
-    JSString typeArg,
+  external JSVoid initCompositionEvent(
+    JSString typeArg, [
     JSBoolean bubblesArg,
     JSBoolean cancelableArg,
     Window? viewArg,
     JSString dataArg,
-  );
+  ]);
+  external JSString get data;
 }
 
 @JS()
 @staticInterop
 @anonymous
-class CompositionEventInit extends UIEventInit {
+class CompositionEventInit implements UIEventInit {
   external factory CompositionEventInit({JSString data = ''});
 }
 
@@ -668,62 +416,15 @@ extension CompositionEventInitExtension on CompositionEventInit {
 
 @JS('MutationEvent')
 @staticInterop
-class MutationEvent extends Event {
-  external factory MutationEvent();
-
+class MutationEvent implements Event {
   external static JSNumber get MODIFICATION;
   external static JSNumber get ADDITION;
   external static JSNumber get REMOVAL;
 }
 
 extension MutationEventExtension on MutationEvent {
-  external Node? get relatedNode;
-  external JSString get prevValue;
-  external JSString get newValue;
-  external JSString get attrName;
-  external JSNumber get attrChange;
-  external JSVoid initMutationEvent(JSString typeArg);
-  external JSVoid initMutationEvent1(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-  );
-  external JSVoid initMutationEvent2(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-  );
-  external JSVoid initMutationEvent3(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-    Node? relatedNodeArg,
-  );
-  external JSVoid initMutationEvent4(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-    Node? relatedNodeArg,
-    JSString prevValueArg,
-  );
-  external JSVoid initMutationEvent5(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-    Node? relatedNodeArg,
-    JSString prevValueArg,
-    JSString newValueArg,
-  );
-  external JSVoid initMutationEvent6(
-    JSString typeArg,
-    JSBoolean bubblesArg,
-    JSBoolean cancelableArg,
-    Node? relatedNodeArg,
-    JSString prevValueArg,
-    JSString newValueArg,
-    JSString attrNameArg,
-  );
-  external JSVoid initMutationEvent7(
-    JSString typeArg,
+  external JSVoid initMutationEvent(
+    JSString typeArg, [
     JSBoolean bubblesArg,
     JSBoolean cancelableArg,
     Node? relatedNodeArg,
@@ -731,5 +432,10 @@ extension MutationEventExtension on MutationEvent {
     JSString newValueArg,
     JSString attrNameArg,
     JSNumber attrChangeArg,
-  );
+  ]);
+  external Node? get relatedNode;
+  external JSString get prevValue;
+  external JSString get newValue;
+  external JSString get attrName;
+  external JSNumber get attrChange;
 }

--- a/lib/src/dom/url.dart
+++ b/lib/src/dom/url.dart
@@ -11,20 +11,17 @@ import 'package:js/js.dart' hide JS;
 @JS('URL')
 @staticInterop
 class URL {
-  external factory URL();
-
-  external factory URL.a1(JSString url);
-
-  external factory URL.a2(
-    JSString url,
+  external factory URL(
+    JSString url, [
     JSString base,
-  );
+  ]);
 
   external static JSString createObjectURL(JSAny obj);
   external static JSVoid revokeObjectURL(JSString url);
 }
 
 extension URLExtension on URL {
+  external JSString toJSON();
   external set href(JSString value);
   external JSString get href;
   external JSString get origin;
@@ -47,17 +44,12 @@ extension URLExtension on URL {
   external URLSearchParams get searchParams;
   external set hash(JSString value);
   external JSString get hash;
-  external JSString toJSON();
 }
 
 @JS('URLSearchParams')
 @staticInterop
 class URLSearchParams {
-  external factory URLSearchParams();
-
-  external factory URLSearchParams.a1();
-
-  external factory URLSearchParams.a2(JSAny init);
+  external factory URLSearchParams([JSAny init]);
 }
 
 extension URLSearchParamsExtension on URLSearchParams {

--- a/lib/src/dom/urlpattern.dart
+++ b/lib/src/dom/urlpattern.dart
@@ -13,42 +13,22 @@ typedef URLPatternInput = JSAny;
 @JS('URLPattern')
 @staticInterop
 class URLPattern {
-  external factory URLPattern();
-
-  external factory URLPattern.a1(
+  external factory URLPattern([
     URLPatternInput input,
-    JSString baseURL,
-  );
-
-  external factory URLPattern.a2(
-    URLPatternInput input,
-    JSString baseURL,
+    JSAny baseURLOrOptions,
     URLPatternOptions options,
-  );
-
-  external factory URLPattern.a3();
-
-  external factory URLPattern.a4(URLPatternInput input);
-
-  external factory URLPattern.a5(
-    URLPatternInput input,
-    URLPatternOptions options,
-  );
+  ]);
 }
 
 extension URLPatternExtension on URLPattern {
-  external JSBoolean test();
-  external JSBoolean test1(URLPatternInput input);
-  external JSBoolean test2(
+  external JSBoolean test([
     URLPatternInput input,
     JSString baseURL,
-  );
-  external URLPatternResult? exec();
-  external URLPatternResult? exec1(URLPatternInput input);
-  external URLPatternResult? exec2(
+  ]);
+  external URLPatternResult? exec([
     URLPatternInput input,
     JSString baseURL,
-  );
+  ]);
   external JSString get protocol;
   external JSString get username;
   external JSString get password;

--- a/lib/src/dom/user_timing.dart
+++ b/lib/src/dom/user_timing.dart
@@ -53,15 +53,11 @@ extension PerformanceMeasureOptionsExtension on PerformanceMeasureOptions {
 
 @JS('PerformanceMark')
 @staticInterop
-class PerformanceMark extends PerformanceEntry {
-  external factory PerformanceMark();
-
-  external factory PerformanceMark.a1(JSString markName);
-
-  external factory PerformanceMark.a2(
-    JSString markName,
+class PerformanceMark implements PerformanceEntry {
+  external factory PerformanceMark(
+    JSString markName, [
     PerformanceMarkOptions markOptions,
-  );
+  ]);
 }
 
 extension PerformanceMarkExtension on PerformanceMark {
@@ -70,9 +66,7 @@ extension PerformanceMarkExtension on PerformanceMark {
 
 @JS('PerformanceMeasure')
 @staticInterop
-class PerformanceMeasure extends PerformanceEntry {
-  external factory PerformanceMeasure();
-}
+class PerformanceMeasure implements PerformanceEntry {}
 
 extension PerformanceMeasureExtension on PerformanceMeasure {
   external JSAny get detail;

--- a/lib/src/dom/virtual_keyboard.dart
+++ b/lib/src/dom/virtual_keyboard.dart
@@ -14,9 +14,7 @@ import 'html.dart';
 
 @JS('VirtualKeyboard')
 @staticInterop
-class VirtualKeyboard extends EventTarget {
-  external factory VirtualKeyboard();
-}
+class VirtualKeyboard implements EventTarget {}
 
 extension VirtualKeyboardExtension on VirtualKeyboard {
   external JSVoid show();

--- a/lib/src/dom/wai_aria.dart
+++ b/lib/src/dom/wai_aria.dart
@@ -12,9 +12,7 @@ import 'dom.dart';
 
 @JS('ARIAMixin')
 @staticInterop
-class ARIAMixin {
-  external factory ARIAMixin();
-}
+class ARIAMixin {}
 
 extension ARIAMixinExtension on ARIAMixin {
   external set role(JSString? value);

--- a/lib/src/dom/wasm_js_api.dart
+++ b/lib/src/dom/wasm_js_api.dart
@@ -37,31 +37,20 @@ external $WebAssembly get WebAssembly;
 
 @JS('WebAssembly')
 @staticInterop
-abstract class $WebAssembly {
-  external factory $WebAssembly();
-}
+abstract class $WebAssembly {}
 
 extension $WebAssemblyExtension on $WebAssembly {
   external JSBoolean validate(BufferSource bytes);
   external JSPromise compile(BufferSource bytes);
-  external JSPromise instantiate(BufferSource bytes);
-  external JSPromise instantiate1(
-    BufferSource bytes,
+  external JSPromise instantiate(
+    JSAny bytesOrModuleObject, [
     JSObject importObject,
-  );
-  @JS('instantiate')
-  external JSPromise instantiate_1_(Module moduleObject);
-  @JS('instantiate')
-  external JSPromise instantiate_1_1(
-    Module moduleObject,
-    JSObject importObject,
-  );
+  ]);
   external JSPromise compileStreaming(JSPromise source);
-  external JSPromise instantiateStreaming(JSPromise source);
-  external JSPromise instantiateStreaming1(
-    JSPromise source,
+  external JSPromise instantiateStreaming(
+    JSPromise source, [
     JSObject importObject,
-  );
+  ]);
 }
 
 @JS()
@@ -104,9 +93,7 @@ extension ModuleImportDescriptorExtension on ModuleImportDescriptor {
 @JS('Module')
 @staticInterop
 class Module {
-  external factory Module();
-
-  external factory Module.a1(BufferSource bytes);
+  external factory Module(BufferSource bytes);
 
   external static JSArray exports(Module moduleObject);
   external static JSArray imports(Module moduleObject);
@@ -119,14 +106,10 @@ class Module {
 @JS('Instance')
 @staticInterop
 class Instance {
-  external factory Instance();
-
-  external factory Instance.a1(Module module);
-
-  external factory Instance.a2(
-    Module module,
+  external factory Instance(
+    Module module, [
     JSObject importObject,
-  );
+  ]);
 }
 
 extension InstanceExtension on Instance {
@@ -153,9 +136,7 @@ extension MemoryDescriptorExtension on MemoryDescriptor {
 @JS('Memory')
 @staticInterop
 class Memory {
-  external factory Memory();
-
-  external factory Memory.a1(MemoryDescriptor descriptor);
+  external factory Memory(MemoryDescriptor descriptor);
 }
 
 extension MemoryExtension on Memory {
@@ -186,28 +167,22 @@ extension TableDescriptorExtension on TableDescriptor {
 @JS('Table')
 @staticInterop
 class Table {
-  external factory Table();
-
-  external factory Table.a1(TableDescriptor descriptor);
-
-  external factory Table.a2(
-    TableDescriptor descriptor,
+  external factory Table(
+    TableDescriptor descriptor, [
     JSAny value,
-  );
+  ]);
 }
 
 extension TableExtension on Table {
-  external JSNumber grow(JSNumber delta);
-  external JSNumber grow1(
-    JSNumber delta,
+  external JSNumber grow(
+    JSNumber delta, [
     JSAny value,
-  );
+  ]);
   external JSAny get(JSNumber index);
-  external JSVoid set(JSNumber index);
-  external JSVoid set1(
-    JSNumber index,
+  external JSVoid set(
+    JSNumber index, [
     JSAny value,
-  );
+  ]);
   external JSNumber get length;
 }
 
@@ -231,14 +206,10 @@ extension GlobalDescriptorExtension on GlobalDescriptor {
 @JS('Global')
 @staticInterop
 class Global {
-  external factory Global();
-
-  external factory Global.a1(GlobalDescriptor descriptor);
-
-  external factory Global.a2(
-    GlobalDescriptor descriptor,
+  external factory Global(
+    GlobalDescriptor descriptor, [
     JSAny v,
-  );
+  ]);
 }
 
 extension GlobalExtension on Global {

--- a/lib/src/dom/web_animations.dart
+++ b/lib/src/dom/web_animations.dart
@@ -23,17 +23,13 @@ typedef CompositeOperationOrAuto = JSString;
 
 @JS('AnimationTimeline')
 @staticInterop
-class AnimationTimeline {
-  external factory AnimationTimeline();
-}
+class AnimationTimeline {}
 
 extension AnimationTimelineExtension on AnimationTimeline {
-  external CSSNumericValue? getCurrentTime();
-  external CSSNumericValue? getCurrentTime1(JSString rangeName);
+  external CSSNumericValue? getCurrentTime([JSString rangeName]);
+  external Animation play([AnimationEffect? effect]);
   external CSSNumberish? get currentTime;
   external CSSNumberish? get duration;
-  external Animation play();
-  external Animation play1(AnimationEffect? effect);
 }
 
 @JS()
@@ -51,30 +47,28 @@ extension DocumentTimelineOptionsExtension on DocumentTimelineOptions {
 
 @JS('DocumentTimeline')
 @staticInterop
-class DocumentTimeline extends AnimationTimeline {
-  external factory DocumentTimeline();
-
-  external factory DocumentTimeline.a1();
-
-  external factory DocumentTimeline.a2(DocumentTimelineOptions options);
+class DocumentTimeline implements AnimationTimeline {
+  external factory DocumentTimeline([DocumentTimelineOptions options]);
 }
 
 @JS('Animation')
 @staticInterop
-class Animation extends EventTarget {
-  external factory Animation();
-
-  external factory Animation.a1();
-
-  external factory Animation.a2(AnimationEffect? effect);
-
-  external factory Animation.a3(
+class Animation implements EventTarget {
+  external factory Animation([
     AnimationEffect? effect,
     AnimationTimeline? timeline,
-  );
+  ]);
 }
 
 extension AnimationExtension on Animation {
+  external JSVoid cancel();
+  external JSVoid finish();
+  external JSVoid play();
+  external JSVoid pause();
+  external JSVoid updatePlaybackRate(JSNumber playbackRate);
+  external JSVoid reverse();
+  external JSVoid persist();
+  external JSVoid commitStyles();
   external set startTime(CSSNumberish? value);
   external CSSNumberish? get startTime;
   external set currentTime(CSSNumberish? value);
@@ -98,34 +92,23 @@ extension AnimationExtension on Animation {
   external EventHandler get oncancel;
   external set onremove(EventHandler value);
   external EventHandler get onremove;
-  external JSVoid cancel();
-  external JSVoid finish();
-  external JSVoid play();
-  external JSVoid pause();
-  external JSVoid updatePlaybackRate(JSNumber playbackRate);
-  external JSVoid reverse();
-  external JSVoid persist();
-  external JSVoid commitStyles();
 }
 
 @JS('AnimationEffect')
 @staticInterop
-class AnimationEffect {
-  external factory AnimationEffect();
-}
+class AnimationEffect {}
 
 extension AnimationEffectExtension on AnimationEffect {
-  external GroupEffect? get parent;
-  external AnimationEffect? get previousSibling;
-  external AnimationEffect? get nextSibling;
   external JSVoid before(AnimationEffect effects);
   external JSVoid after(AnimationEffect effects);
   external JSVoid replace(AnimationEffect effects);
   external JSVoid remove();
   external EffectTiming getTiming();
   external ComputedEffectTiming getComputedTiming();
-  external JSVoid updateTiming();
-  external JSVoid updateTiming1(OptionalEffectTiming timing);
+  external JSVoid updateTiming([OptionalEffectTiming timing]);
+  external GroupEffect? get parent;
+  external AnimationEffect? get previousSibling;
+  external AnimationEffect? get nextSibling;
 }
 
 @JS()
@@ -207,7 +190,7 @@ extension OptionalEffectTimingExtension on OptionalEffectTiming {
 @JS()
 @staticInterop
 @anonymous
-class ComputedEffectTiming extends EffectTiming {
+class ComputedEffectTiming implements EffectTiming {
   external factory ComputedEffectTiming({
     CSSNumberish startTime,
     CSSNumberish endTime,
@@ -235,24 +218,17 @@ extension ComputedEffectTimingExtension on ComputedEffectTiming {
 
 @JS('KeyframeEffect')
 @staticInterop
-class KeyframeEffect extends AnimationEffect {
-  external factory KeyframeEffect();
-
-  external factory KeyframeEffect.a1(
-    Element? target,
-    JSObject? keyframes,
-  );
-
-  external factory KeyframeEffect.a2(
-    Element? target,
+class KeyframeEffect implements AnimationEffect {
+  external factory KeyframeEffect(
+    JSAny? sourceOrTarget, [
     JSObject? keyframes,
     JSAny options,
-  );
-
-  external factory KeyframeEffect.a3(KeyframeEffect source);
+  ]);
 }
 
 extension KeyframeEffectExtension on KeyframeEffect {
+  external JSArray getKeyframes();
+  external JSVoid setKeyframes(JSObject? keyframes);
   external set iterationComposite(IterationCompositeOperation value);
   external IterationCompositeOperation get iterationComposite;
   external set target(Element? value);
@@ -261,8 +237,6 @@ extension KeyframeEffectExtension on KeyframeEffect {
   external JSString? get pseudoElement;
   external set composite(CompositeOperation value);
   external CompositeOperation get composite;
-  external JSArray getKeyframes();
-  external JSVoid setKeyframes(JSObject? keyframes);
 }
 
 @JS()
@@ -331,7 +305,7 @@ extension BaseKeyframeExtension on BaseKeyframe {
 @JS()
 @staticInterop
 @anonymous
-class KeyframeEffectOptions extends EffectTiming {
+class KeyframeEffectOptions implements EffectTiming {
   external factory KeyframeEffectOptions({
     IterationCompositeOperation iterationComposite = 'replace',
     CompositeOperation composite = 'replace',
@@ -350,24 +324,20 @@ extension KeyframeEffectOptionsExtension on KeyframeEffectOptions {
 
 @JS('Animatable')
 @staticInterop
-class Animatable {
-  external factory Animatable();
-}
+class Animatable {}
 
 extension AnimatableExtension on Animatable {
-  external Animation animate(JSObject? keyframes);
-  external Animation animate1(
-    JSObject? keyframes,
+  external Animation animate(
+    JSObject? keyframes, [
     JSAny options,
-  );
-  external JSArray getAnimations();
-  external JSArray getAnimations1(GetAnimationsOptions options);
+  ]);
+  external JSArray getAnimations([GetAnimationsOptions options]);
 }
 
 @JS()
 @staticInterop
 @anonymous
-class KeyframeAnimationOptions extends KeyframeEffectOptions {
+class KeyframeAnimationOptions implements KeyframeEffectOptions {
   external factory KeyframeAnimationOptions({
     JSString id = '',
     AnimationTimeline? timeline,

--- a/lib/src/dom/web_animations_2.dart
+++ b/lib/src/dom/web_animations_2.dart
@@ -18,47 +18,37 @@ typedef IterationCompositeOperation = JSString;
 @JS('GroupEffect')
 @staticInterop
 class GroupEffect {
-  external factory GroupEffect();
-
-  external factory GroupEffect.a1(JSArray? children);
-
-  external factory GroupEffect.a2(
-    JSArray? children,
+  external factory GroupEffect(
+    JSArray? children, [
     JSAny timing,
-  );
+  ]);
 }
 
 extension GroupEffectExtension on GroupEffect {
-  external AnimationNodeList get children;
-  external AnimationEffect? get firstChild;
-  external AnimationEffect? get lastChild;
   external GroupEffect clone();
   external JSVoid prepend(AnimationEffect effects);
   external JSVoid append(AnimationEffect effects);
+  external AnimationNodeList get children;
+  external AnimationEffect? get firstChild;
+  external AnimationEffect? get lastChild;
 }
 
 @JS('AnimationNodeList')
 @staticInterop
-class AnimationNodeList {
-  external factory AnimationNodeList();
-}
+class AnimationNodeList {}
 
 extension AnimationNodeListExtension on AnimationNodeList {
-  external JSNumber get length;
   external AnimationEffect? item(JSNumber index);
+  external JSNumber get length;
 }
 
 @JS('SequenceEffect')
 @staticInterop
-class SequenceEffect extends GroupEffect {
-  external factory SequenceEffect();
-
-  external factory SequenceEffect.a1(JSArray? children);
-
-  external factory SequenceEffect.a2(
-    JSArray? children,
+class SequenceEffect implements GroupEffect {
+  external factory SequenceEffect(
+    JSArray? children, [
     JSAny timing,
-  );
+  ]);
 }
 
 extension SequenceEffectExtension on SequenceEffect {
@@ -67,15 +57,11 @@ extension SequenceEffectExtension on SequenceEffect {
 
 @JS('AnimationPlaybackEvent')
 @staticInterop
-class AnimationPlaybackEvent extends Event {
-  external factory AnimationPlaybackEvent();
-
-  external factory AnimationPlaybackEvent.a1(JSString type);
-
-  external factory AnimationPlaybackEvent.a2(
-    JSString type,
+class AnimationPlaybackEvent implements Event {
+  external factory AnimationPlaybackEvent(
+    JSString type, [
     AnimationPlaybackEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension AnimationPlaybackEventExtension on AnimationPlaybackEvent {
@@ -86,7 +72,7 @@ extension AnimationPlaybackEventExtension on AnimationPlaybackEvent {
 @JS()
 @staticInterop
 @anonymous
-class AnimationPlaybackEventInit extends EventInit {
+class AnimationPlaybackEventInit implements EventInit {
   external factory AnimationPlaybackEventInit({
     CSSNumberish? currentTime,
     CSSNumberish? timelineTime,

--- a/lib/src/dom/web_app_launch.dart
+++ b/lib/src/dom/web_app_launch.dart
@@ -12,9 +12,7 @@ typedef LaunchConsumer = JSFunction;
 
 @JS('LaunchParams')
 @staticInterop
-class LaunchParams {
-  external factory LaunchParams();
-}
+class LaunchParams {}
 
 extension LaunchParamsExtension on LaunchParams {
   external JSString? get targetURL;
@@ -23,9 +21,7 @@ extension LaunchParamsExtension on LaunchParams {
 
 @JS('LaunchQueue')
 @staticInterop
-class LaunchQueue {
-  external factory LaunchQueue();
-}
+class LaunchQueue {}
 
 extension LaunchQueueExtension on LaunchQueue {
   external JSVoid setConsumer(LaunchConsumer consumer);

--- a/lib/src/dom/web_bluetooth.dart
+++ b/lib/src/dom/web_bluetooth.dart
@@ -38,7 +38,7 @@ extension BluetoothDataFilterInitExtension on BluetoothDataFilterInit {
 @JS()
 @staticInterop
 @anonymous
-class BluetoothManufacturerDataFilterInit extends BluetoothDataFilterInit {
+class BluetoothManufacturerDataFilterInit implements BluetoothDataFilterInit {
   external factory BluetoothManufacturerDataFilterInit(
       {required JSNumber companyIdentifier});
 }
@@ -52,7 +52,7 @@ extension BluetoothManufacturerDataFilterInitExtension
 @JS()
 @staticInterop
 @anonymous
-class BluetoothServiceDataFilterInit extends BluetoothDataFilterInit {
+class BluetoothServiceDataFilterInit implements BluetoothDataFilterInit {
   external factory BluetoothServiceDataFilterInit(
       {required BluetoothServiceUUID service});
 }
@@ -114,28 +114,26 @@ extension RequestDeviceOptionsExtension on RequestDeviceOptions {
 
 @JS('Bluetooth')
 @staticInterop
-class Bluetooth extends EventTarget
+class Bluetooth
     implements
+        EventTarget,
         BluetoothDeviceEventHandlers,
         CharacteristicEventHandlers,
-        ServiceEventHandlers {
-  external factory Bluetooth();
-}
+        ServiceEventHandlers {}
 
 extension BluetoothExtension on Bluetooth {
   external JSPromise getAvailability();
+  external JSPromise getDevices();
+  external JSPromise requestDevice([RequestDeviceOptions options]);
   external set onavailabilitychanged(EventHandler value);
   external EventHandler get onavailabilitychanged;
   external BluetoothDevice? get referringDevice;
-  external JSPromise getDevices();
-  external JSPromise requestDevice();
-  external JSPromise requestDevice1(RequestDeviceOptions options);
 }
 
 @JS()
 @staticInterop
 @anonymous
-class BluetoothPermissionDescriptor extends PermissionDescriptor {
+class BluetoothPermissionDescriptor implements PermissionDescriptor {
   external factory BluetoothPermissionDescriptor({
     JSString deviceId,
     JSArray filters,
@@ -197,9 +195,7 @@ extension BluetoothPermissionStorageExtension on BluetoothPermissionStorage {
 
 @JS('BluetoothPermissionResult')
 @staticInterop
-class BluetoothPermissionResult extends PermissionStatus {
-  external factory BluetoothPermissionResult();
-}
+class BluetoothPermissionResult implements PermissionStatus {}
 
 extension BluetoothPermissionResultExtension on BluetoothPermissionResult {
   external set devices(JSArray value);
@@ -208,15 +204,11 @@ extension BluetoothPermissionResultExtension on BluetoothPermissionResult {
 
 @JS('ValueEvent')
 @staticInterop
-class ValueEvent extends Event {
-  external factory ValueEvent();
-
-  external factory ValueEvent.a1(JSString type);
-
-  external factory ValueEvent.a2(
-    JSString type,
+class ValueEvent implements Event {
+  external factory ValueEvent(
+    JSString type, [
     ValueEventInit initDict,
-  );
+  ]);
 }
 
 extension ValueEventExtension on ValueEvent {
@@ -226,7 +218,7 @@ extension ValueEventExtension on ValueEvent {
 @JS()
 @staticInterop
 @anonymous
-class ValueEventInit extends EventInit {
+class ValueEventInit implements EventInit {
   external factory ValueEventInit({JSAny value});
 }
 
@@ -237,21 +229,19 @@ extension ValueEventInitExtension on ValueEventInit {
 
 @JS('BluetoothDevice')
 @staticInterop
-class BluetoothDevice extends EventTarget
+class BluetoothDevice
     implements
+        EventTarget,
         BluetoothDeviceEventHandlers,
         CharacteristicEventHandlers,
-        ServiceEventHandlers {
-  external factory BluetoothDevice();
-}
+        ServiceEventHandlers {}
 
 extension BluetoothDeviceExtension on BluetoothDevice {
+  external JSPromise forget();
+  external JSPromise watchAdvertisements([WatchAdvertisementsOptions options]);
   external JSString get id;
   external JSString? get name;
   external BluetoothRemoteGATTServer? get gatt;
-  external JSPromise forget();
-  external JSPromise watchAdvertisements();
-  external JSPromise watchAdvertisements1(WatchAdvertisementsOptions options);
   external JSBoolean get watchingAdvertisements;
 }
 
@@ -269,27 +259,21 @@ extension WatchAdvertisementsOptionsExtension on WatchAdvertisementsOptions {
 
 @JS('BluetoothManufacturerDataMap')
 @staticInterop
-class BluetoothManufacturerDataMap {
-  external factory BluetoothManufacturerDataMap();
-}
+class BluetoothManufacturerDataMap {}
 
 extension BluetoothManufacturerDataMapExtension
     on BluetoothManufacturerDataMap {}
 
 @JS('BluetoothServiceDataMap')
 @staticInterop
-class BluetoothServiceDataMap {
-  external factory BluetoothServiceDataMap();
-}
+class BluetoothServiceDataMap {}
 
 extension BluetoothServiceDataMapExtension on BluetoothServiceDataMap {}
 
 @JS('BluetoothAdvertisingEvent')
 @staticInterop
-class BluetoothAdvertisingEvent extends Event {
-  external factory BluetoothAdvertisingEvent();
-
-  external factory BluetoothAdvertisingEvent.a1(
+class BluetoothAdvertisingEvent implements Event {
+  external factory BluetoothAdvertisingEvent(
     JSString type,
     BluetoothAdvertisingEventInit init,
   );
@@ -309,7 +293,7 @@ extension BluetoothAdvertisingEventExtension on BluetoothAdvertisingEvent {
 @JS()
 @staticInterop
 @anonymous
-class BluetoothAdvertisingEventInit extends EventInit {
+class BluetoothAdvertisingEventInit implements EventInit {
   external factory BluetoothAdvertisingEventInit({
     required BluetoothDevice device,
     JSArray uuids,
@@ -344,70 +328,58 @@ extension BluetoothAdvertisingEventInitExtension
 
 @JS('BluetoothRemoteGATTServer')
 @staticInterop
-class BluetoothRemoteGATTServer {
-  external factory BluetoothRemoteGATTServer();
-}
+class BluetoothRemoteGATTServer {}
 
 extension BluetoothRemoteGATTServerExtension on BluetoothRemoteGATTServer {
-  external BluetoothDevice get device;
-  external JSBoolean get connected;
   external JSPromise connect();
   external JSVoid disconnect();
   external JSPromise getPrimaryService(BluetoothServiceUUID service);
-  external JSPromise getPrimaryServices();
-  external JSPromise getPrimaryServices1(BluetoothServiceUUID service);
+  external JSPromise getPrimaryServices([BluetoothServiceUUID service]);
+  external BluetoothDevice get device;
+  external JSBoolean get connected;
 }
 
 @JS('BluetoothRemoteGATTService')
 @staticInterop
-class BluetoothRemoteGATTService extends EventTarget
-    implements CharacteristicEventHandlers, ServiceEventHandlers {
-  external factory BluetoothRemoteGATTService();
-}
+class BluetoothRemoteGATTService
+    implements EventTarget, CharacteristicEventHandlers, ServiceEventHandlers {}
 
 extension BluetoothRemoteGATTServiceExtension on BluetoothRemoteGATTService {
+  external JSPromise getCharacteristic(
+      BluetoothCharacteristicUUID characteristic);
+  external JSPromise getCharacteristics(
+      [BluetoothCharacteristicUUID characteristic]);
+  external JSPromise getIncludedService(BluetoothServiceUUID service);
+  external JSPromise getIncludedServices([BluetoothServiceUUID service]);
   external BluetoothDevice get device;
   external UUID get uuid;
   external JSBoolean get isPrimary;
-  external JSPromise getCharacteristic(
-      BluetoothCharacteristicUUID characteristic);
-  external JSPromise getCharacteristics();
-  external JSPromise getCharacteristics1(
-      BluetoothCharacteristicUUID characteristic);
-  external JSPromise getIncludedService(BluetoothServiceUUID service);
-  external JSPromise getIncludedServices();
-  external JSPromise getIncludedServices1(BluetoothServiceUUID service);
 }
 
 @JS('BluetoothRemoteGATTCharacteristic')
 @staticInterop
-class BluetoothRemoteGATTCharacteristic extends EventTarget
-    implements CharacteristicEventHandlers {
-  external factory BluetoothRemoteGATTCharacteristic();
-}
+class BluetoothRemoteGATTCharacteristic
+    implements EventTarget, CharacteristicEventHandlers {}
 
 extension BluetoothRemoteGATTCharacteristicExtension
     on BluetoothRemoteGATTCharacteristic {
-  external BluetoothRemoteGATTService get service;
-  external UUID get uuid;
-  external BluetoothCharacteristicProperties get properties;
-  external JSDataView? get value;
   external JSPromise getDescriptor(BluetoothDescriptorUUID descriptor);
-  external JSPromise getDescriptors();
-  external JSPromise getDescriptors1(BluetoothDescriptorUUID descriptor);
+  external JSPromise getDescriptors([BluetoothDescriptorUUID descriptor]);
   external JSPromise readValue();
   external JSPromise writeValue(BufferSource value);
   external JSPromise writeValueWithResponse(BufferSource value);
   external JSPromise writeValueWithoutResponse(BufferSource value);
   external JSPromise startNotifications();
   external JSPromise stopNotifications();
+  external BluetoothRemoteGATTService get service;
+  external UUID get uuid;
+  external BluetoothCharacteristicProperties get properties;
+  external JSDataView? get value;
 }
 
 @JS('BluetoothCharacteristicProperties')
 @staticInterop
-class BluetoothCharacteristicProperties {
-  external factory BluetoothCharacteristicProperties();
-}
+class BluetoothCharacteristicProperties {}
 
 extension BluetoothCharacteristicPropertiesExtension
     on BluetoothCharacteristicProperties {
@@ -424,24 +396,20 @@ extension BluetoothCharacteristicPropertiesExtension
 
 @JS('BluetoothRemoteGATTDescriptor')
 @staticInterop
-class BluetoothRemoteGATTDescriptor {
-  external factory BluetoothRemoteGATTDescriptor();
-}
+class BluetoothRemoteGATTDescriptor {}
 
 extension BluetoothRemoteGATTDescriptorExtension
     on BluetoothRemoteGATTDescriptor {
+  external JSPromise readValue();
+  external JSPromise writeValue(BufferSource value);
   external BluetoothRemoteGATTCharacteristic get characteristic;
   external UUID get uuid;
   external JSDataView? get value;
-  external JSPromise readValue();
-  external JSPromise writeValue(BufferSource value);
 }
 
 @JS('CharacteristicEventHandlers')
 @staticInterop
-class CharacteristicEventHandlers {
-  external factory CharacteristicEventHandlers();
-}
+class CharacteristicEventHandlers {}
 
 extension CharacteristicEventHandlersExtension on CharacteristicEventHandlers {
   external set oncharacteristicvaluechanged(EventHandler value);
@@ -450,9 +418,7 @@ extension CharacteristicEventHandlersExtension on CharacteristicEventHandlers {
 
 @JS('BluetoothDeviceEventHandlers')
 @staticInterop
-class BluetoothDeviceEventHandlers {
-  external factory BluetoothDeviceEventHandlers();
-}
+class BluetoothDeviceEventHandlers {}
 
 extension BluetoothDeviceEventHandlersExtension
     on BluetoothDeviceEventHandlers {
@@ -464,9 +430,7 @@ extension BluetoothDeviceEventHandlersExtension
 
 @JS('ServiceEventHandlers')
 @staticInterop
-class ServiceEventHandlers {
-  external factory ServiceEventHandlers();
-}
+class ServiceEventHandlers {}
 
 extension ServiceEventHandlersExtension on ServiceEventHandlers {
   external set onserviceadded(EventHandler value);
@@ -480,8 +444,6 @@ extension ServiceEventHandlersExtension on ServiceEventHandlers {
 @JS('BluetoothUUID')
 @staticInterop
 class BluetoothUUID {
-  external factory BluetoothUUID();
-
   external static UUID getService(JSAny name);
   external static UUID getCharacteristic(JSAny name);
   external static UUID getDescriptor(JSAny name);

--- a/lib/src/dom/web_locks.dart
+++ b/lib/src/dom/web_locks.dart
@@ -15,9 +15,7 @@ typedef LockMode = JSString;
 
 @JS('NavigatorLocks')
 @staticInterop
-class NavigatorLocks {
-  external factory NavigatorLocks();
-}
+class NavigatorLocks {}
 
 extension NavigatorLocksExtension on NavigatorLocks {
   external LockManager get locks;
@@ -25,21 +23,14 @@ extension NavigatorLocksExtension on NavigatorLocks {
 
 @JS('LockManager')
 @staticInterop
-class LockManager {
-  external factory LockManager();
-}
+class LockManager {}
 
 extension LockManagerExtension on LockManager {
   external JSPromise request(
     JSString name,
+    JSAny callbackOrOptions, [
     LockGrantedCallback callback,
-  );
-  @JS('request')
-  external JSPromise request_1_(
-    JSString name,
-    LockOptions options,
-    LockGrantedCallback callback,
-  );
+  ]);
   external JSPromise query();
 }
 
@@ -105,9 +96,7 @@ extension LockInfoExtension on LockInfo {
 
 @JS('Lock')
 @staticInterop
-class Lock {
-  external factory Lock();
-}
+class Lock {}
 
 extension LockExtension on Lock {
   external JSString get name;

--- a/lib/src/dom/web_nfc.dart
+++ b/lib/src/dom/web_nfc.dart
@@ -16,9 +16,7 @@ typedef NDEFMessageSource = JSAny;
 @JS('NDEFMessage')
 @staticInterop
 class NDEFMessage {
-  external factory NDEFMessage();
-
-  external factory NDEFMessage.a1(NDEFMessageInit messageInit);
+  external factory NDEFMessage(NDEFMessageInit messageInit);
 }
 
 extension NDEFMessageExtension on NDEFMessage {
@@ -40,19 +38,17 @@ extension NDEFMessageInitExtension on NDEFMessageInit {
 @JS('NDEFRecord')
 @staticInterop
 class NDEFRecord {
-  external factory NDEFRecord();
-
-  external factory NDEFRecord.a1(NDEFRecordInit recordInit);
+  external factory NDEFRecord(NDEFRecordInit recordInit);
 }
 
 extension NDEFRecordExtension on NDEFRecord {
+  external JSArray? toRecords();
   external JSString get recordType;
   external JSString? get mediaType;
   external JSString? get id;
   external JSDataView? get data;
   external JSString? get encoding;
   external JSString? get lang;
-  external JSArray? toRecords();
 }
 
 @JS()
@@ -86,32 +82,27 @@ extension NDEFRecordInitExtension on NDEFRecordInit {
 
 @JS('NDEFReader')
 @staticInterop
-class NDEFReader extends EventTarget {
-  external factory NDEFReader.a0();
+class NDEFReader implements EventTarget {
+  external factory NDEFReader();
 }
 
 extension NDEFReaderExtension on NDEFReader {
+  external JSPromise scan([NDEFScanOptions options]);
+  external JSPromise write(
+    NDEFMessageSource message, [
+    NDEFWriteOptions options,
+  ]);
+  external JSPromise makeReadOnly([NDEFMakeReadOnlyOptions options]);
   external set onreading(EventHandler value);
   external EventHandler get onreading;
   external set onreadingerror(EventHandler value);
   external EventHandler get onreadingerror;
-  external JSPromise scan();
-  external JSPromise scan1(NDEFScanOptions options);
-  external JSPromise write(NDEFMessageSource message);
-  external JSPromise write1(
-    NDEFMessageSource message,
-    NDEFWriteOptions options,
-  );
-  external JSPromise makeReadOnly();
-  external JSPromise makeReadOnly1(NDEFMakeReadOnlyOptions options);
 }
 
 @JS('NDEFReadingEvent')
 @staticInterop
-class NDEFReadingEvent extends Event {
-  external factory NDEFReadingEvent();
-
-  external factory NDEFReadingEvent.a1(
+class NDEFReadingEvent implements Event {
+  external factory NDEFReadingEvent(
     JSString type,
     NDEFReadingEventInit readingEventInitDict,
   );
@@ -125,7 +116,7 @@ extension NDEFReadingEventExtension on NDEFReadingEvent {
 @JS()
 @staticInterop
 @anonymous
-class NDEFReadingEventInit extends EventInit {
+class NDEFReadingEventInit implements EventInit {
   external factory NDEFReadingEventInit({
     JSString? serialNumber = '',
     required NDEFMessageInit message,

--- a/lib/src/dom/web_otp.dart
+++ b/lib/src/dom/web_otp.dart
@@ -14,9 +14,7 @@ typedef OTPCredentialTransportType = JSString;
 
 @JS('OTPCredential')
 @staticInterop
-class OTPCredential extends Credential {
-  external factory OTPCredential();
-}
+class OTPCredential implements Credential {}
 
 extension OTPCredentialExtension on OTPCredential {
   external JSString get code;

--- a/lib/src/dom/webaudio.dart
+++ b/lib/src/dom/webaudio.dart
@@ -31,19 +31,9 @@ typedef OverSampleType = JSString;
 
 @JS('BaseAudioContext')
 @staticInterop
-class BaseAudioContext extends EventTarget {
-  external factory BaseAudioContext();
-}
+class BaseAudioContext implements EventTarget {}
 
 extension BaseAudioContextExtension on BaseAudioContext {
-  external AudioDestinationNode get destination;
-  external JSNumber get sampleRate;
-  external JSNumber get currentTime;
-  external AudioListener get listener;
-  external AudioContextState get state;
-  external AudioWorklet get audioWorklet;
-  external set onstatechange(EventHandler value);
-  external EventHandler get onstatechange;
   external AnalyserNode createAnalyser();
   external BiquadFilterNode createBiquadFilter();
   external AudioBuffer createBuffer(
@@ -52,14 +42,12 @@ extension BaseAudioContextExtension on BaseAudioContext {
     JSNumber sampleRate,
   );
   external AudioBufferSourceNode createBufferSource();
-  external ChannelMergerNode createChannelMerger();
-  external ChannelMergerNode createChannelMerger1(JSNumber numberOfInputs);
-  external ChannelSplitterNode createChannelSplitter();
-  external ChannelSplitterNode createChannelSplitter1(JSNumber numberOfOutputs);
+  external ChannelMergerNode createChannelMerger([JSNumber numberOfInputs]);
+  external ChannelSplitterNode createChannelSplitter(
+      [JSNumber numberOfOutputs]);
   external ConstantSourceNode createConstantSource();
   external ConvolverNode createConvolver();
-  external DelayNode createDelay();
-  external DelayNode createDelay1(JSNumber maxDelayTime);
+  external DelayNode createDelay([JSNumber maxDelayTime]);
   external DynamicsCompressorNode createDynamicsCompressor();
   external GainNode createGain();
   external IIRFilterNode createIIRFilter(
@@ -70,55 +58,38 @@ extension BaseAudioContextExtension on BaseAudioContext {
   external PannerNode createPanner();
   external PeriodicWave createPeriodicWave(
     JSArray real,
-    JSArray imag,
-  );
-  external PeriodicWave createPeriodicWave1(
-    JSArray real,
-    JSArray imag,
+    JSArray imag, [
     PeriodicWaveConstraints constraints,
-  );
-  external ScriptProcessorNode createScriptProcessor();
-  external ScriptProcessorNode createScriptProcessor1(JSNumber bufferSize);
-  external ScriptProcessorNode createScriptProcessor2(
-    JSNumber bufferSize,
-    JSNumber numberOfInputChannels,
-  );
-  external ScriptProcessorNode createScriptProcessor3(
+  ]);
+  external ScriptProcessorNode createScriptProcessor([
     JSNumber bufferSize,
     JSNumber numberOfInputChannels,
     JSNumber numberOfOutputChannels,
-  );
+  ]);
   external StereoPannerNode createStereoPanner();
   external WaveShaperNode createWaveShaper();
-  external JSPromise decodeAudioData(JSArrayBuffer audioData);
-  external JSPromise decodeAudioData1(
-    JSArrayBuffer audioData,
-    DecodeSuccessCallback? successCallback,
-  );
-  external JSPromise decodeAudioData2(
-    JSArrayBuffer audioData,
+  external JSPromise decodeAudioData(
+    JSArrayBuffer audioData, [
     DecodeSuccessCallback? successCallback,
     DecodeErrorCallback? errorCallback,
-  );
+  ]);
+  external AudioDestinationNode get destination;
+  external JSNumber get sampleRate;
+  external JSNumber get currentTime;
+  external AudioListener get listener;
+  external AudioContextState get state;
+  external AudioWorklet get audioWorklet;
+  external set onstatechange(EventHandler value);
+  external EventHandler get onstatechange;
 }
 
 @JS('AudioContext')
 @staticInterop
-class AudioContext extends BaseAudioContext {
-  external factory AudioContext();
-
-  external factory AudioContext.a1();
-
-  external factory AudioContext.a2(AudioContextOptions contextOptions);
+class AudioContext implements BaseAudioContext {
+  external factory AudioContext([AudioContextOptions contextOptions]);
 }
 
 extension AudioContextExtension on AudioContext {
-  external JSNumber get baseLatency;
-  external JSNumber get outputLatency;
-  external JSAny get sinkId;
-  external AudioRenderCapacity get renderCapacity;
-  external set onsinkchange(EventHandler value);
-  external EventHandler get onsinkchange;
   external AudioTimestamp getOutputTimestamp();
   external JSPromise resume();
   external JSPromise suspend();
@@ -131,6 +102,12 @@ extension AudioContextExtension on AudioContext {
   external MediaStreamTrackAudioSourceNode createMediaStreamTrackSource(
       MediaStreamTrack mediaStreamTrack);
   external MediaStreamAudioDestinationNode createMediaStreamDestination();
+  external JSNumber get baseLatency;
+  external JSNumber get outputLatency;
+  external JSAny get sinkId;
+  external AudioRenderCapacity get renderCapacity;
+  external set onsinkchange(EventHandler value);
+  external EventHandler get onsinkchange;
 }
 
 @JS()
@@ -167,9 +144,7 @@ extension AudioSinkOptionsExtension on AudioSinkOptions {
 
 @JS('AudioSinkInfo')
 @staticInterop
-class AudioSinkInfo {
-  external factory AudioSinkInfo();
-}
+class AudioSinkInfo {}
 
 extension AudioSinkInfoExtension on AudioSinkInfo {
   external AudioSinkType get type;
@@ -194,13 +169,10 @@ extension AudioTimestampExtension on AudioTimestamp {
 
 @JS('AudioRenderCapacity')
 @staticInterop
-class AudioRenderCapacity extends EventTarget {
-  external factory AudioRenderCapacity();
-}
+class AudioRenderCapacity implements EventTarget {}
 
 extension AudioRenderCapacityExtension on AudioRenderCapacity {
-  external JSVoid start();
-  external JSVoid start1(AudioRenderCapacityOptions options);
+  external JSVoid start([AudioRenderCapacityOptions options]);
   external JSVoid stop();
   external set onupdate(EventHandler value);
   external EventHandler get onupdate;
@@ -220,15 +192,11 @@ extension AudioRenderCapacityOptionsExtension on AudioRenderCapacityOptions {
 
 @JS('AudioRenderCapacityEvent')
 @staticInterop
-class AudioRenderCapacityEvent extends Event {
-  external factory AudioRenderCapacityEvent();
-
-  external factory AudioRenderCapacityEvent.a1(JSString type);
-
-  external factory AudioRenderCapacityEvent.a2(
-    JSString type,
+class AudioRenderCapacityEvent implements Event {
+  external factory AudioRenderCapacityEvent(
+    JSString type, [
     AudioRenderCapacityEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension AudioRenderCapacityEventExtension on AudioRenderCapacityEvent {
@@ -241,7 +209,7 @@ extension AudioRenderCapacityEventExtension on AudioRenderCapacityEvent {
 @JS()
 @staticInterop
 @anonymous
-class AudioRenderCapacityEventInit extends EventInit {
+class AudioRenderCapacityEventInit implements EventInit {
   external factory AudioRenderCapacityEventInit({
     JSNumber timestamp = 0,
     JSNumber averageLoad = 0,
@@ -264,17 +232,12 @@ extension AudioRenderCapacityEventInitExtension
 
 @JS('OfflineAudioContext')
 @staticInterop
-class OfflineAudioContext extends BaseAudioContext {
-  external factory OfflineAudioContext();
-
-  external factory OfflineAudioContext.a1(
-      OfflineAudioContextOptions contextOptions);
-
-  external factory OfflineAudioContext.a2(
-    JSNumber numberOfChannels,
+class OfflineAudioContext implements BaseAudioContext {
+  external factory OfflineAudioContext(
+    JSAny contextOptionsOrNumberOfChannels, [
     JSNumber length,
     JSNumber sampleRate,
-  );
+  ]);
 }
 
 extension OfflineAudioContextExtension on OfflineAudioContext {
@@ -308,10 +271,8 @@ extension OfflineAudioContextOptionsExtension on OfflineAudioContextOptions {
 
 @JS('OfflineAudioCompletionEvent')
 @staticInterop
-class OfflineAudioCompletionEvent extends Event {
-  external factory OfflineAudioCompletionEvent();
-
-  external factory OfflineAudioCompletionEvent.a1(
+class OfflineAudioCompletionEvent implements Event {
+  external factory OfflineAudioCompletionEvent(
     JSString type,
     OfflineAudioCompletionEventInit eventInitDict,
   );
@@ -324,7 +285,7 @@ extension OfflineAudioCompletionEventExtension on OfflineAudioCompletionEvent {
 @JS()
 @staticInterop
 @anonymous
-class OfflineAudioCompletionEventInit extends EventInit {
+class OfflineAudioCompletionEventInit implements EventInit {
   external factory OfflineAudioCompletionEventInit(
       {required AudioBuffer renderedBuffer});
 }
@@ -338,35 +299,25 @@ extension OfflineAudioCompletionEventInitExtension
 @JS('AudioBuffer')
 @staticInterop
 class AudioBuffer {
-  external factory AudioBuffer();
-
-  external factory AudioBuffer.a1(AudioBufferOptions options);
+  external factory AudioBuffer(AudioBufferOptions options);
 }
 
 extension AudioBufferExtension on AudioBuffer {
+  external JSFloat32Array getChannelData(JSNumber channel);
+  external JSVoid copyFromChannel(
+    JSFloat32Array destination,
+    JSNumber channelNumber, [
+    JSNumber bufferOffset,
+  ]);
+  external JSVoid copyToChannel(
+    JSFloat32Array source,
+    JSNumber channelNumber, [
+    JSNumber bufferOffset,
+  ]);
   external JSNumber get sampleRate;
   external JSNumber get length;
   external JSNumber get duration;
   external JSNumber get numberOfChannels;
-  external JSFloat32Array getChannelData(JSNumber channel);
-  external JSVoid copyFromChannel(
-    JSFloat32Array destination,
-    JSNumber channelNumber,
-  );
-  external JSVoid copyFromChannel1(
-    JSFloat32Array destination,
-    JSNumber channelNumber,
-    JSNumber bufferOffset,
-  );
-  external JSVoid copyToChannel(
-    JSFloat32Array source,
-    JSNumber channelNumber,
-  );
-  external JSVoid copyToChannel1(
-    JSFloat32Array source,
-    JSNumber channelNumber,
-    JSNumber bufferOffset,
-  );
 }
 
 @JS()
@@ -391,51 +342,19 @@ extension AudioBufferOptionsExtension on AudioBufferOptions {
 
 @JS('AudioNode')
 @staticInterop
-class AudioNode extends EventTarget {
-  external factory AudioNode();
-}
+class AudioNode implements EventTarget {}
 
 extension AudioNodeExtension on AudioNode {
-  external AudioNode connect(AudioNode destinationNode);
-  external AudioNode connect1(
-    AudioNode destinationNode,
-    JSNumber output,
-  );
-  external AudioNode connect2(
-    AudioNode destinationNode,
+  external JSAny connect(
+    JSAny destinationNodeOrDestinationParam, [
     JSNumber output,
     JSNumber input,
-  );
-  @JS('connect')
-  external JSVoid connect_1_(AudioParam destinationParam);
-  @JS('connect')
-  external JSVoid connect_1_1(
-    AudioParam destinationParam,
-    JSNumber output,
-  );
-  external JSVoid disconnect();
-  @JS('disconnect')
-  external JSVoid disconnect_1_(JSNumber output);
-  @JS('disconnect')
-  external JSVoid disconnect_2_(AudioNode destinationNode);
-  @JS('disconnect')
-  external JSVoid disconnect_3_(
-    AudioNode destinationNode,
-    JSNumber output,
-  );
-  @JS('disconnect')
-  external JSVoid disconnect_4_(
-    AudioNode destinationNode,
+  ]);
+  external JSVoid disconnect([
+    JSAny destinationNodeOrDestinationParamOrOutput,
     JSNumber output,
     JSNumber input,
-  );
-  @JS('disconnect')
-  external JSVoid disconnect_5_(AudioParam destinationParam);
-  @JS('disconnect')
-  external JSVoid disconnect_6_(
-    AudioParam destinationParam,
-    JSNumber output,
-  );
+  ]);
   external BaseAudioContext get context;
   external JSNumber get numberOfInputs;
   external JSNumber get numberOfOutputs;
@@ -469,18 +388,9 @@ extension AudioNodeOptionsExtension on AudioNodeOptions {
 
 @JS('AudioParam')
 @staticInterop
-class AudioParam {
-  external factory AudioParam();
-}
+class AudioParam {}
 
 extension AudioParamExtension on AudioParam {
-  external set value(JSNumber value);
-  external JSNumber get value;
-  external set automationRate(AutomationRate value);
-  external AutomationRate get automationRate;
-  external JSNumber get defaultValue;
-  external JSNumber get minValue;
-  external JSNumber get maxValue;
   external AudioParam setValueAtTime(
     JSNumber value,
     JSNumber startTime,
@@ -505,34 +415,33 @@ extension AudioParamExtension on AudioParam {
   );
   external AudioParam cancelScheduledValues(JSNumber cancelTime);
   external AudioParam cancelAndHoldAtTime(JSNumber cancelTime);
+  external set value(JSNumber value);
+  external JSNumber get value;
+  external set automationRate(AutomationRate value);
+  external AutomationRate get automationRate;
+  external JSNumber get defaultValue;
+  external JSNumber get minValue;
+  external JSNumber get maxValue;
 }
 
 @JS('AudioScheduledSourceNode')
 @staticInterop
-class AudioScheduledSourceNode extends AudioNode {
-  external factory AudioScheduledSourceNode();
-}
+class AudioScheduledSourceNode implements AudioNode {}
 
 extension AudioScheduledSourceNodeExtension on AudioScheduledSourceNode {
+  external JSVoid start([JSNumber when]);
+  external JSVoid stop([JSNumber when]);
   external set onended(EventHandler value);
   external EventHandler get onended;
-  external JSVoid start();
-  external JSVoid start1(JSNumber when);
-  external JSVoid stop();
-  external JSVoid stop1(JSNumber when);
 }
 
 @JS('AnalyserNode')
 @staticInterop
-class AnalyserNode extends AudioNode {
-  external factory AnalyserNode();
-
-  external factory AnalyserNode.a1(BaseAudioContext context);
-
-  external factory AnalyserNode.a2(
-    BaseAudioContext context,
+class AnalyserNode implements AudioNode {
+  external factory AnalyserNode(
+    BaseAudioContext context, [
     AnalyserOptions options,
-  );
+  ]);
 }
 
 extension AnalyserNodeExtension on AnalyserNode {
@@ -554,7 +463,7 @@ extension AnalyserNodeExtension on AnalyserNode {
 @JS()
 @staticInterop
 @anonymous
-class AnalyserOptions extends AudioNodeOptions {
+class AnalyserOptions implements AudioNodeOptions {
   external factory AnalyserOptions({
     JSNumber fftSize = 2048,
     JSNumber maxDecibels = -30,
@@ -576,18 +485,19 @@ extension AnalyserOptionsExtension on AnalyserOptions {
 
 @JS('AudioBufferSourceNode')
 @staticInterop
-class AudioBufferSourceNode extends AudioScheduledSourceNode {
-  external factory AudioBufferSourceNode();
-
-  external factory AudioBufferSourceNode.a1(BaseAudioContext context);
-
-  external factory AudioBufferSourceNode.a2(
-    BaseAudioContext context,
+class AudioBufferSourceNode implements AudioScheduledSourceNode {
+  external factory AudioBufferSourceNode(
+    BaseAudioContext context, [
     AudioBufferSourceOptions options,
-  );
+  ]);
 }
 
 extension AudioBufferSourceNodeExtension on AudioBufferSourceNode {
+  external JSVoid start([
+    JSNumber when,
+    JSNumber offset,
+    JSNumber duration,
+  ]);
   external set buffer(AudioBuffer? value);
   external AudioBuffer? get buffer;
   external AudioParam get playbackRate;
@@ -598,17 +508,6 @@ extension AudioBufferSourceNodeExtension on AudioBufferSourceNode {
   external JSNumber get loopStart;
   external set loopEnd(JSNumber value);
   external JSNumber get loopEnd;
-  external JSVoid start();
-  external JSVoid start1(JSNumber when);
-  external JSVoid start2(
-    JSNumber when,
-    JSNumber offset,
-  );
-  external JSVoid start3(
-    JSNumber when,
-    JSNumber offset,
-    JSNumber duration,
-  );
 }
 
 @JS()
@@ -642,9 +541,7 @@ extension AudioBufferSourceOptionsExtension on AudioBufferSourceOptions {
 
 @JS('AudioDestinationNode')
 @staticInterop
-class AudioDestinationNode extends AudioNode {
-  external factory AudioDestinationNode();
-}
+class AudioDestinationNode implements AudioNode {}
 
 extension AudioDestinationNodeExtension on AudioDestinationNode {
   external JSNumber get maxChannelCount;
@@ -652,20 +549,9 @@ extension AudioDestinationNodeExtension on AudioDestinationNode {
 
 @JS('AudioListener')
 @staticInterop
-class AudioListener {
-  external factory AudioListener();
-}
+class AudioListener {}
 
 extension AudioListenerExtension on AudioListener {
-  external AudioParam get positionX;
-  external AudioParam get positionY;
-  external AudioParam get positionZ;
-  external AudioParam get forwardX;
-  external AudioParam get forwardY;
-  external AudioParam get forwardZ;
-  external AudioParam get upX;
-  external AudioParam get upY;
-  external AudioParam get upZ;
   external JSVoid setPosition(
     JSNumber x,
     JSNumber y,
@@ -679,14 +565,21 @@ extension AudioListenerExtension on AudioListener {
     JSNumber yUp,
     JSNumber zUp,
   );
+  external AudioParam get positionX;
+  external AudioParam get positionY;
+  external AudioParam get positionZ;
+  external AudioParam get forwardX;
+  external AudioParam get forwardY;
+  external AudioParam get forwardZ;
+  external AudioParam get upX;
+  external AudioParam get upY;
+  external AudioParam get upZ;
 }
 
 @JS('AudioProcessingEvent')
 @staticInterop
-class AudioProcessingEvent extends Event {
-  external factory AudioProcessingEvent();
-
-  external factory AudioProcessingEvent.a1(
+class AudioProcessingEvent implements Event {
+  external factory AudioProcessingEvent(
     JSString type,
     AudioProcessingEventInit eventInitDict,
   );
@@ -701,7 +594,7 @@ extension AudioProcessingEventExtension on AudioProcessingEvent {
 @JS()
 @staticInterop
 @anonymous
-class AudioProcessingEventInit extends EventInit {
+class AudioProcessingEventInit implements EventInit {
   external factory AudioProcessingEventInit({
     required JSNumber playbackTime,
     required AudioBuffer inputBuffer,
@@ -720,35 +613,31 @@ extension AudioProcessingEventInitExtension on AudioProcessingEventInit {
 
 @JS('BiquadFilterNode')
 @staticInterop
-class BiquadFilterNode extends AudioNode {
-  external factory BiquadFilterNode();
-
-  external factory BiquadFilterNode.a1(BaseAudioContext context);
-
-  external factory BiquadFilterNode.a2(
-    BaseAudioContext context,
+class BiquadFilterNode implements AudioNode {
+  external factory BiquadFilterNode(
+    BaseAudioContext context, [
     BiquadFilterOptions options,
-  );
+  ]);
 }
 
 extension BiquadFilterNodeExtension on BiquadFilterNode {
+  external JSVoid getFrequencyResponse(
+    JSFloat32Array frequencyHz,
+    JSFloat32Array magResponse,
+    JSFloat32Array phaseResponse,
+  );
   external set type(BiquadFilterType value);
   external BiquadFilterType get type;
   external AudioParam get frequency;
   external AudioParam get detune;
   external AudioParam get Q;
   external AudioParam get gain;
-  external JSVoid getFrequencyResponse(
-    JSFloat32Array frequencyHz,
-    JSFloat32Array magResponse,
-    JSFloat32Array phaseResponse,
-  );
 }
 
 @JS()
 @staticInterop
 @anonymous
-class BiquadFilterOptions extends AudioNodeOptions {
+class BiquadFilterOptions implements AudioNodeOptions {
   external factory BiquadFilterOptions({
     BiquadFilterType type = 'lowpass',
     JSNumber Q = 1,
@@ -773,21 +662,17 @@ extension BiquadFilterOptionsExtension on BiquadFilterOptions {
 
 @JS('ChannelMergerNode')
 @staticInterop
-class ChannelMergerNode extends AudioNode {
-  external factory ChannelMergerNode();
-
-  external factory ChannelMergerNode.a1(BaseAudioContext context);
-
-  external factory ChannelMergerNode.a2(
-    BaseAudioContext context,
+class ChannelMergerNode implements AudioNode {
+  external factory ChannelMergerNode(
+    BaseAudioContext context, [
     ChannelMergerOptions options,
-  );
+  ]);
 }
 
 @JS()
 @staticInterop
 @anonymous
-class ChannelMergerOptions extends AudioNodeOptions {
+class ChannelMergerOptions implements AudioNodeOptions {
   external factory ChannelMergerOptions({JSNumber numberOfInputs = 6});
 }
 
@@ -798,21 +683,17 @@ extension ChannelMergerOptionsExtension on ChannelMergerOptions {
 
 @JS('ChannelSplitterNode')
 @staticInterop
-class ChannelSplitterNode extends AudioNode {
-  external factory ChannelSplitterNode();
-
-  external factory ChannelSplitterNode.a1(BaseAudioContext context);
-
-  external factory ChannelSplitterNode.a2(
-    BaseAudioContext context,
+class ChannelSplitterNode implements AudioNode {
+  external factory ChannelSplitterNode(
+    BaseAudioContext context, [
     ChannelSplitterOptions options,
-  );
+  ]);
 }
 
 @JS()
 @staticInterop
 @anonymous
-class ChannelSplitterOptions extends AudioNodeOptions {
+class ChannelSplitterOptions implements AudioNodeOptions {
   external factory ChannelSplitterOptions({JSNumber numberOfOutputs = 6});
 }
 
@@ -823,15 +704,11 @@ extension ChannelSplitterOptionsExtension on ChannelSplitterOptions {
 
 @JS('ConstantSourceNode')
 @staticInterop
-class ConstantSourceNode extends AudioScheduledSourceNode {
-  external factory ConstantSourceNode();
-
-  external factory ConstantSourceNode.a1(BaseAudioContext context);
-
-  external factory ConstantSourceNode.a2(
-    BaseAudioContext context,
+class ConstantSourceNode implements AudioScheduledSourceNode {
+  external factory ConstantSourceNode(
+    BaseAudioContext context, [
     ConstantSourceOptions options,
-  );
+  ]);
 }
 
 extension ConstantSourceNodeExtension on ConstantSourceNode {
@@ -852,15 +729,11 @@ extension ConstantSourceOptionsExtension on ConstantSourceOptions {
 
 @JS('ConvolverNode')
 @staticInterop
-class ConvolverNode extends AudioNode {
-  external factory ConvolverNode();
-
-  external factory ConvolverNode.a1(BaseAudioContext context);
-
-  external factory ConvolverNode.a2(
-    BaseAudioContext context,
+class ConvolverNode implements AudioNode {
+  external factory ConvolverNode(
+    BaseAudioContext context, [
     ConvolverOptions options,
-  );
+  ]);
 }
 
 extension ConvolverNodeExtension on ConvolverNode {
@@ -873,7 +746,7 @@ extension ConvolverNodeExtension on ConvolverNode {
 @JS()
 @staticInterop
 @anonymous
-class ConvolverOptions extends AudioNodeOptions {
+class ConvolverOptions implements AudioNodeOptions {
   external factory ConvolverOptions({
     AudioBuffer? buffer,
     JSBoolean disableNormalization = false,
@@ -889,15 +762,11 @@ extension ConvolverOptionsExtension on ConvolverOptions {
 
 @JS('DelayNode')
 @staticInterop
-class DelayNode extends AudioNode {
-  external factory DelayNode();
-
-  external factory DelayNode.a1(BaseAudioContext context);
-
-  external factory DelayNode.a2(
-    BaseAudioContext context,
+class DelayNode implements AudioNode {
+  external factory DelayNode(
+    BaseAudioContext context, [
     DelayOptions options,
-  );
+  ]);
 }
 
 extension DelayNodeExtension on DelayNode {
@@ -907,7 +776,7 @@ extension DelayNodeExtension on DelayNode {
 @JS()
 @staticInterop
 @anonymous
-class DelayOptions extends AudioNodeOptions {
+class DelayOptions implements AudioNodeOptions {
   external factory DelayOptions({
     JSNumber maxDelayTime = 1,
     JSNumber delayTime = 0,
@@ -923,15 +792,11 @@ extension DelayOptionsExtension on DelayOptions {
 
 @JS('DynamicsCompressorNode')
 @staticInterop
-class DynamicsCompressorNode extends AudioNode {
-  external factory DynamicsCompressorNode();
-
-  external factory DynamicsCompressorNode.a1(BaseAudioContext context);
-
-  external factory DynamicsCompressorNode.a2(
-    BaseAudioContext context,
+class DynamicsCompressorNode implements AudioNode {
+  external factory DynamicsCompressorNode(
+    BaseAudioContext context, [
     DynamicsCompressorOptions options,
-  );
+  ]);
 }
 
 extension DynamicsCompressorNodeExtension on DynamicsCompressorNode {
@@ -946,7 +811,7 @@ extension DynamicsCompressorNodeExtension on DynamicsCompressorNode {
 @JS()
 @staticInterop
 @anonymous
-class DynamicsCompressorOptions extends AudioNodeOptions {
+class DynamicsCompressorOptions implements AudioNodeOptions {
   external factory DynamicsCompressorOptions({
     JSNumber attack = 0.003,
     JSNumber knee = 30,
@@ -971,15 +836,11 @@ extension DynamicsCompressorOptionsExtension on DynamicsCompressorOptions {
 
 @JS('GainNode')
 @staticInterop
-class GainNode extends AudioNode {
-  external factory GainNode();
-
-  external factory GainNode.a1(BaseAudioContext context);
-
-  external factory GainNode.a2(
-    BaseAudioContext context,
+class GainNode implements AudioNode {
+  external factory GainNode(
+    BaseAudioContext context, [
     GainOptions options,
-  );
+  ]);
 }
 
 extension GainNodeExtension on GainNode {
@@ -989,7 +850,7 @@ extension GainNodeExtension on GainNode {
 @JS()
 @staticInterop
 @anonymous
-class GainOptions extends AudioNodeOptions {
+class GainOptions implements AudioNodeOptions {
   external factory GainOptions({JSNumber gain = 1.0});
 }
 
@@ -1000,10 +861,8 @@ extension GainOptionsExtension on GainOptions {
 
 @JS('IIRFilterNode')
 @staticInterop
-class IIRFilterNode extends AudioNode {
-  external factory IIRFilterNode();
-
-  external factory IIRFilterNode.a1(
+class IIRFilterNode implements AudioNode {
+  external factory IIRFilterNode(
     BaseAudioContext context,
     IIRFilterOptions options,
   );
@@ -1020,7 +879,7 @@ extension IIRFilterNodeExtension on IIRFilterNode {
 @JS()
 @staticInterop
 @anonymous
-class IIRFilterOptions extends AudioNodeOptions {
+class IIRFilterOptions implements AudioNodeOptions {
   external factory IIRFilterOptions({
     required JSArray feedforward,
     required JSArray feedback,
@@ -1036,10 +895,8 @@ extension IIRFilterOptionsExtension on IIRFilterOptions {
 
 @JS('MediaElementAudioSourceNode')
 @staticInterop
-class MediaElementAudioSourceNode extends AudioNode {
-  external factory MediaElementAudioSourceNode();
-
-  external factory MediaElementAudioSourceNode.a1(
+class MediaElementAudioSourceNode implements AudioNode {
+  external factory MediaElementAudioSourceNode(
     AudioContext context,
     MediaElementAudioSourceOptions options,
   );
@@ -1065,15 +922,11 @@ extension MediaElementAudioSourceOptionsExtension
 
 @JS('MediaStreamAudioDestinationNode')
 @staticInterop
-class MediaStreamAudioDestinationNode extends AudioNode {
-  external factory MediaStreamAudioDestinationNode();
-
-  external factory MediaStreamAudioDestinationNode.a1(AudioContext context);
-
-  external factory MediaStreamAudioDestinationNode.a2(
-    AudioContext context,
+class MediaStreamAudioDestinationNode implements AudioNode {
+  external factory MediaStreamAudioDestinationNode(
+    AudioContext context, [
     AudioNodeOptions options,
-  );
+  ]);
 }
 
 extension MediaStreamAudioDestinationNodeExtension
@@ -1083,10 +936,8 @@ extension MediaStreamAudioDestinationNodeExtension
 
 @JS('MediaStreamAudioSourceNode')
 @staticInterop
-class MediaStreamAudioSourceNode extends AudioNode {
-  external factory MediaStreamAudioSourceNode();
-
-  external factory MediaStreamAudioSourceNode.a1(
+class MediaStreamAudioSourceNode implements AudioNode {
+  external factory MediaStreamAudioSourceNode(
     AudioContext context,
     MediaStreamAudioSourceOptions options,
   );
@@ -1112,10 +963,8 @@ extension MediaStreamAudioSourceOptionsExtension
 
 @JS('MediaStreamTrackAudioSourceNode')
 @staticInterop
-class MediaStreamTrackAudioSourceNode extends AudioNode {
-  external factory MediaStreamTrackAudioSourceNode();
-
-  external factory MediaStreamTrackAudioSourceNode.a1(
+class MediaStreamTrackAudioSourceNode implements AudioNode {
+  external factory MediaStreamTrackAudioSourceNode(
     AudioContext context,
     MediaStreamTrackAudioSourceOptions options,
   );
@@ -1137,29 +986,25 @@ extension MediaStreamTrackAudioSourceOptionsExtension
 
 @JS('OscillatorNode')
 @staticInterop
-class OscillatorNode extends AudioScheduledSourceNode {
-  external factory OscillatorNode();
-
-  external factory OscillatorNode.a1(BaseAudioContext context);
-
-  external factory OscillatorNode.a2(
-    BaseAudioContext context,
+class OscillatorNode implements AudioScheduledSourceNode {
+  external factory OscillatorNode(
+    BaseAudioContext context, [
     OscillatorOptions options,
-  );
+  ]);
 }
 
 extension OscillatorNodeExtension on OscillatorNode {
+  external JSVoid setPeriodicWave(PeriodicWave periodicWave);
   external set type(OscillatorType value);
   external OscillatorType get type;
   external AudioParam get frequency;
   external AudioParam get detune;
-  external JSVoid setPeriodicWave(PeriodicWave periodicWave);
 }
 
 @JS()
 @staticInterop
 @anonymous
-class OscillatorOptions extends AudioNodeOptions {
+class OscillatorOptions implements AudioNodeOptions {
   external factory OscillatorOptions({
     OscillatorType type = 'sine',
     JSNumber frequency = 440,
@@ -1181,18 +1026,24 @@ extension OscillatorOptionsExtension on OscillatorOptions {
 
 @JS('PannerNode')
 @staticInterop
-class PannerNode extends AudioNode {
-  external factory PannerNode();
-
-  external factory PannerNode.a1(BaseAudioContext context);
-
-  external factory PannerNode.a2(
-    BaseAudioContext context,
+class PannerNode implements AudioNode {
+  external factory PannerNode(
+    BaseAudioContext context, [
     PannerOptions options,
-  );
+  ]);
 }
 
 extension PannerNodeExtension on PannerNode {
+  external JSVoid setPosition(
+    JSNumber x,
+    JSNumber y,
+    JSNumber z,
+  );
+  external JSVoid setOrientation(
+    JSNumber x,
+    JSNumber y,
+    JSNumber z,
+  );
   external set panningModel(PanningModelType value);
   external PanningModelType get panningModel;
   external AudioParam get positionX;
@@ -1215,22 +1066,12 @@ extension PannerNodeExtension on PannerNode {
   external JSNumber get coneOuterAngle;
   external set coneOuterGain(JSNumber value);
   external JSNumber get coneOuterGain;
-  external JSVoid setPosition(
-    JSNumber x,
-    JSNumber y,
-    JSNumber z,
-  );
-  external JSVoid setOrientation(
-    JSNumber x,
-    JSNumber y,
-    JSNumber z,
-  );
 }
 
 @JS()
 @staticInterop
 @anonymous
-class PannerOptions extends AudioNodeOptions {
+class PannerOptions implements AudioNodeOptions {
   external factory PannerOptions({
     PanningModelType panningModel = 'equalpower',
     DistanceModelType distanceModel = 'inverse',
@@ -1283,14 +1124,10 @@ extension PannerOptionsExtension on PannerOptions {
 @JS('PeriodicWave')
 @staticInterop
 class PeriodicWave {
-  external factory PeriodicWave();
-
-  external factory PeriodicWave.a1(BaseAudioContext context);
-
-  external factory PeriodicWave.a2(
-    BaseAudioContext context,
+  external factory PeriodicWave(
+    BaseAudioContext context, [
     PeriodicWaveOptions options,
-  );
+  ]);
 }
 
 @JS()
@@ -1309,7 +1146,7 @@ extension PeriodicWaveConstraintsExtension on PeriodicWaveConstraints {
 @JS()
 @staticInterop
 @anonymous
-class PeriodicWaveOptions extends PeriodicWaveConstraints {
+class PeriodicWaveOptions implements PeriodicWaveConstraints {
   external factory PeriodicWaveOptions({
     JSArray real,
     JSArray imag,
@@ -1325,9 +1162,7 @@ extension PeriodicWaveOptionsExtension on PeriodicWaveOptions {
 
 @JS('ScriptProcessorNode')
 @staticInterop
-class ScriptProcessorNode extends AudioNode {
-  external factory ScriptProcessorNode();
-}
+class ScriptProcessorNode implements AudioNode {}
 
 extension ScriptProcessorNodeExtension on ScriptProcessorNode {
   external set onaudioprocess(EventHandler value);
@@ -1337,15 +1172,11 @@ extension ScriptProcessorNodeExtension on ScriptProcessorNode {
 
 @JS('StereoPannerNode')
 @staticInterop
-class StereoPannerNode extends AudioNode {
-  external factory StereoPannerNode();
-
-  external factory StereoPannerNode.a1(BaseAudioContext context);
-
-  external factory StereoPannerNode.a2(
-    BaseAudioContext context,
+class StereoPannerNode implements AudioNode {
+  external factory StereoPannerNode(
+    BaseAudioContext context, [
     StereoPannerOptions options,
-  );
+  ]);
 }
 
 extension StereoPannerNodeExtension on StereoPannerNode {
@@ -1355,7 +1186,7 @@ extension StereoPannerNodeExtension on StereoPannerNode {
 @JS()
 @staticInterop
 @anonymous
-class StereoPannerOptions extends AudioNodeOptions {
+class StereoPannerOptions implements AudioNodeOptions {
   external factory StereoPannerOptions({JSNumber pan = 0});
 }
 
@@ -1366,15 +1197,11 @@ extension StereoPannerOptionsExtension on StereoPannerOptions {
 
 @JS('WaveShaperNode')
 @staticInterop
-class WaveShaperNode extends AudioNode {
-  external factory WaveShaperNode();
-
-  external factory WaveShaperNode.a1(BaseAudioContext context);
-
-  external factory WaveShaperNode.a2(
-    BaseAudioContext context,
+class WaveShaperNode implements AudioNode {
+  external factory WaveShaperNode(
+    BaseAudioContext context, [
     WaveShaperOptions options,
-  );
+  ]);
 }
 
 extension WaveShaperNodeExtension on WaveShaperNode {
@@ -1387,7 +1214,7 @@ extension WaveShaperNodeExtension on WaveShaperNode {
 @JS()
 @staticInterop
 @anonymous
-class WaveShaperOptions extends AudioNodeOptions {
+class WaveShaperOptions implements AudioNodeOptions {
   external factory WaveShaperOptions({
     JSArray curve,
     OverSampleType oversample = 'none',
@@ -1403,9 +1230,7 @@ extension WaveShaperOptionsExtension on WaveShaperOptions {
 
 @JS('AudioWorklet')
 @staticInterop
-class AudioWorklet extends Worklet {
-  external factory AudioWorklet();
-}
+class AudioWorklet implements Worklet {}
 
 extension AudioWorkletExtension on AudioWorklet {
   external MessagePort get port;
@@ -1413,9 +1238,7 @@ extension AudioWorkletExtension on AudioWorklet {
 
 @JS('AudioWorkletGlobalScope')
 @staticInterop
-class AudioWorkletGlobalScope extends WorkletGlobalScope {
-  external factory AudioWorkletGlobalScope();
-}
+class AudioWorkletGlobalScope implements WorkletGlobalScope {}
 
 extension AudioWorkletGlobalScopeExtension on AudioWorkletGlobalScope {
   external JSVoid registerProcessor(
@@ -1430,27 +1253,18 @@ extension AudioWorkletGlobalScopeExtension on AudioWorkletGlobalScope {
 
 @JS('AudioParamMap')
 @staticInterop
-class AudioParamMap {
-  external factory AudioParamMap();
-}
+class AudioParamMap {}
 
 extension AudioParamMapExtension on AudioParamMap {}
 
 @JS('AudioWorkletNode')
 @staticInterop
-class AudioWorkletNode extends AudioNode {
-  external factory AudioWorkletNode();
-
-  external factory AudioWorkletNode.a1(
+class AudioWorkletNode implements AudioNode {
+  external factory AudioWorkletNode(
     BaseAudioContext context,
-    JSString name,
-  );
-
-  external factory AudioWorkletNode.a2(
-    BaseAudioContext context,
-    JSString name,
+    JSString name, [
     AudioWorkletNodeOptions options,
-  );
+  ]);
 }
 
 extension AudioWorkletNodeExtension on AudioWorkletNode {
@@ -1463,7 +1277,7 @@ extension AudioWorkletNodeExtension on AudioWorkletNode {
 @JS()
 @staticInterop
 @anonymous
-class AudioWorkletNodeOptions extends AudioNodeOptions {
+class AudioWorkletNodeOptions implements AudioNodeOptions {
   external factory AudioWorkletNodeOptions({
     JSNumber numberOfInputs = 1,
     JSNumber numberOfOutputs = 1,
@@ -1489,7 +1303,7 @@ extension AudioWorkletNodeOptionsExtension on AudioWorkletNodeOptions {
 @JS('AudioWorkletProcessor')
 @staticInterop
 class AudioWorkletProcessor {
-  external factory AudioWorkletProcessor.a0();
+  external factory AudioWorkletProcessor();
 }
 
 extension AudioWorkletProcessorExtension on AudioWorkletProcessor {

--- a/lib/src/dom/webauthn.dart
+++ b/lib/src/dom/webauthn.dart
@@ -29,9 +29,7 @@ typedef LargeBlobSupport = JSString;
 
 @JS('PublicKeyCredential')
 @staticInterop
-class PublicKeyCredential extends Credential {
-  external factory PublicKeyCredential();
-
+class PublicKeyCredential implements Credential {
   external static JSPromise isConditionalMediationAvailable();
   external static JSPromise isUserVerifyingPlatformAuthenticatorAvailable();
   external static PublicKeyCredentialCreationOptions
@@ -42,11 +40,11 @@ class PublicKeyCredential extends Credential {
 }
 
 extension PublicKeyCredentialExtension on PublicKeyCredential {
+  external AuthenticationExtensionsClientOutputs getClientExtensionResults();
+  external PublicKeyCredentialJSON toJSON();
   external JSArrayBuffer get rawId;
   external AuthenticatorResponse get response;
   external JSString? get authenticatorAttachment;
-  external AuthenticationExtensionsClientOutputs getClientExtensionResults();
-  external PublicKeyCredentialJSON toJSON();
 }
 
 @JS()
@@ -281,9 +279,7 @@ extension PublicKeyCredentialRequestOptionsJSONExtension
 
 @JS('AuthenticatorResponse')
 @staticInterop
-class AuthenticatorResponse {
-  external factory AuthenticatorResponse();
-}
+class AuthenticatorResponse {}
 
 extension AuthenticatorResponseExtension on AuthenticatorResponse {
   external JSArrayBuffer get clientDataJSON;
@@ -291,24 +287,20 @@ extension AuthenticatorResponseExtension on AuthenticatorResponse {
 
 @JS('AuthenticatorAttestationResponse')
 @staticInterop
-class AuthenticatorAttestationResponse extends AuthenticatorResponse {
-  external factory AuthenticatorAttestationResponse();
-}
+class AuthenticatorAttestationResponse implements AuthenticatorResponse {}
 
 extension AuthenticatorAttestationResponseExtension
     on AuthenticatorAttestationResponse {
-  external JSArrayBuffer get attestationObject;
   external JSArray getTransports();
   external JSArrayBuffer getAuthenticatorData();
   external JSArrayBuffer? getPublicKey();
   external COSEAlgorithmIdentifier getPublicKeyAlgorithm();
+  external JSArrayBuffer get attestationObject;
 }
 
 @JS('AuthenticatorAssertionResponse')
 @staticInterop
-class AuthenticatorAssertionResponse extends AuthenticatorResponse {
-  external factory AuthenticatorAssertionResponse();
-}
+class AuthenticatorAssertionResponse implements AuthenticatorResponse {}
 
 extension AuthenticatorAssertionResponseExtension
     on AuthenticatorAssertionResponse {
@@ -393,7 +385,7 @@ extension PublicKeyCredentialEntityExtension on PublicKeyCredentialEntity {
 @JS()
 @staticInterop
 @anonymous
-class PublicKeyCredentialRpEntity extends PublicKeyCredentialEntity {
+class PublicKeyCredentialRpEntity implements PublicKeyCredentialEntity {
   external factory PublicKeyCredentialRpEntity({JSString id});
 }
 
@@ -405,7 +397,7 @@ extension PublicKeyCredentialRpEntityExtension on PublicKeyCredentialRpEntity {
 @JS()
 @staticInterop
 @anonymous
-class PublicKeyCredentialUserEntity extends PublicKeyCredentialEntity {
+class PublicKeyCredentialUserEntity implements PublicKeyCredentialEntity {
   external factory PublicKeyCredentialUserEntity({
     required BufferSource id,
     required JSString displayName,

--- a/lib/src/dom/webcodecs.dart
+++ b/lib/src/dom/webcodecs.dart
@@ -39,23 +39,21 @@ typedef VideoMatrixCoefficients = JSString;
 @JS('AudioDecoder')
 @staticInterop
 class AudioDecoder {
-  external factory AudioDecoder();
-
-  external factory AudioDecoder.a1(AudioDecoderInit init);
+  external factory AudioDecoder(AudioDecoderInit init);
 
   external static JSPromise isConfigSupported(AudioDecoderConfig config);
 }
 
 extension AudioDecoderExtension on AudioDecoder {
-  external CodecState get state;
-  external JSNumber get decodeQueueSize;
-  external set ondequeue(EventHandler value);
-  external EventHandler get ondequeue;
   external JSVoid configure(AudioDecoderConfig config);
   external JSVoid decode(EncodedAudioChunk chunk);
   external JSPromise flush();
   external JSVoid reset();
   external JSVoid close();
+  external CodecState get state;
+  external JSNumber get decodeQueueSize;
+  external set ondequeue(EventHandler value);
+  external EventHandler get ondequeue;
 }
 
 @JS()
@@ -78,23 +76,21 @@ extension AudioDecoderInitExtension on AudioDecoderInit {
 @JS('VideoDecoder')
 @staticInterop
 class VideoDecoder {
-  external factory VideoDecoder();
-
-  external factory VideoDecoder.a1(VideoDecoderInit init);
+  external factory VideoDecoder(VideoDecoderInit init);
 
   external static JSPromise isConfigSupported(VideoDecoderConfig config);
 }
 
 extension VideoDecoderExtension on VideoDecoder {
-  external CodecState get state;
-  external JSNumber get decodeQueueSize;
-  external set ondequeue(EventHandler value);
-  external EventHandler get ondequeue;
   external JSVoid configure(VideoDecoderConfig config);
   external JSVoid decode(EncodedVideoChunk chunk);
   external JSPromise flush();
   external JSVoid reset();
   external JSVoid close();
+  external CodecState get state;
+  external JSNumber get decodeQueueSize;
+  external set ondequeue(EventHandler value);
+  external EventHandler get ondequeue;
 }
 
 @JS()
@@ -117,23 +113,21 @@ extension VideoDecoderInitExtension on VideoDecoderInit {
 @JS('AudioEncoder')
 @staticInterop
 class AudioEncoder {
-  external factory AudioEncoder();
-
-  external factory AudioEncoder.a1(AudioEncoderInit init);
+  external factory AudioEncoder(AudioEncoderInit init);
 
   external static JSPromise isConfigSupported(AudioEncoderConfig config);
 }
 
 extension AudioEncoderExtension on AudioEncoder {
-  external CodecState get state;
-  external JSNumber get encodeQueueSize;
-  external set ondequeue(EventHandler value);
-  external EventHandler get ondequeue;
   external JSVoid configure(AudioEncoderConfig config);
   external JSVoid encode(AudioData data);
   external JSPromise flush();
   external JSVoid reset();
   external JSVoid close();
+  external CodecState get state;
+  external JSNumber get encodeQueueSize;
+  external set ondequeue(EventHandler value);
+  external EventHandler get ondequeue;
 }
 
 @JS()
@@ -169,27 +163,24 @@ extension EncodedAudioChunkMetadataExtension on EncodedAudioChunkMetadata {
 @JS('VideoEncoder')
 @staticInterop
 class VideoEncoder {
-  external factory VideoEncoder();
-
-  external factory VideoEncoder.a1(VideoEncoderInit init);
+  external factory VideoEncoder(VideoEncoderInit init);
 
   external static JSPromise isConfigSupported(VideoEncoderConfig config);
 }
 
 extension VideoEncoderExtension on VideoEncoder {
+  external JSVoid configure(VideoEncoderConfig config);
+  external JSVoid encode(
+    VideoFrame frame, [
+    VideoEncoderEncodeOptions options,
+  ]);
+  external JSPromise flush();
+  external JSVoid reset();
+  external JSVoid close();
   external CodecState get state;
   external JSNumber get encodeQueueSize;
   external set ondequeue(EventHandler value);
   external EventHandler get ondequeue;
-  external JSVoid configure(VideoEncoderConfig config);
-  external JSVoid encode(VideoFrame frame);
-  external JSVoid encode1(
-    VideoFrame frame,
-    VideoEncoderEncodeOptions options,
-  );
-  external JSPromise flush();
-  external JSVoid reset();
-  external JSVoid close();
 }
 
 @JS()
@@ -470,17 +461,15 @@ extension VideoEncoderEncodeOptionsExtension on VideoEncoderEncodeOptions {
 @JS('EncodedAudioChunk')
 @staticInterop
 class EncodedAudioChunk {
-  external factory EncodedAudioChunk();
-
-  external factory EncodedAudioChunk.a1(EncodedAudioChunkInit init);
+  external factory EncodedAudioChunk(EncodedAudioChunkInit init);
 }
 
 extension EncodedAudioChunkExtension on EncodedAudioChunk {
+  external JSVoid copyTo(BufferSource destination);
   external EncodedAudioChunkType get type;
   external JSNumber get timestamp;
   external JSNumber? get duration;
   external JSNumber get byteLength;
-  external JSVoid copyTo(BufferSource destination);
 }
 
 @JS()
@@ -509,17 +498,15 @@ extension EncodedAudioChunkInitExtension on EncodedAudioChunkInit {
 @JS('EncodedVideoChunk')
 @staticInterop
 class EncodedVideoChunk {
-  external factory EncodedVideoChunk();
-
-  external factory EncodedVideoChunk.a1(EncodedVideoChunkInit init);
+  external factory EncodedVideoChunk(EncodedVideoChunkInit init);
 }
 
 extension EncodedVideoChunkExtension on EncodedVideoChunk {
+  external JSVoid copyTo(BufferSource destination);
   external EncodedVideoChunkType get type;
   external JSNumber get timestamp;
   external JSNumber? get duration;
   external JSNumber get byteLength;
-  external JSVoid copyTo(BufferSource destination);
 }
 
 @JS()
@@ -548,18 +535,10 @@ extension EncodedVideoChunkInitExtension on EncodedVideoChunkInit {
 @JS('AudioData')
 @staticInterop
 class AudioData {
-  external factory AudioData();
-
-  external factory AudioData.a1(AudioDataInit init);
+  external factory AudioData(AudioDataInit init);
 }
 
 extension AudioDataExtension on AudioData {
-  external AudioSampleFormat? get format;
-  external JSNumber get sampleRate;
-  external JSNumber get numberOfFrames;
-  external JSNumber get numberOfChannels;
-  external JSNumber get duration;
-  external JSNumber get timestamp;
   external JSNumber allocationSize(AudioDataCopyToOptions options);
   external JSVoid copyTo(
     BufferSource destination,
@@ -567,6 +546,12 @@ extension AudioDataExtension on AudioData {
   );
   external AudioData clone();
   external JSVoid close();
+  external AudioSampleFormat? get format;
+  external JSNumber get sampleRate;
+  external JSNumber get numberOfFrames;
+  external JSNumber get numberOfChannels;
+  external JSNumber get duration;
+  external JSNumber get timestamp;
 }
 
 @JS()
@@ -624,22 +609,21 @@ extension AudioDataCopyToOptionsExtension on AudioDataCopyToOptions {
 @JS('VideoFrame')
 @staticInterop
 class VideoFrame {
-  external factory VideoFrame();
-
-  external factory VideoFrame.a1(CanvasImageSource image);
-
-  external factory VideoFrame.a2(
-    CanvasImageSource image,
-    VideoFrameInit init,
-  );
-
-  external factory VideoFrame.a3(
-    BufferSource data,
-    VideoFrameBufferInit init,
-  );
+  external factory VideoFrame(
+    JSAny dataOrImage, [
+    JSAny init,
+  ]);
 }
 
 extension VideoFrameExtension on VideoFrame {
+  external VideoFrameMetadata metadata();
+  external JSNumber allocationSize([VideoFrameCopyToOptions options]);
+  external JSPromise copyTo(
+    BufferSource destination, [
+    VideoFrameCopyToOptions options,
+  ]);
+  external VideoFrame clone();
+  external JSVoid close();
   external VideoPixelFormat? get format;
   external JSNumber get codedWidth;
   external JSNumber get codedHeight;
@@ -650,16 +634,6 @@ extension VideoFrameExtension on VideoFrame {
   external JSNumber? get duration;
   external JSNumber get timestamp;
   external VideoColorSpace get colorSpace;
-  external VideoFrameMetadata metadata();
-  external JSNumber allocationSize();
-  external JSNumber allocationSize1(VideoFrameCopyToOptions options);
-  external JSPromise copyTo(BufferSource destination);
-  external JSPromise copyTo1(
-    BufferSource destination,
-    VideoFrameCopyToOptions options,
-  );
-  external VideoFrame clone();
-  external JSVoid close();
 }
 
 @JS()
@@ -779,19 +753,15 @@ extension PlaneLayoutExtension on PlaneLayout {
 @JS('VideoColorSpace')
 @staticInterop
 class VideoColorSpace {
-  external factory VideoColorSpace();
-
-  external factory VideoColorSpace.a1();
-
-  external factory VideoColorSpace.a2(VideoColorSpaceInit init);
+  external factory VideoColorSpace([VideoColorSpaceInit init]);
 }
 
 extension VideoColorSpaceExtension on VideoColorSpace {
+  external VideoColorSpaceInit toJSON();
   external VideoColorPrimaries? get primaries;
   external VideoTransferCharacteristics? get transfer;
   external VideoMatrixCoefficients? get matrix;
   external JSBoolean? get fullRange;
-  external VideoColorSpaceInit toJSON();
 }
 
 @JS()
@@ -820,22 +790,19 @@ extension VideoColorSpaceInitExtension on VideoColorSpaceInit {
 @JS('ImageDecoder')
 @staticInterop
 class ImageDecoder {
-  external factory ImageDecoder();
-
-  external factory ImageDecoder.a1(ImageDecoderInit init);
+  external factory ImageDecoder(ImageDecoderInit init);
 
   external static JSPromise isTypeSupported(JSString type);
 }
 
 extension ImageDecoderExtension on ImageDecoder {
+  external JSPromise decode([ImageDecodeOptions options]);
+  external JSVoid reset();
+  external JSVoid close();
   external JSString get type;
   external JSBoolean get complete;
   external JSPromise get completed;
   external ImageTrackList get tracks;
-  external JSPromise decode();
-  external JSPromise decode1(ImageDecodeOptions options);
-  external JSVoid reset();
-  external JSVoid close();
 }
 
 @JS()
@@ -903,9 +870,7 @@ extension ImageDecodeResultExtension on ImageDecodeResult {
 
 @JS('ImageTrackList')
 @staticInterop
-class ImageTrackList {
-  external factory ImageTrackList();
-}
+class ImageTrackList {}
 
 extension ImageTrackListExtension on ImageTrackList {
   external JSPromise get ready;
@@ -916,9 +881,7 @@ extension ImageTrackListExtension on ImageTrackList {
 
 @JS('ImageTrack')
 @staticInterop
-class ImageTrack {
-  external factory ImageTrack();
-}
+class ImageTrack {}
 
 extension ImageTrackExtension on ImageTrack {
   external JSBoolean get animated;

--- a/lib/src/dom/webcrypto_secure_curves.dart
+++ b/lib/src/dom/webcrypto_secure_curves.dart
@@ -14,7 +14,7 @@ import 'webidl.dart';
 @JS()
 @staticInterop
 @anonymous
-class Ed448Params extends Algorithm {
+class Ed448Params implements Algorithm {
   external factory Ed448Params({BufferSource context});
 }
 

--- a/lib/src/dom/webcryptoapi.dart
+++ b/lib/src/dom/webcryptoapi.dart
@@ -20,14 +20,12 @@ typedef KeyFormat = JSString;
 
 @JS('Crypto')
 @staticInterop
-class Crypto {
-  external factory Crypto();
-}
+class Crypto {}
 
 extension CryptoExtension on Crypto {
-  external SubtleCrypto get subtle;
   external ArrayBufferView getRandomValues(ArrayBufferView array);
   external JSString randomUUID();
+  external SubtleCrypto get subtle;
 }
 
 @JS()
@@ -56,9 +54,7 @@ extension KeyAlgorithmExtension on KeyAlgorithm {
 
 @JS('CryptoKey')
 @staticInterop
-class CryptoKey {
-  external factory CryptoKey();
-}
+class CryptoKey {}
 
 extension CryptoKeyExtension on CryptoKey {
   external KeyType get type;
@@ -69,9 +65,7 @@ extension CryptoKeyExtension on CryptoKey {
 
 @JS('SubtleCrypto')
 @staticInterop
-class SubtleCrypto {
-  external factory SubtleCrypto();
-}
+class SubtleCrypto {}
 
 extension SubtleCryptoExtension on SubtleCrypto {
   external JSPromise encrypt(
@@ -249,7 +243,7 @@ extension CryptoKeyPairExtension on CryptoKeyPair {
 @JS()
 @staticInterop
 @anonymous
-class RsaKeyGenParams extends Algorithm {
+class RsaKeyGenParams implements Algorithm {
   external factory RsaKeyGenParams({
     required JSNumber modulusLength,
     required BigInteger publicExponent,
@@ -266,7 +260,7 @@ extension RsaKeyGenParamsExtension on RsaKeyGenParams {
 @JS()
 @staticInterop
 @anonymous
-class RsaHashedKeyGenParams extends RsaKeyGenParams {
+class RsaHashedKeyGenParams implements RsaKeyGenParams {
   external factory RsaHashedKeyGenParams(
       {required HashAlgorithmIdentifier hash});
 }
@@ -279,7 +273,7 @@ extension RsaHashedKeyGenParamsExtension on RsaHashedKeyGenParams {
 @JS()
 @staticInterop
 @anonymous
-class RsaKeyAlgorithm extends KeyAlgorithm {
+class RsaKeyAlgorithm implements KeyAlgorithm {
   external factory RsaKeyAlgorithm({
     required JSNumber modulusLength,
     required BigInteger publicExponent,
@@ -296,7 +290,7 @@ extension RsaKeyAlgorithmExtension on RsaKeyAlgorithm {
 @JS()
 @staticInterop
 @anonymous
-class RsaHashedKeyAlgorithm extends RsaKeyAlgorithm {
+class RsaHashedKeyAlgorithm implements RsaKeyAlgorithm {
   external factory RsaHashedKeyAlgorithm({required KeyAlgorithm hash});
 }
 
@@ -308,7 +302,7 @@ extension RsaHashedKeyAlgorithmExtension on RsaHashedKeyAlgorithm {
 @JS()
 @staticInterop
 @anonymous
-class RsaHashedImportParams extends Algorithm {
+class RsaHashedImportParams implements Algorithm {
   external factory RsaHashedImportParams(
       {required HashAlgorithmIdentifier hash});
 }
@@ -321,7 +315,7 @@ extension RsaHashedImportParamsExtension on RsaHashedImportParams {
 @JS()
 @staticInterop
 @anonymous
-class RsaPssParams extends Algorithm {
+class RsaPssParams implements Algorithm {
   external factory RsaPssParams({required JSNumber saltLength});
 }
 
@@ -333,7 +327,7 @@ extension RsaPssParamsExtension on RsaPssParams {
 @JS()
 @staticInterop
 @anonymous
-class RsaOaepParams extends Algorithm {
+class RsaOaepParams implements Algorithm {
   external factory RsaOaepParams({BufferSource label});
 }
 
@@ -345,7 +339,7 @@ extension RsaOaepParamsExtension on RsaOaepParams {
 @JS()
 @staticInterop
 @anonymous
-class EcdsaParams extends Algorithm {
+class EcdsaParams implements Algorithm {
   external factory EcdsaParams({required HashAlgorithmIdentifier hash});
 }
 
@@ -357,7 +351,7 @@ extension EcdsaParamsExtension on EcdsaParams {
 @JS()
 @staticInterop
 @anonymous
-class EcKeyGenParams extends Algorithm {
+class EcKeyGenParams implements Algorithm {
   external factory EcKeyGenParams({required NamedCurve namedCurve});
 }
 
@@ -369,7 +363,7 @@ extension EcKeyGenParamsExtension on EcKeyGenParams {
 @JS()
 @staticInterop
 @anonymous
-class EcKeyAlgorithm extends KeyAlgorithm {
+class EcKeyAlgorithm implements KeyAlgorithm {
   external factory EcKeyAlgorithm({required NamedCurve namedCurve});
 }
 
@@ -381,7 +375,7 @@ extension EcKeyAlgorithmExtension on EcKeyAlgorithm {
 @JS()
 @staticInterop
 @anonymous
-class EcKeyImportParams extends Algorithm {
+class EcKeyImportParams implements Algorithm {
   external factory EcKeyImportParams({required NamedCurve namedCurve});
 }
 
@@ -393,7 +387,7 @@ extension EcKeyImportParamsExtension on EcKeyImportParams {
 @JS()
 @staticInterop
 @anonymous
-class EcdhKeyDeriveParams extends Algorithm {
+class EcdhKeyDeriveParams implements Algorithm {
   external factory EcdhKeyDeriveParams({required CryptoKey public});
 }
 
@@ -405,7 +399,7 @@ extension EcdhKeyDeriveParamsExtension on EcdhKeyDeriveParams {
 @JS()
 @staticInterop
 @anonymous
-class AesCtrParams extends Algorithm {
+class AesCtrParams implements Algorithm {
   external factory AesCtrParams({
     required BufferSource counter,
     required JSNumber length,
@@ -422,7 +416,7 @@ extension AesCtrParamsExtension on AesCtrParams {
 @JS()
 @staticInterop
 @anonymous
-class AesKeyAlgorithm extends KeyAlgorithm {
+class AesKeyAlgorithm implements KeyAlgorithm {
   external factory AesKeyAlgorithm({required JSNumber length});
 }
 
@@ -434,7 +428,7 @@ extension AesKeyAlgorithmExtension on AesKeyAlgorithm {
 @JS()
 @staticInterop
 @anonymous
-class AesKeyGenParams extends Algorithm {
+class AesKeyGenParams implements Algorithm {
   external factory AesKeyGenParams({required JSNumber length});
 }
 
@@ -446,7 +440,7 @@ extension AesKeyGenParamsExtension on AesKeyGenParams {
 @JS()
 @staticInterop
 @anonymous
-class AesDerivedKeyParams extends Algorithm {
+class AesDerivedKeyParams implements Algorithm {
   external factory AesDerivedKeyParams({required JSNumber length});
 }
 
@@ -458,7 +452,7 @@ extension AesDerivedKeyParamsExtension on AesDerivedKeyParams {
 @JS()
 @staticInterop
 @anonymous
-class AesCbcParams extends Algorithm {
+class AesCbcParams implements Algorithm {
   external factory AesCbcParams({required BufferSource iv});
 }
 
@@ -470,7 +464,7 @@ extension AesCbcParamsExtension on AesCbcParams {
 @JS()
 @staticInterop
 @anonymous
-class AesGcmParams extends Algorithm {
+class AesGcmParams implements Algorithm {
   external factory AesGcmParams({
     required BufferSource iv,
     BufferSource additionalData,
@@ -490,7 +484,7 @@ extension AesGcmParamsExtension on AesGcmParams {
 @JS()
 @staticInterop
 @anonymous
-class HmacImportParams extends Algorithm {
+class HmacImportParams implements Algorithm {
   external factory HmacImportParams({
     required HashAlgorithmIdentifier hash,
     JSNumber length,
@@ -507,7 +501,7 @@ extension HmacImportParamsExtension on HmacImportParams {
 @JS()
 @staticInterop
 @anonymous
-class HmacKeyAlgorithm extends KeyAlgorithm {
+class HmacKeyAlgorithm implements KeyAlgorithm {
   external factory HmacKeyAlgorithm({
     required KeyAlgorithm hash,
     required JSNumber length,
@@ -524,7 +518,7 @@ extension HmacKeyAlgorithmExtension on HmacKeyAlgorithm {
 @JS()
 @staticInterop
 @anonymous
-class HmacKeyGenParams extends Algorithm {
+class HmacKeyGenParams implements Algorithm {
   external factory HmacKeyGenParams({
     required HashAlgorithmIdentifier hash,
     JSNumber length,
@@ -541,7 +535,7 @@ extension HmacKeyGenParamsExtension on HmacKeyGenParams {
 @JS()
 @staticInterop
 @anonymous
-class HkdfParams extends Algorithm {
+class HkdfParams implements Algorithm {
   external factory HkdfParams({
     required HashAlgorithmIdentifier hash,
     required BufferSource salt,
@@ -561,7 +555,7 @@ extension HkdfParamsExtension on HkdfParams {
 @JS()
 @staticInterop
 @anonymous
-class Pbkdf2Params extends Algorithm {
+class Pbkdf2Params implements Algorithm {
   external factory Pbkdf2Params({
     required BufferSource salt,
     required JSNumber iterations,

--- a/lib/src/dom/webdriver.dart
+++ b/lib/src/dom/webdriver.dart
@@ -10,9 +10,7 @@ import 'package:js/js.dart' hide JS;
 
 @JS('NavigatorAutomationInformation')
 @staticInterop
-class NavigatorAutomationInformation {
-  external factory NavigatorAutomationInformation();
-}
+class NavigatorAutomationInformation {}
 
 extension NavigatorAutomationInformationExtension
     on NavigatorAutomationInformation {

--- a/lib/src/dom/webgl1.dart
+++ b/lib/src/dom/webgl1.dart
@@ -74,57 +74,39 @@ extension WebGLContextAttributesExtension on WebGLContextAttributes {
 
 @JS('WebGLObject')
 @staticInterop
-class WebGLObject {
-  external factory WebGLObject();
-}
+class WebGLObject {}
 
 @JS('WebGLBuffer')
 @staticInterop
-class WebGLBuffer extends WebGLObject {
-  external factory WebGLBuffer();
-}
+class WebGLBuffer implements WebGLObject {}
 
 @JS('WebGLFramebuffer')
 @staticInterop
-class WebGLFramebuffer extends WebGLObject {
-  external factory WebGLFramebuffer();
-}
+class WebGLFramebuffer implements WebGLObject {}
 
 @JS('WebGLProgram')
 @staticInterop
-class WebGLProgram extends WebGLObject {
-  external factory WebGLProgram();
-}
+class WebGLProgram implements WebGLObject {}
 
 @JS('WebGLRenderbuffer')
 @staticInterop
-class WebGLRenderbuffer extends WebGLObject {
-  external factory WebGLRenderbuffer();
-}
+class WebGLRenderbuffer implements WebGLObject {}
 
 @JS('WebGLShader')
 @staticInterop
-class WebGLShader extends WebGLObject {
-  external factory WebGLShader();
-}
+class WebGLShader implements WebGLObject {}
 
 @JS('WebGLTexture')
 @staticInterop
-class WebGLTexture extends WebGLObject {
-  external factory WebGLTexture();
-}
+class WebGLTexture implements WebGLObject {}
 
 @JS('WebGLUniformLocation')
 @staticInterop
-class WebGLUniformLocation {
-  external factory WebGLUniformLocation();
-}
+class WebGLUniformLocation {}
 
 @JS('WebGLActiveInfo')
 @staticInterop
-class WebGLActiveInfo {
-  external factory WebGLActiveInfo();
-}
+class WebGLActiveInfo {}
 
 extension WebGLActiveInfoExtension on WebGLActiveInfo {
   external GLint get size;
@@ -134,9 +116,7 @@ extension WebGLActiveInfoExtension on WebGLActiveInfo {
 
 @JS('WebGLShaderPrecisionFormat')
 @staticInterop
-class WebGLShaderPrecisionFormat {
-  external factory WebGLShaderPrecisionFormat();
-}
+class WebGLShaderPrecisionFormat {}
 
 extension WebGLShaderPrecisionFormatExtension on WebGLShaderPrecisionFormat {
   external GLint get rangeMin;
@@ -147,8 +127,6 @@ extension WebGLShaderPrecisionFormatExtension on WebGLShaderPrecisionFormat {
 @JS('WebGLRenderingContextBase')
 @staticInterop
 class WebGLRenderingContextBase {
-  external factory WebGLRenderingContextBase();
-
   external static GLenum get DEPTH_BUFFER_BIT;
   external static GLenum get STENCIL_BUFFER_BIT;
   external static GLenum get COLOR_BUFFER_BIT;
@@ -448,13 +426,6 @@ class WebGLRenderingContextBase {
 }
 
 extension WebGLRenderingContextBaseExtension on WebGLRenderingContextBase {
-  external JSAny get canvas;
-  external GLsizei get drawingBufferWidth;
-  external GLsizei get drawingBufferHeight;
-  external set drawingBufferColorSpace(PredefinedColorSpace value);
-  external PredefinedColorSpace get drawingBufferColorSpace;
-  external set unpackColorSpace(PredefinedColorSpace value);
-  external PredefinedColorSpace get unpackColorSpace;
   external WebGLContextAttributes? getContextAttributes();
   external JSBoolean isContextLost();
   external JSArray? getSupportedExtensions();
@@ -838,25 +809,24 @@ extension WebGLRenderingContextBaseExtension on WebGLRenderingContextBase {
     GLsizei height,
   );
   external JSPromise makeXRCompatible();
+  external JSAny get canvas;
+  external GLsizei get drawingBufferWidth;
+  external GLsizei get drawingBufferHeight;
+  external set drawingBufferColorSpace(PredefinedColorSpace value);
+  external PredefinedColorSpace get drawingBufferColorSpace;
+  external set unpackColorSpace(PredefinedColorSpace value);
+  external PredefinedColorSpace get unpackColorSpace;
 }
 
 @JS('WebGLRenderingContextOverloads')
 @staticInterop
-class WebGLRenderingContextOverloads {
-  external factory WebGLRenderingContextOverloads();
-}
+class WebGLRenderingContextOverloads {}
 
 extension WebGLRenderingContextOverloadsExtension
     on WebGLRenderingContextOverloads {
   external JSVoid bufferData(
     GLenum target,
-    GLsizeiptr size,
-    GLenum usage,
-  );
-  @JS('bufferData')
-  external JSVoid bufferData_1_(
-    GLenum target,
-    BufferSource? data,
+    JSAny? dataOrSize,
     GLenum usage,
   );
   external JSVoid bufferSubData(
@@ -896,43 +866,24 @@ extension WebGLRenderingContextOverloadsExtension
     GLenum target,
     GLint level,
     GLint internalformat,
-    GLsizei width,
-    GLsizei height,
-    GLint border,
+    JSAny formatOrWidth,
+    JSAny heightOrType,
+    JSAny borderOrSource, [
     GLenum format,
     GLenum type,
     ArrayBufferView? pixels,
-  );
-  @JS('texImage2D')
-  external JSVoid texImage2D_1_(
-    GLenum target,
-    GLint level,
-    GLint internalformat,
-    GLenum format,
-    GLenum type,
-    TexImageSource source,
-  );
+  ]);
   external JSVoid texSubImage2D(
     GLenum target,
     GLint level,
     GLint xoffset,
     GLint yoffset,
-    GLsizei width,
-    GLsizei height,
-    GLenum format,
+    JSAny formatOrWidth,
+    JSAny heightOrType,
+    JSAny formatOrSource, [
     GLenum type,
     ArrayBufferView? pixels,
-  );
-  @JS('texSubImage2D')
-  external JSVoid texSubImage2D_1_(
-    GLenum target,
-    GLint level,
-    GLint xoffset,
-    GLint yoffset,
-    GLenum format,
-    GLenum type,
-    TexImageSource source,
-  );
+  ]);
   external JSVoid uniform1fv(
     WebGLUniformLocation? location,
     Float32List v,
@@ -985,21 +936,15 @@ extension WebGLRenderingContextOverloadsExtension
 @JS('WebGLRenderingContext')
 @staticInterop
 class WebGLRenderingContext
-    implements WebGLRenderingContextBase, WebGLRenderingContextOverloads {
-  external factory WebGLRenderingContext();
-}
+    implements WebGLRenderingContextBase, WebGLRenderingContextOverloads {}
 
 @JS('WebGLContextEvent')
 @staticInterop
-class WebGLContextEvent extends Event {
-  external factory WebGLContextEvent();
-
-  external factory WebGLContextEvent.a1(JSString type);
-
-  external factory WebGLContextEvent.a2(
-    JSString type,
+class WebGLContextEvent implements Event {
+  external factory WebGLContextEvent(
+    JSString type, [
     WebGLContextEventInit eventInit,
-  );
+  ]);
 }
 
 extension WebGLContextEventExtension on WebGLContextEvent {
@@ -1009,7 +954,7 @@ extension WebGLContextEventExtension on WebGLContextEvent {
 @JS()
 @staticInterop
 @anonymous
-class WebGLContextEventInit extends EventInit {
+class WebGLContextEventInit implements EventInit {
   external factory WebGLContextEventInit({JSString statusMessage = ''});
 }
 

--- a/lib/src/dom/webgl2.dart
+++ b/lib/src/dom/webgl2.dart
@@ -17,39 +17,27 @@ typedef Uint32List = JSAny;
 
 @JS('WebGLQuery')
 @staticInterop
-class WebGLQuery extends WebGLObject {
-  external factory WebGLQuery();
-}
+class WebGLQuery implements WebGLObject {}
 
 @JS('WebGLSampler')
 @staticInterop
-class WebGLSampler extends WebGLObject {
-  external factory WebGLSampler();
-}
+class WebGLSampler implements WebGLObject {}
 
 @JS('WebGLSync')
 @staticInterop
-class WebGLSync extends WebGLObject {
-  external factory WebGLSync();
-}
+class WebGLSync implements WebGLObject {}
 
 @JS('WebGLTransformFeedback')
 @staticInterop
-class WebGLTransformFeedback extends WebGLObject {
-  external factory WebGLTransformFeedback();
-}
+class WebGLTransformFeedback implements WebGLObject {}
 
 @JS('WebGLVertexArrayObject')
 @staticInterop
-class WebGLVertexArrayObject extends WebGLObject {
-  external factory WebGLVertexArrayObject();
-}
+class WebGLVertexArrayObject implements WebGLObject {}
 
 @JS('WebGL2RenderingContextBase')
 @staticInterop
 class WebGL2RenderingContextBase {
-  external factory WebGL2RenderingContextBase();
-
   external static GLenum get READ_BUFFER;
   external static GLenum get UNPACK_ROW_LENGTH;
   external static GLenum get UNPACK_SKIP_ROWS;
@@ -326,21 +314,10 @@ extension WebGL2RenderingContextBaseExtension on WebGL2RenderingContextBase {
   external JSVoid getBufferSubData(
     GLenum target,
     GLintptr srcByteOffset,
-    ArrayBufferView dstBuffer,
-  );
-  external JSVoid getBufferSubData1(
-    GLenum target,
-    GLintptr srcByteOffset,
-    ArrayBufferView dstBuffer,
-    GLuint dstOffset,
-  );
-  external JSVoid getBufferSubData2(
-    GLenum target,
-    GLintptr srcByteOffset,
-    ArrayBufferView dstBuffer,
+    ArrayBufferView dstBuffer, [
     GLuint dstOffset,
     GLuint length,
-  );
+  ]);
   external JSVoid blitFramebuffer(
     GLint srcX0,
     GLint srcY0,
@@ -410,48 +387,9 @@ extension WebGL2RenderingContextBaseExtension on WebGL2RenderingContextBase {
     GLint border,
     GLenum format,
     GLenum type,
-    GLintptr pboOffset,
-  );
-  @JS('texImage3D')
-  external JSVoid texImage3D_1_(
-    GLenum target,
-    GLint level,
-    GLint internalformat,
-    GLsizei width,
-    GLsizei height,
-    GLsizei depth,
-    GLint border,
-    GLenum format,
-    GLenum type,
-    TexImageSource source,
-  );
-  @JS('texImage3D')
-  external JSVoid texImage3D_2_(
-    GLenum target,
-    GLint level,
-    GLint internalformat,
-    GLsizei width,
-    GLsizei height,
-    GLsizei depth,
-    GLint border,
-    GLenum format,
-    GLenum type,
-    ArrayBufferView? srcData,
-  );
-  @JS('texImage3D')
-  external JSVoid texImage3D_3_(
-    GLenum target,
-    GLint level,
-    GLint internalformat,
-    GLsizei width,
-    GLsizei height,
-    GLsizei depth,
-    GLint border,
-    GLenum format,
-    GLenum type,
-    ArrayBufferView srcData,
+    JSAny? pboOffsetOrSourceOrSrcData, [
     GLuint srcOffset,
-  );
+  ]);
   external JSVoid texSubImage3D(
     GLenum target,
     GLint level,
@@ -463,51 +401,9 @@ extension WebGL2RenderingContextBaseExtension on WebGL2RenderingContextBase {
     GLsizei depth,
     GLenum format,
     GLenum type,
-    GLintptr pboOffset,
-  );
-  @JS('texSubImage3D')
-  external JSVoid texSubImage3D_1_(
-    GLenum target,
-    GLint level,
-    GLint xoffset,
-    GLint yoffset,
-    GLint zoffset,
-    GLsizei width,
-    GLsizei height,
-    GLsizei depth,
-    GLenum format,
-    GLenum type,
-    TexImageSource source,
-  );
-  @JS('texSubImage3D')
-  external JSVoid texSubImage3D_2_(
-    GLenum target,
-    GLint level,
-    GLint xoffset,
-    GLint yoffset,
-    GLint zoffset,
-    GLsizei width,
-    GLsizei height,
-    GLsizei depth,
-    GLenum format,
-    GLenum type,
-    ArrayBufferView? srcData,
-  );
-  @JS('texSubImage3D')
-  external JSVoid texSubImage3D_2_1(
-    GLenum target,
-    GLint level,
-    GLint xoffset,
-    GLint yoffset,
-    GLint zoffset,
-    GLsizei width,
-    GLsizei height,
-    GLsizei depth,
-    GLenum format,
-    GLenum type,
-    ArrayBufferView? srcData,
+    JSAny? pboOffsetOrSourceOrSrcData, [
     GLuint srcOffset,
-  );
+  ]);
   external JSVoid copyTexSubImage3D(
     GLenum target,
     GLint level,
@@ -527,45 +423,10 @@ extension WebGL2RenderingContextBaseExtension on WebGL2RenderingContextBase {
     GLsizei height,
     GLsizei depth,
     GLint border,
-    GLsizei imageSize,
-    GLintptr offset,
-  );
-  @JS('compressedTexImage3D')
-  external JSVoid compressedTexImage3D_1_(
-    GLenum target,
-    GLint level,
-    GLenum internalformat,
-    GLsizei width,
-    GLsizei height,
-    GLsizei depth,
-    GLint border,
-    ArrayBufferView srcData,
-  );
-  @JS('compressedTexImage3D')
-  external JSVoid compressedTexImage3D_1_1(
-    GLenum target,
-    GLint level,
-    GLenum internalformat,
-    GLsizei width,
-    GLsizei height,
-    GLsizei depth,
-    GLint border,
-    ArrayBufferView srcData,
-    GLuint srcOffset,
-  );
-  @JS('compressedTexImage3D')
-  external JSVoid compressedTexImage3D_1_2(
-    GLenum target,
-    GLint level,
-    GLenum internalformat,
-    GLsizei width,
-    GLsizei height,
-    GLsizei depth,
-    GLint border,
-    ArrayBufferView srcData,
-    GLuint srcOffset,
+    JSAny imageSizeOrSrcData, [
+    JSAny offsetOrSrcOffset,
     GLuint srcLengthOverride,
-  );
+  ]);
   external JSVoid compressedTexSubImage3D(
     GLenum target,
     GLint level,
@@ -576,51 +437,10 @@ extension WebGL2RenderingContextBaseExtension on WebGL2RenderingContextBase {
     GLsizei height,
     GLsizei depth,
     GLenum format,
-    GLsizei imageSize,
-    GLintptr offset,
-  );
-  @JS('compressedTexSubImage3D')
-  external JSVoid compressedTexSubImage3D_1_(
-    GLenum target,
-    GLint level,
-    GLint xoffset,
-    GLint yoffset,
-    GLint zoffset,
-    GLsizei width,
-    GLsizei height,
-    GLsizei depth,
-    GLenum format,
-    ArrayBufferView srcData,
-  );
-  @JS('compressedTexSubImage3D')
-  external JSVoid compressedTexSubImage3D_1_1(
-    GLenum target,
-    GLint level,
-    GLint xoffset,
-    GLint yoffset,
-    GLint zoffset,
-    GLsizei width,
-    GLsizei height,
-    GLsizei depth,
-    GLenum format,
-    ArrayBufferView srcData,
-    GLuint srcOffset,
-  );
-  @JS('compressedTexSubImage3D')
-  external JSVoid compressedTexSubImage3D_1_2(
-    GLenum target,
-    GLint level,
-    GLint xoffset,
-    GLint yoffset,
-    GLint zoffset,
-    GLsizei width,
-    GLsizei height,
-    GLsizei depth,
-    GLenum format,
-    ArrayBufferView srcData,
-    GLuint srcOffset,
+    JSAny imageSizeOrSrcData, [
+    JSAny offsetOrSrcOffset,
     GLuint srcLengthOverride,
-  );
+  ]);
   external GLint getFragDataLocation(
     WebGLProgram program,
     JSString name,
@@ -649,172 +469,70 @@ extension WebGL2RenderingContextBaseExtension on WebGL2RenderingContextBase {
   );
   external JSVoid uniform1uiv(
     WebGLUniformLocation? location,
-    Uint32List data,
-  );
-  external JSVoid uniform1uiv1(
-    WebGLUniformLocation? location,
-    Uint32List data,
-    GLuint srcOffset,
-  );
-  external JSVoid uniform1uiv2(
-    WebGLUniformLocation? location,
-    Uint32List data,
+    Uint32List data, [
     GLuint srcOffset,
     GLuint srcLength,
-  );
+  ]);
   external JSVoid uniform2uiv(
     WebGLUniformLocation? location,
-    Uint32List data,
-  );
-  external JSVoid uniform2uiv1(
-    WebGLUniformLocation? location,
-    Uint32List data,
-    GLuint srcOffset,
-  );
-  external JSVoid uniform2uiv2(
-    WebGLUniformLocation? location,
-    Uint32List data,
+    Uint32List data, [
     GLuint srcOffset,
     GLuint srcLength,
-  );
+  ]);
   external JSVoid uniform3uiv(
     WebGLUniformLocation? location,
-    Uint32List data,
-  );
-  external JSVoid uniform3uiv1(
-    WebGLUniformLocation? location,
-    Uint32List data,
-    GLuint srcOffset,
-  );
-  external JSVoid uniform3uiv2(
-    WebGLUniformLocation? location,
-    Uint32List data,
+    Uint32List data, [
     GLuint srcOffset,
     GLuint srcLength,
-  );
+  ]);
   external JSVoid uniform4uiv(
     WebGLUniformLocation? location,
-    Uint32List data,
-  );
-  external JSVoid uniform4uiv1(
-    WebGLUniformLocation? location,
-    Uint32List data,
-    GLuint srcOffset,
-  );
-  external JSVoid uniform4uiv2(
-    WebGLUniformLocation? location,
-    Uint32List data,
+    Uint32List data, [
     GLuint srcOffset,
     GLuint srcLength,
-  );
+  ]);
   external JSVoid uniformMatrix3x2fv(
     WebGLUniformLocation? location,
     GLboolean transpose,
-    Float32List data,
-  );
-  external JSVoid uniformMatrix3x2fv1(
-    WebGLUniformLocation? location,
-    GLboolean transpose,
-    Float32List data,
-    GLuint srcOffset,
-  );
-  external JSVoid uniformMatrix3x2fv2(
-    WebGLUniformLocation? location,
-    GLboolean transpose,
-    Float32List data,
+    Float32List data, [
     GLuint srcOffset,
     GLuint srcLength,
-  );
+  ]);
   external JSVoid uniformMatrix4x2fv(
     WebGLUniformLocation? location,
     GLboolean transpose,
-    Float32List data,
-  );
-  external JSVoid uniformMatrix4x2fv1(
-    WebGLUniformLocation? location,
-    GLboolean transpose,
-    Float32List data,
-    GLuint srcOffset,
-  );
-  external JSVoid uniformMatrix4x2fv2(
-    WebGLUniformLocation? location,
-    GLboolean transpose,
-    Float32List data,
+    Float32List data, [
     GLuint srcOffset,
     GLuint srcLength,
-  );
+  ]);
   external JSVoid uniformMatrix2x3fv(
     WebGLUniformLocation? location,
     GLboolean transpose,
-    Float32List data,
-  );
-  external JSVoid uniformMatrix2x3fv1(
-    WebGLUniformLocation? location,
-    GLboolean transpose,
-    Float32List data,
-    GLuint srcOffset,
-  );
-  external JSVoid uniformMatrix2x3fv2(
-    WebGLUniformLocation? location,
-    GLboolean transpose,
-    Float32List data,
+    Float32List data, [
     GLuint srcOffset,
     GLuint srcLength,
-  );
+  ]);
   external JSVoid uniformMatrix4x3fv(
     WebGLUniformLocation? location,
     GLboolean transpose,
-    Float32List data,
-  );
-  external JSVoid uniformMatrix4x3fv1(
-    WebGLUniformLocation? location,
-    GLboolean transpose,
-    Float32List data,
-    GLuint srcOffset,
-  );
-  external JSVoid uniformMatrix4x3fv2(
-    WebGLUniformLocation? location,
-    GLboolean transpose,
-    Float32List data,
+    Float32List data, [
     GLuint srcOffset,
     GLuint srcLength,
-  );
+  ]);
   external JSVoid uniformMatrix2x4fv(
     WebGLUniformLocation? location,
     GLboolean transpose,
-    Float32List data,
-  );
-  external JSVoid uniformMatrix2x4fv1(
-    WebGLUniformLocation? location,
-    GLboolean transpose,
-    Float32List data,
-    GLuint srcOffset,
-  );
-  external JSVoid uniformMatrix2x4fv2(
-    WebGLUniformLocation? location,
-    GLboolean transpose,
-    Float32List data,
+    Float32List data, [
     GLuint srcOffset,
     GLuint srcLength,
-  );
+  ]);
   external JSVoid uniformMatrix3x4fv(
     WebGLUniformLocation? location,
     GLboolean transpose,
-    Float32List data,
-  );
-  external JSVoid uniformMatrix3x4fv1(
-    WebGLUniformLocation? location,
-    GLboolean transpose,
-    Float32List data,
-    GLuint srcOffset,
-  );
-  external JSVoid uniformMatrix3x4fv2(
-    WebGLUniformLocation? location,
-    GLboolean transpose,
-    Float32List data,
+    Float32List data, [
     GLuint srcOffset,
     GLuint srcLength,
-  );
+  ]);
   external JSVoid vertexAttribI4i(
     GLuint index,
     GLint x,
@@ -873,36 +591,21 @@ extension WebGL2RenderingContextBaseExtension on WebGL2RenderingContextBase {
   external JSVoid clearBufferfv(
     GLenum buffer,
     GLint drawbuffer,
-    Float32List values,
-  );
-  external JSVoid clearBufferfv1(
-    GLenum buffer,
-    GLint drawbuffer,
-    Float32List values,
+    Float32List values, [
     GLuint srcOffset,
-  );
+  ]);
   external JSVoid clearBufferiv(
     GLenum buffer,
     GLint drawbuffer,
-    Int32List values,
-  );
-  external JSVoid clearBufferiv1(
-    GLenum buffer,
-    GLint drawbuffer,
-    Int32List values,
+    Int32List values, [
     GLuint srcOffset,
-  );
+  ]);
   external JSVoid clearBufferuiv(
     GLenum buffer,
     GLint drawbuffer,
-    Uint32List values,
-  );
-  external JSVoid clearBufferuiv1(
-    GLenum buffer,
-    GLint drawbuffer,
-    Uint32List values,
+    Uint32List values, [
     GLuint srcOffset,
-  );
+  ]);
   external JSVoid clearBufferfi(
     GLenum buffer,
     GLint drawbuffer,
@@ -1037,173 +740,48 @@ extension WebGL2RenderingContextBaseExtension on WebGL2RenderingContextBase {
 
 @JS('WebGL2RenderingContextOverloads')
 @staticInterop
-class WebGL2RenderingContextOverloads {
-  external factory WebGL2RenderingContextOverloads();
-}
+class WebGL2RenderingContextOverloads {}
 
 extension WebGL2RenderingContextOverloadsExtension
     on WebGL2RenderingContextOverloads {
   external JSVoid bufferData(
     GLenum target,
-    GLsizeiptr size,
-    GLenum usage,
-  );
-  @JS('bufferData')
-  external JSVoid bufferData_1_(
-    GLenum target,
-    BufferSource? srcData,
-    GLenum usage,
-  );
+    JSAny? sizeOrSrcData,
+    GLenum usage, [
+    GLuint srcOffset,
+    GLuint length,
+  ]);
   external JSVoid bufferSubData(
     GLenum target,
     GLintptr dstByteOffset,
-    BufferSource srcData,
-  );
-  @JS('bufferData')
-  external JSVoid bufferData_2_(
-    GLenum target,
-    ArrayBufferView srcData,
-    GLenum usage,
-    GLuint srcOffset,
-  );
-  @JS('bufferData')
-  external JSVoid bufferData_2_1(
-    GLenum target,
-    ArrayBufferView srcData,
-    GLenum usage,
+    JSAny srcData, [
     GLuint srcOffset,
     GLuint length,
-  );
-  @JS('bufferSubData')
-  external JSVoid bufferSubData_1_(
-    GLenum target,
-    GLintptr dstByteOffset,
-    ArrayBufferView srcData,
-    GLuint srcOffset,
-  );
-  @JS('bufferSubData')
-  external JSVoid bufferSubData_1_1(
-    GLenum target,
-    GLintptr dstByteOffset,
-    ArrayBufferView srcData,
-    GLuint srcOffset,
-    GLuint length,
-  );
+  ]);
   external JSVoid texImage2D(
     GLenum target,
     GLint level,
     GLint internalformat,
-    GLsizei width,
-    GLsizei height,
-    GLint border,
+    JSAny formatOrWidth,
+    JSAny heightOrType,
+    JSAny borderOrSource, [
     GLenum format,
     GLenum type,
-    ArrayBufferView? pixels,
-  );
-  @JS('texImage2D')
-  external JSVoid texImage2D_1_(
-    GLenum target,
-    GLint level,
-    GLint internalformat,
-    GLenum format,
-    GLenum type,
-    TexImageSource source,
-  );
+    JSAny? pboOffsetOrPixelsOrSourceOrSrcData,
+    GLuint srcOffset,
+  ]);
   external JSVoid texSubImage2D(
     GLenum target,
     GLint level,
     GLint xoffset,
     GLint yoffset,
-    GLsizei width,
-    GLsizei height,
-    GLenum format,
+    JSAny formatOrWidth,
+    JSAny heightOrType,
+    JSAny formatOrSource, [
     GLenum type,
-    ArrayBufferView? pixels,
-  );
-  @JS('texSubImage2D')
-  external JSVoid texSubImage2D_1_(
-    GLenum target,
-    GLint level,
-    GLint xoffset,
-    GLint yoffset,
-    GLenum format,
-    GLenum type,
-    TexImageSource source,
-  );
-  @JS('texImage2D')
-  external JSVoid texImage2D_2_(
-    GLenum target,
-    GLint level,
-    GLint internalformat,
-    GLsizei width,
-    GLsizei height,
-    GLint border,
-    GLenum format,
-    GLenum type,
-    GLintptr pboOffset,
-  );
-  @JS('texImage2D')
-  external JSVoid texImage2D_3_(
-    GLenum target,
-    GLint level,
-    GLint internalformat,
-    GLsizei width,
-    GLsizei height,
-    GLint border,
-    GLenum format,
-    GLenum type,
-    TexImageSource source,
-  );
-  @JS('texImage2D')
-  external JSVoid texImage2D_4_(
-    GLenum target,
-    GLint level,
-    GLint internalformat,
-    GLsizei width,
-    GLsizei height,
-    GLint border,
-    GLenum format,
-    GLenum type,
-    ArrayBufferView srcData,
+    JSAny? pboOffsetOrPixelsOrSourceOrSrcData,
     GLuint srcOffset,
-  );
-  @JS('texSubImage2D')
-  external JSVoid texSubImage2D_2_(
-    GLenum target,
-    GLint level,
-    GLint xoffset,
-    GLint yoffset,
-    GLsizei width,
-    GLsizei height,
-    GLenum format,
-    GLenum type,
-    GLintptr pboOffset,
-  );
-  @JS('texSubImage2D')
-  external JSVoid texSubImage2D_3_(
-    GLenum target,
-    GLint level,
-    GLint xoffset,
-    GLint yoffset,
-    GLsizei width,
-    GLsizei height,
-    GLenum format,
-    GLenum type,
-    TexImageSource source,
-  );
-  @JS('texSubImage2D')
-  external JSVoid texSubImage2D_4_(
-    GLenum target,
-    GLint level,
-    GLint xoffset,
-    GLint yoffset,
-    GLsizei width,
-    GLsizei height,
-    GLenum format,
-    GLenum type,
-    ArrayBufferView srcData,
-    GLuint srcOffset,
-  );
+  ]);
   external JSVoid compressedTexImage2D(
     GLenum target,
     GLint level,
@@ -1211,42 +789,10 @@ extension WebGL2RenderingContextOverloadsExtension
     GLsizei width,
     GLsizei height,
     GLint border,
-    GLsizei imageSize,
-    GLintptr offset,
-  );
-  @JS('compressedTexImage2D')
-  external JSVoid compressedTexImage2D_1_(
-    GLenum target,
-    GLint level,
-    GLenum internalformat,
-    GLsizei width,
-    GLsizei height,
-    GLint border,
-    ArrayBufferView srcData,
-  );
-  @JS('compressedTexImage2D')
-  external JSVoid compressedTexImage2D_1_1(
-    GLenum target,
-    GLint level,
-    GLenum internalformat,
-    GLsizei width,
-    GLsizei height,
-    GLint border,
-    ArrayBufferView srcData,
-    GLuint srcOffset,
-  );
-  @JS('compressedTexImage2D')
-  external JSVoid compressedTexImage2D_1_2(
-    GLenum target,
-    GLint level,
-    GLenum internalformat,
-    GLsizei width,
-    GLsizei height,
-    GLint border,
-    ArrayBufferView srcData,
-    GLuint srcOffset,
+    JSAny imageSizeOrSrcData, [
+    JSAny offsetOrSrcOffset,
     GLuint srcLengthOverride,
-  );
+  ]);
   external JSVoid compressedTexSubImage2D(
     GLenum target,
     GLint level,
@@ -1255,219 +801,79 @@ extension WebGL2RenderingContextOverloadsExtension
     GLsizei width,
     GLsizei height,
     GLenum format,
-    GLsizei imageSize,
-    GLintptr offset,
-  );
-  @JS('compressedTexSubImage2D')
-  external JSVoid compressedTexSubImage2D_1_(
-    GLenum target,
-    GLint level,
-    GLint xoffset,
-    GLint yoffset,
-    GLsizei width,
-    GLsizei height,
-    GLenum format,
-    ArrayBufferView srcData,
-  );
-  @JS('compressedTexSubImage2D')
-  external JSVoid compressedTexSubImage2D_1_1(
-    GLenum target,
-    GLint level,
-    GLint xoffset,
-    GLint yoffset,
-    GLsizei width,
-    GLsizei height,
-    GLenum format,
-    ArrayBufferView srcData,
-    GLuint srcOffset,
-  );
-  @JS('compressedTexSubImage2D')
-  external JSVoid compressedTexSubImage2D_1_2(
-    GLenum target,
-    GLint level,
-    GLint xoffset,
-    GLint yoffset,
-    GLsizei width,
-    GLsizei height,
-    GLenum format,
-    ArrayBufferView srcData,
-    GLuint srcOffset,
+    JSAny imageSizeOrSrcData, [
+    JSAny offsetOrSrcOffset,
     GLuint srcLengthOverride,
-  );
+  ]);
   external JSVoid uniform1fv(
     WebGLUniformLocation? location,
-    Float32List data,
-  );
-  external JSVoid uniform1fv1(
-    WebGLUniformLocation? location,
-    Float32List data,
-    GLuint srcOffset,
-  );
-  external JSVoid uniform1fv2(
-    WebGLUniformLocation? location,
-    Float32List data,
+    Float32List data, [
     GLuint srcOffset,
     GLuint srcLength,
-  );
+  ]);
   external JSVoid uniform2fv(
     WebGLUniformLocation? location,
-    Float32List data,
-  );
-  external JSVoid uniform2fv1(
-    WebGLUniformLocation? location,
-    Float32List data,
-    GLuint srcOffset,
-  );
-  external JSVoid uniform2fv2(
-    WebGLUniformLocation? location,
-    Float32List data,
+    Float32List data, [
     GLuint srcOffset,
     GLuint srcLength,
-  );
+  ]);
   external JSVoid uniform3fv(
     WebGLUniformLocation? location,
-    Float32List data,
-  );
-  external JSVoid uniform3fv1(
-    WebGLUniformLocation? location,
-    Float32List data,
-    GLuint srcOffset,
-  );
-  external JSVoid uniform3fv2(
-    WebGLUniformLocation? location,
-    Float32List data,
+    Float32List data, [
     GLuint srcOffset,
     GLuint srcLength,
-  );
+  ]);
   external JSVoid uniform4fv(
     WebGLUniformLocation? location,
-    Float32List data,
-  );
-  external JSVoid uniform4fv1(
-    WebGLUniformLocation? location,
-    Float32List data,
-    GLuint srcOffset,
-  );
-  external JSVoid uniform4fv2(
-    WebGLUniformLocation? location,
-    Float32List data,
+    Float32List data, [
     GLuint srcOffset,
     GLuint srcLength,
-  );
+  ]);
   external JSVoid uniform1iv(
     WebGLUniformLocation? location,
-    Int32List data,
-  );
-  external JSVoid uniform1iv1(
-    WebGLUniformLocation? location,
-    Int32List data,
-    GLuint srcOffset,
-  );
-  external JSVoid uniform1iv2(
-    WebGLUniformLocation? location,
-    Int32List data,
+    Int32List data, [
     GLuint srcOffset,
     GLuint srcLength,
-  );
+  ]);
   external JSVoid uniform2iv(
     WebGLUniformLocation? location,
-    Int32List data,
-  );
-  external JSVoid uniform2iv1(
-    WebGLUniformLocation? location,
-    Int32List data,
-    GLuint srcOffset,
-  );
-  external JSVoid uniform2iv2(
-    WebGLUniformLocation? location,
-    Int32List data,
+    Int32List data, [
     GLuint srcOffset,
     GLuint srcLength,
-  );
+  ]);
   external JSVoid uniform3iv(
     WebGLUniformLocation? location,
-    Int32List data,
-  );
-  external JSVoid uniform3iv1(
-    WebGLUniformLocation? location,
-    Int32List data,
-    GLuint srcOffset,
-  );
-  external JSVoid uniform3iv2(
-    WebGLUniformLocation? location,
-    Int32List data,
+    Int32List data, [
     GLuint srcOffset,
     GLuint srcLength,
-  );
+  ]);
   external JSVoid uniform4iv(
     WebGLUniformLocation? location,
-    Int32List data,
-  );
-  external JSVoid uniform4iv1(
-    WebGLUniformLocation? location,
-    Int32List data,
-    GLuint srcOffset,
-  );
-  external JSVoid uniform4iv2(
-    WebGLUniformLocation? location,
-    Int32List data,
+    Int32List data, [
     GLuint srcOffset,
     GLuint srcLength,
-  );
+  ]);
   external JSVoid uniformMatrix2fv(
     WebGLUniformLocation? location,
     GLboolean transpose,
-    Float32List data,
-  );
-  external JSVoid uniformMatrix2fv1(
-    WebGLUniformLocation? location,
-    GLboolean transpose,
-    Float32List data,
-    GLuint srcOffset,
-  );
-  external JSVoid uniformMatrix2fv2(
-    WebGLUniformLocation? location,
-    GLboolean transpose,
-    Float32List data,
+    Float32List data, [
     GLuint srcOffset,
     GLuint srcLength,
-  );
+  ]);
   external JSVoid uniformMatrix3fv(
     WebGLUniformLocation? location,
     GLboolean transpose,
-    Float32List data,
-  );
-  external JSVoid uniformMatrix3fv1(
-    WebGLUniformLocation? location,
-    GLboolean transpose,
-    Float32List data,
-    GLuint srcOffset,
-  );
-  external JSVoid uniformMatrix3fv2(
-    WebGLUniformLocation? location,
-    GLboolean transpose,
-    Float32List data,
+    Float32List data, [
     GLuint srcOffset,
     GLuint srcLength,
-  );
+  ]);
   external JSVoid uniformMatrix4fv(
     WebGLUniformLocation? location,
     GLboolean transpose,
-    Float32List data,
-  );
-  external JSVoid uniformMatrix4fv1(
-    WebGLUniformLocation? location,
-    GLboolean transpose,
-    Float32List data,
-    GLuint srcOffset,
-  );
-  external JSVoid uniformMatrix4fv2(
-    WebGLUniformLocation? location,
-    GLboolean transpose,
-    Float32List data,
+    Float32List data, [
     GLuint srcOffset,
     GLuint srcLength,
-  );
+  ]);
   external JSVoid readPixels(
     GLint x,
     GLint y,
@@ -1475,29 +881,9 @@ extension WebGL2RenderingContextOverloadsExtension
     GLsizei height,
     GLenum format,
     GLenum type,
-    ArrayBufferView? dstData,
-  );
-  @JS('readPixels')
-  external JSVoid readPixels_1_(
-    GLint x,
-    GLint y,
-    GLsizei width,
-    GLsizei height,
-    GLenum format,
-    GLenum type,
-    GLintptr offset,
-  );
-  @JS('readPixels')
-  external JSVoid readPixels_2_(
-    GLint x,
-    GLint y,
-    GLsizei width,
-    GLsizei height,
-    GLenum format,
-    GLenum type,
-    ArrayBufferView dstData,
+    JSAny? dstDataOrOffset, [
     GLuint dstOffset,
-  );
+  ]);
 }
 
 @JS('WebGL2RenderingContext')
@@ -1506,6 +892,4 @@ class WebGL2RenderingContext
     implements
         WebGLRenderingContextBase,
         WebGL2RenderingContextBase,
-        WebGL2RenderingContextOverloads {
-  external factory WebGL2RenderingContext();
-}
+        WebGL2RenderingContextOverloads {}

--- a/lib/src/dom/webgl_blend_equation_advanced_coherent.dart
+++ b/lib/src/dom/webgl_blend_equation_advanced_coherent.dart
@@ -13,8 +13,6 @@ import 'webgl1.dart';
 @JS('WEBGL_blend_equation_advanced_coherent')
 @staticInterop
 class WEBGL_blend_equation_advanced_coherent {
-  external factory WEBGL_blend_equation_advanced_coherent();
-
   external static GLenum get MULTIPLY;
   external static GLenum get SCREEN;
   external static GLenum get OVERLAY;

--- a/lib/src/dom/webgl_clip_cull_distance.dart
+++ b/lib/src/dom/webgl_clip_cull_distance.dart
@@ -13,8 +13,6 @@ import 'webgl1.dart';
 @JS('WEBGL_clip_cull_distance')
 @staticInterop
 class WEBGL_clip_cull_distance {
-  external factory WEBGL_clip_cull_distance();
-
   external static GLenum get MAX_CLIP_DISTANCES_WEBGL;
   external static GLenum get MAX_CULL_DISTANCES_WEBGL;
   external static GLenum get MAX_COMBINED_CLIP_AND_CULL_DISTANCES_WEBGL;

--- a/lib/src/dom/webgl_color_buffer_float.dart
+++ b/lib/src/dom/webgl_color_buffer_float.dart
@@ -13,8 +13,6 @@ import 'webgl1.dart';
 @JS('WEBGL_color_buffer_float')
 @staticInterop
 class WEBGL_color_buffer_float {
-  external factory WEBGL_color_buffer_float();
-
   external static GLenum get RGBA32F_EXT;
   external static GLenum get FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT;
   external static GLenum get UNSIGNED_NORMALIZED_EXT;

--- a/lib/src/dom/webgl_compressed_texture_astc.dart
+++ b/lib/src/dom/webgl_compressed_texture_astc.dart
@@ -13,8 +13,6 @@ import 'webgl1.dart';
 @JS('WEBGL_compressed_texture_astc')
 @staticInterop
 class WEBGL_compressed_texture_astc {
-  external factory WEBGL_compressed_texture_astc();
-
   external static GLenum get COMPRESSED_RGBA_ASTC_4x4_KHR;
   external static GLenum get COMPRESSED_RGBA_ASTC_5x4_KHR;
   external static GLenum get COMPRESSED_RGBA_ASTC_5x5_KHR;

--- a/lib/src/dom/webgl_compressed_texture_etc.dart
+++ b/lib/src/dom/webgl_compressed_texture_etc.dart
@@ -13,8 +13,6 @@ import 'webgl1.dart';
 @JS('WEBGL_compressed_texture_etc')
 @staticInterop
 class WEBGL_compressed_texture_etc {
-  external factory WEBGL_compressed_texture_etc();
-
   external static GLenum get COMPRESSED_R11_EAC;
   external static GLenum get COMPRESSED_SIGNED_R11_EAC;
   external static GLenum get COMPRESSED_RG11_EAC;

--- a/lib/src/dom/webgl_compressed_texture_etc1.dart
+++ b/lib/src/dom/webgl_compressed_texture_etc1.dart
@@ -13,7 +13,5 @@ import 'webgl1.dart';
 @JS('WEBGL_compressed_texture_etc1')
 @staticInterop
 class WEBGL_compressed_texture_etc1 {
-  external factory WEBGL_compressed_texture_etc1();
-
   external static GLenum get COMPRESSED_RGB_ETC1_WEBGL;
 }

--- a/lib/src/dom/webgl_compressed_texture_pvrtc.dart
+++ b/lib/src/dom/webgl_compressed_texture_pvrtc.dart
@@ -13,8 +13,6 @@ import 'webgl1.dart';
 @JS('WEBGL_compressed_texture_pvrtc')
 @staticInterop
 class WEBGL_compressed_texture_pvrtc {
-  external factory WEBGL_compressed_texture_pvrtc();
-
   external static GLenum get COMPRESSED_RGB_PVRTC_4BPPV1_IMG;
   external static GLenum get COMPRESSED_RGB_PVRTC_2BPPV1_IMG;
   external static GLenum get COMPRESSED_RGBA_PVRTC_4BPPV1_IMG;

--- a/lib/src/dom/webgl_compressed_texture_s3tc.dart
+++ b/lib/src/dom/webgl_compressed_texture_s3tc.dart
@@ -13,8 +13,6 @@ import 'webgl1.dart';
 @JS('WEBGL_compressed_texture_s3tc')
 @staticInterop
 class WEBGL_compressed_texture_s3tc {
-  external factory WEBGL_compressed_texture_s3tc();
-
   external static GLenum get COMPRESSED_RGB_S3TC_DXT1_EXT;
   external static GLenum get COMPRESSED_RGBA_S3TC_DXT1_EXT;
   external static GLenum get COMPRESSED_RGBA_S3TC_DXT3_EXT;

--- a/lib/src/dom/webgl_compressed_texture_s3tc_srgb.dart
+++ b/lib/src/dom/webgl_compressed_texture_s3tc_srgb.dart
@@ -13,8 +13,6 @@ import 'webgl1.dart';
 @JS('WEBGL_compressed_texture_s3tc_srgb')
 @staticInterop
 class WEBGL_compressed_texture_s3tc_srgb {
-  external factory WEBGL_compressed_texture_s3tc_srgb();
-
   external static GLenum get COMPRESSED_SRGB_S3TC_DXT1_EXT;
   external static GLenum get COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT;
   external static GLenum get COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT;

--- a/lib/src/dom/webgl_debug_renderer_info.dart
+++ b/lib/src/dom/webgl_debug_renderer_info.dart
@@ -13,8 +13,6 @@ import 'webgl1.dart';
 @JS('WEBGL_debug_renderer_info')
 @staticInterop
 class WEBGL_debug_renderer_info {
-  external factory WEBGL_debug_renderer_info();
-
   external static GLenum get UNMASKED_VENDOR_WEBGL;
   external static GLenum get UNMASKED_RENDERER_WEBGL;
 }

--- a/lib/src/dom/webgl_debug_shaders.dart
+++ b/lib/src/dom/webgl_debug_shaders.dart
@@ -12,9 +12,7 @@ import 'webgl1.dart';
 
 @JS('WEBGL_debug_shaders')
 @staticInterop
-class WEBGL_debug_shaders {
-  external factory WEBGL_debug_shaders();
-}
+class WEBGL_debug_shaders {}
 
 extension WEBGLDebugShadersExtension on WEBGL_debug_shaders {
   external JSString getTranslatedShaderSource(WebGLShader shader);

--- a/lib/src/dom/webgl_depth_texture.dart
+++ b/lib/src/dom/webgl_depth_texture.dart
@@ -13,7 +13,5 @@ import 'webgl1.dart';
 @JS('WEBGL_depth_texture')
 @staticInterop
 class WEBGL_depth_texture {
-  external factory WEBGL_depth_texture();
-
   external static GLenum get UNSIGNED_INT_24_8_WEBGL;
 }

--- a/lib/src/dom/webgl_draw_buffers.dart
+++ b/lib/src/dom/webgl_draw_buffers.dart
@@ -13,8 +13,6 @@ import 'webgl1.dart';
 @JS('WEBGL_draw_buffers')
 @staticInterop
 class WEBGL_draw_buffers {
-  external factory WEBGL_draw_buffers();
-
   external static GLenum get COLOR_ATTACHMENT0_WEBGL;
   external static GLenum get COLOR_ATTACHMENT1_WEBGL;
   external static GLenum get COLOR_ATTACHMENT2_WEBGL;

--- a/lib/src/dom/webgl_draw_instanced_base_vertex_base_instance.dart
+++ b/lib/src/dom/webgl_draw_instanced_base_vertex_base_instance.dart
@@ -12,9 +12,7 @@ import 'webgl1.dart';
 
 @JS('WEBGL_draw_instanced_base_vertex_base_instance')
 @staticInterop
-class WEBGL_draw_instanced_base_vertex_base_instance {
-  external factory WEBGL_draw_instanced_base_vertex_base_instance();
-}
+class WEBGL_draw_instanced_base_vertex_base_instance {}
 
 extension WEBGLDrawInstancedBaseVertexBaseInstanceExtension
     on WEBGL_draw_instanced_base_vertex_base_instance {

--- a/lib/src/dom/webgl_lose_context.dart
+++ b/lib/src/dom/webgl_lose_context.dart
@@ -10,9 +10,7 @@ import 'package:js/js.dart' hide JS;
 
 @JS('WEBGL_lose_context')
 @staticInterop
-class WEBGL_lose_context {
-  external factory WEBGL_lose_context();
-}
+class WEBGL_lose_context {}
 
 extension WEBGLLoseContextExtension on WEBGL_lose_context {
   external JSVoid loseContext();

--- a/lib/src/dom/webgl_multi_draw.dart
+++ b/lib/src/dom/webgl_multi_draw.dart
@@ -12,9 +12,7 @@ import 'webgl1.dart';
 
 @JS('WEBGL_multi_draw')
 @staticInterop
-class WEBGL_multi_draw {
-  external factory WEBGL_multi_draw();
-}
+class WEBGL_multi_draw {}
 
 extension WEBGLMultiDrawExtension on WEBGL_multi_draw {
   external JSVoid multiDrawArraysWEBGL(

--- a/lib/src/dom/webgl_multi_draw_instanced_base_vertex_base_instance.dart
+++ b/lib/src/dom/webgl_multi_draw_instanced_base_vertex_base_instance.dart
@@ -12,9 +12,7 @@ import 'webgl1.dart';
 
 @JS('WEBGL_multi_draw_instanced_base_vertex_base_instance')
 @staticInterop
-class WEBGL_multi_draw_instanced_base_vertex_base_instance {
-  external factory WEBGL_multi_draw_instanced_base_vertex_base_instance();
-}
+class WEBGL_multi_draw_instanced_base_vertex_base_instance {}
 
 extension WEBGLMultiDrawInstancedBaseVertexBaseInstanceExtension
     on WEBGL_multi_draw_instanced_base_vertex_base_instance {

--- a/lib/src/dom/webgl_provoking_vertex.dart
+++ b/lib/src/dom/webgl_provoking_vertex.dart
@@ -13,8 +13,6 @@ import 'webgl1.dart';
 @JS('WEBGL_provoking_vertex')
 @staticInterop
 class WEBGL_provoking_vertex {
-  external factory WEBGL_provoking_vertex();
-
   external static GLenum get FIRST_VERTEX_CONVENTION_WEBGL;
   external static GLenum get LAST_VERTEX_CONVENTION_WEBGL;
   external static GLenum get PROVOKING_VERTEX_WEBGL;

--- a/lib/src/dom/webgpu.dart
+++ b/lib/src/dom/webgpu.dart
@@ -73,9 +73,7 @@ typedef GPUErrorFilter = JSString;
 
 @JS('GPUObjectBase')
 @staticInterop
-class GPUObjectBase {
-  external factory GPUObjectBase();
-}
+class GPUObjectBase {}
 
 extension GPUObjectBaseExtension on GPUObjectBase {
   external set label(JSString value);
@@ -96,9 +94,7 @@ extension GPUObjectDescriptorBaseExtension on GPUObjectDescriptorBase {
 
 @JS('GPUSupportedLimits')
 @staticInterop
-class GPUSupportedLimits {
-  external factory GPUSupportedLimits();
-}
+class GPUSupportedLimits {}
 
 extension GPUSupportedLimitsExtension on GPUSupportedLimits {
   external JSNumber get maxTextureDimension1D;
@@ -136,17 +132,13 @@ extension GPUSupportedLimitsExtension on GPUSupportedLimits {
 
 @JS('GPUSupportedFeatures')
 @staticInterop
-class GPUSupportedFeatures {
-  external factory GPUSupportedFeatures();
-}
+class GPUSupportedFeatures {}
 
 extension GPUSupportedFeaturesExtension on GPUSupportedFeatures {}
 
 @JS('GPUAdapterInfo')
 @staticInterop
-class GPUAdapterInfo {
-  external factory GPUAdapterInfo();
-}
+class GPUAdapterInfo {}
 
 extension GPUAdapterInfoExtension on GPUAdapterInfo {
   external JSString get vendor;
@@ -157,9 +149,7 @@ extension GPUAdapterInfoExtension on GPUAdapterInfo {
 
 @JS('NavigatorGPU')
 @staticInterop
-class NavigatorGPU {
-  external factory NavigatorGPU();
-}
+class NavigatorGPU {}
 
 extension NavigatorGPUExtension on NavigatorGPU {
   external GPU get gpu;
@@ -167,13 +157,10 @@ extension NavigatorGPUExtension on NavigatorGPU {
 
 @JS('GPU')
 @staticInterop
-class GPU {
-  external factory GPU();
-}
+class GPU {}
 
 extension GPUExtension on GPU {
-  external JSPromise requestAdapter();
-  external JSPromise requestAdapter1(GPURequestAdapterOptions options);
+  external JSPromise requestAdapter([GPURequestAdapterOptions options]);
   external GPUTextureFormat getPreferredCanvasFormat();
 }
 
@@ -196,24 +183,20 @@ extension GPURequestAdapterOptionsExtension on GPURequestAdapterOptions {
 
 @JS('GPUAdapter')
 @staticInterop
-class GPUAdapter {
-  external factory GPUAdapter();
-}
+class GPUAdapter {}
 
 extension GPUAdapterExtension on GPUAdapter {
+  external JSPromise requestDevice([GPUDeviceDescriptor descriptor]);
+  external JSPromise requestAdapterInfo([JSArray unmaskHints]);
   external GPUSupportedFeatures get features;
   external GPUSupportedLimits get limits;
   external JSBoolean get isFallbackAdapter;
-  external JSPromise requestDevice();
-  external JSPromise requestDevice1(GPUDeviceDescriptor descriptor);
-  external JSPromise requestAdapterInfo();
-  external JSPromise requestAdapterInfo1(JSArray unmaskHints);
 }
 
 @JS()
 @staticInterop
 @anonymous
-class GPUDeviceDescriptor extends GPUObjectDescriptorBase {
+class GPUDeviceDescriptor implements GPUObjectDescriptorBase {
   external factory GPUDeviceDescriptor({
     JSArray requiredFeatures = const [],
     JSAny requiredLimits,
@@ -232,19 +215,13 @@ extension GPUDeviceDescriptorExtension on GPUDeviceDescriptor {
 
 @JS('GPUDevice')
 @staticInterop
-class GPUDevice extends EventTarget implements GPUObjectBase {
-  external factory GPUDevice();
-}
+class GPUDevice implements EventTarget, GPUObjectBase {}
 
 extension GPUDeviceExtension on GPUDevice {
-  external GPUSupportedFeatures get features;
-  external GPUSupportedLimits get limits;
-  external GPUQueue get queue;
   external JSVoid destroy();
   external GPUBuffer createBuffer(GPUBufferDescriptor descriptor);
   external GPUTexture createTexture(GPUTextureDescriptor descriptor);
-  external GPUSampler createSampler();
-  external GPUSampler createSampler1(GPUSamplerDescriptor descriptor);
+  external GPUSampler createSampler([GPUSamplerDescriptor descriptor]);
   external GPUExternalTexture importExternalTexture(
       GPUExternalTextureDescriptor descriptor);
   external GPUBindGroupLayout createBindGroupLayout(
@@ -262,53 +239,46 @@ extension GPUDeviceExtension on GPUDevice {
       GPUComputePipelineDescriptor descriptor);
   external JSPromise createRenderPipelineAsync(
       GPURenderPipelineDescriptor descriptor);
-  external GPUCommandEncoder createCommandEncoder();
-  external GPUCommandEncoder createCommandEncoder1(
-      GPUCommandEncoderDescriptor descriptor);
+  external GPUCommandEncoder createCommandEncoder(
+      [GPUCommandEncoderDescriptor descriptor]);
   external GPURenderBundleEncoder createRenderBundleEncoder(
       GPURenderBundleEncoderDescriptor descriptor);
   external GPUQuerySet createQuerySet(GPUQuerySetDescriptor descriptor);
-  external JSPromise get lost;
   external JSVoid pushErrorScope(GPUErrorFilter filter);
   external JSPromise popErrorScope();
+  external GPUSupportedFeatures get features;
+  external GPUSupportedLimits get limits;
+  external GPUQueue get queue;
+  external JSPromise get lost;
   external set onuncapturederror(EventHandler value);
   external EventHandler get onuncapturederror;
 }
 
 @JS('GPUBuffer')
 @staticInterop
-class GPUBuffer implements GPUObjectBase {
-  external factory GPUBuffer();
-}
+class GPUBuffer implements GPUObjectBase {}
 
 extension GPUBufferExtension on GPUBuffer {
+  external JSPromise mapAsync(
+    GPUMapModeFlags mode, [
+    GPUSize64 offset,
+    GPUSize64 size,
+  ]);
+  external JSArrayBuffer getMappedRange([
+    GPUSize64 offset,
+    GPUSize64 size,
+  ]);
+  external JSVoid unmap();
+  external JSVoid destroy();
   external GPUSize64 get size;
   external GPUBufferUsageFlags get usage;
   external GPUBufferMapState get mapState;
-  external JSPromise mapAsync(GPUMapModeFlags mode);
-  external JSPromise mapAsync1(
-    GPUMapModeFlags mode,
-    GPUSize64 offset,
-  );
-  external JSPromise mapAsync2(
-    GPUMapModeFlags mode,
-    GPUSize64 offset,
-    GPUSize64 size,
-  );
-  external JSArrayBuffer getMappedRange();
-  external JSArrayBuffer getMappedRange1(GPUSize64 offset);
-  external JSArrayBuffer getMappedRange2(
-    GPUSize64 offset,
-    GPUSize64 size,
-  );
-  external JSVoid unmap();
-  external JSVoid destroy();
 }
 
 @JS()
 @staticInterop
 @anonymous
-class GPUBufferDescriptor extends GPUObjectDescriptorBase {
+class GPUBufferDescriptor implements GPUObjectDescriptorBase {
   external factory GPUBufferDescriptor({
     required GPUSize64 size,
     required GPUBufferUsageFlags usage,
@@ -331,8 +301,6 @@ external $GPUBufferUsage get GPUBufferUsage;
 @JS('GPUBufferUsage')
 @staticInterop
 abstract class $GPUBufferUsage {
-  external factory $GPUBufferUsage();
-
   external static GPUFlagsConstant get MAP_READ;
   external static GPUFlagsConstant get MAP_WRITE;
   external static GPUFlagsConstant get COPY_SRC;
@@ -351,21 +319,16 @@ external $GPUMapMode get GPUMapMode;
 @JS('GPUMapMode')
 @staticInterop
 abstract class $GPUMapMode {
-  external factory $GPUMapMode();
-
   external static GPUFlagsConstant get READ;
   external static GPUFlagsConstant get WRITE;
 }
 
 @JS('GPUTexture')
 @staticInterop
-class GPUTexture implements GPUObjectBase {
-  external factory GPUTexture();
-}
+class GPUTexture implements GPUObjectBase {}
 
 extension GPUTextureExtension on GPUTexture {
-  external GPUTextureView createView();
-  external GPUTextureView createView1(GPUTextureViewDescriptor descriptor);
+  external GPUTextureView createView([GPUTextureViewDescriptor descriptor]);
   external JSVoid destroy();
   external GPUIntegerCoordinate get width;
   external GPUIntegerCoordinate get height;
@@ -380,7 +343,7 @@ extension GPUTextureExtension on GPUTexture {
 @JS()
 @staticInterop
 @anonymous
-class GPUTextureDescriptor extends GPUObjectDescriptorBase {
+class GPUTextureDescriptor implements GPUObjectDescriptorBase {
   external factory GPUTextureDescriptor({
     required GPUExtent3D size,
     GPUIntegerCoordinate mipLevelCount = 1,
@@ -415,8 +378,6 @@ external $GPUTextureUsage get GPUTextureUsage;
 @JS('GPUTextureUsage')
 @staticInterop
 abstract class $GPUTextureUsage {
-  external factory $GPUTextureUsage();
-
   external static GPUFlagsConstant get COPY_SRC;
   external static GPUFlagsConstant get COPY_DST;
   external static GPUFlagsConstant get TEXTURE_BINDING;
@@ -426,14 +387,12 @@ abstract class $GPUTextureUsage {
 
 @JS('GPUTextureView')
 @staticInterop
-class GPUTextureView implements GPUObjectBase {
-  external factory GPUTextureView();
-}
+class GPUTextureView implements GPUObjectBase {}
 
 @JS()
 @staticInterop
 @anonymous
-class GPUTextureViewDescriptor extends GPUObjectDescriptorBase {
+class GPUTextureViewDescriptor implements GPUObjectDescriptorBase {
   external factory GPUTextureViewDescriptor({
     GPUTextureFormat format,
     GPUTextureViewDimension dimension,
@@ -464,14 +423,12 @@ extension GPUTextureViewDescriptorExtension on GPUTextureViewDescriptor {
 
 @JS('GPUExternalTexture')
 @staticInterop
-class GPUExternalTexture implements GPUObjectBase {
-  external factory GPUExternalTexture();
-}
+class GPUExternalTexture implements GPUObjectBase {}
 
 @JS()
 @staticInterop
 @anonymous
-class GPUExternalTextureDescriptor extends GPUObjectDescriptorBase {
+class GPUExternalTextureDescriptor implements GPUObjectDescriptorBase {
   external factory GPUExternalTextureDescriptor({
     required HTMLVideoElement source,
     PredefinedColorSpace colorSpace = 'srgb',
@@ -488,14 +445,12 @@ extension GPUExternalTextureDescriptorExtension
 
 @JS('GPUSampler')
 @staticInterop
-class GPUSampler implements GPUObjectBase {
-  external factory GPUSampler();
-}
+class GPUSampler implements GPUObjectBase {}
 
 @JS()
 @staticInterop
 @anonymous
-class GPUSamplerDescriptor extends GPUObjectDescriptorBase {
+class GPUSamplerDescriptor implements GPUObjectDescriptorBase {
   external factory GPUSamplerDescriptor({
     GPUAddressMode addressModeU = 'clamp-to-edge',
     GPUAddressMode addressModeV = 'clamp-to-edge',
@@ -535,14 +490,12 @@ extension GPUSamplerDescriptorExtension on GPUSamplerDescriptor {
 
 @JS('GPUBindGroupLayout')
 @staticInterop
-class GPUBindGroupLayout implements GPUObjectBase {
-  external factory GPUBindGroupLayout();
-}
+class GPUBindGroupLayout implements GPUObjectBase {}
 
 @JS()
 @staticInterop
 @anonymous
-class GPUBindGroupLayoutDescriptor extends GPUObjectDescriptorBase {
+class GPUBindGroupLayoutDescriptor implements GPUObjectDescriptorBase {
   external factory GPUBindGroupLayoutDescriptor({required JSArray entries});
 }
 
@@ -590,8 +543,6 @@ external $GPUShaderStage get GPUShaderStage;
 @JS('GPUShaderStage')
 @staticInterop
 abstract class $GPUShaderStage {
-  external factory $GPUShaderStage();
-
   external static GPUFlagsConstant get VERTEX;
   external static GPUFlagsConstant get FRAGMENT;
   external static GPUFlagsConstant get COMPUTE;
@@ -680,14 +631,12 @@ class GPUExternalTextureBindingLayout {
 
 @JS('GPUBindGroup')
 @staticInterop
-class GPUBindGroup implements GPUObjectBase {
-  external factory GPUBindGroup();
-}
+class GPUBindGroup implements GPUObjectBase {}
 
 @JS()
 @staticInterop
 @anonymous
-class GPUBindGroupDescriptor extends GPUObjectDescriptorBase {
+class GPUBindGroupDescriptor implements GPUObjectDescriptorBase {
   external factory GPUBindGroupDescriptor({
     required GPUBindGroupLayout layout,
     required JSArray entries,
@@ -740,14 +689,12 @@ extension GPUBufferBindingExtension on GPUBufferBinding {
 
 @JS('GPUPipelineLayout')
 @staticInterop
-class GPUPipelineLayout implements GPUObjectBase {
-  external factory GPUPipelineLayout();
-}
+class GPUPipelineLayout implements GPUObjectBase {}
 
 @JS()
 @staticInterop
 @anonymous
-class GPUPipelineLayoutDescriptor extends GPUObjectDescriptorBase {
+class GPUPipelineLayoutDescriptor implements GPUObjectDescriptorBase {
   external factory GPUPipelineLayoutDescriptor(
       {required JSArray bindGroupLayouts});
 }
@@ -759,9 +706,7 @@ extension GPUPipelineLayoutDescriptorExtension on GPUPipelineLayoutDescriptor {
 
 @JS('GPUShaderModule')
 @staticInterop
-class GPUShaderModule implements GPUObjectBase {
-  external factory GPUShaderModule();
-}
+class GPUShaderModule implements GPUObjectBase {}
 
 extension GPUShaderModuleExtension on GPUShaderModule {
   external JSPromise compilationInfo();
@@ -770,7 +715,7 @@ extension GPUShaderModuleExtension on GPUShaderModule {
 @JS()
 @staticInterop
 @anonymous
-class GPUShaderModuleDescriptor extends GPUObjectDescriptorBase {
+class GPUShaderModuleDescriptor implements GPUObjectDescriptorBase {
   external factory GPUShaderModuleDescriptor({
     required JSString code,
     JSObject sourceMap,
@@ -802,9 +747,7 @@ extension GPUShaderModuleCompilationHintExtension
 
 @JS('GPUCompilationMessage')
 @staticInterop
-class GPUCompilationMessage {
-  external factory GPUCompilationMessage();
-}
+class GPUCompilationMessage {}
 
 extension GPUCompilationMessageExtension on GPUCompilationMessage {
   external JSString get message;
@@ -817,9 +760,7 @@ extension GPUCompilationMessageExtension on GPUCompilationMessage {
 
 @JS('GPUCompilationInfo')
 @staticInterop
-class GPUCompilationInfo {
-  external factory GPUCompilationInfo();
-}
+class GPUCompilationInfo {}
 
 extension GPUCompilationInfoExtension on GPUCompilationInfo {
   external JSArray get messages;
@@ -827,10 +768,8 @@ extension GPUCompilationInfoExtension on GPUCompilationInfo {
 
 @JS('GPUPipelineError')
 @staticInterop
-class GPUPipelineError extends DOMException {
-  external factory GPUPipelineError();
-
-  external factory GPUPipelineError.a1(
+class GPUPipelineError implements DOMException {
+  external factory GPUPipelineError(
     JSString message,
     GPUPipelineErrorInit options,
   );
@@ -856,7 +795,7 @@ extension GPUPipelineErrorInitExtension on GPUPipelineErrorInit {
 @JS()
 @staticInterop
 @anonymous
-class GPUPipelineDescriptorBase extends GPUObjectDescriptorBase {
+class GPUPipelineDescriptorBase implements GPUObjectDescriptorBase {
   external factory GPUPipelineDescriptorBase({required JSAny layout});
 }
 
@@ -867,9 +806,7 @@ extension GPUPipelineDescriptorBaseExtension on GPUPipelineDescriptorBase {
 
 @JS('GPUPipelineBase')
 @staticInterop
-class GPUPipelineBase {
-  external factory GPUPipelineBase();
-}
+class GPUPipelineBase {}
 
 extension GPUPipelineBaseExtension on GPUPipelineBase {
   external GPUBindGroupLayout getBindGroupLayout(JSNumber index);
@@ -897,14 +834,12 @@ extension GPUProgrammableStageExtension on GPUProgrammableStage {
 
 @JS('GPUComputePipeline')
 @staticInterop
-class GPUComputePipeline implements GPUObjectBase, GPUPipelineBase {
-  external factory GPUComputePipeline();
-}
+class GPUComputePipeline implements GPUObjectBase, GPUPipelineBase {}
 
 @JS()
 @staticInterop
 @anonymous
-class GPUComputePipelineDescriptor extends GPUPipelineDescriptorBase {
+class GPUComputePipelineDescriptor implements GPUPipelineDescriptorBase {
   external factory GPUComputePipelineDescriptor(
       {required GPUProgrammableStage compute});
 }
@@ -917,14 +852,12 @@ extension GPUComputePipelineDescriptorExtension
 
 @JS('GPURenderPipeline')
 @staticInterop
-class GPURenderPipeline implements GPUObjectBase, GPUPipelineBase {
-  external factory GPURenderPipeline();
-}
+class GPURenderPipeline implements GPUObjectBase, GPUPipelineBase {}
 
 @JS()
 @staticInterop
 @anonymous
-class GPURenderPipelineDescriptor extends GPUPipelineDescriptorBase {
+class GPURenderPipelineDescriptor implements GPUPipelineDescriptorBase {
   external factory GPURenderPipelineDescriptor({
     required GPUVertexState vertex,
     GPUPrimitiveState primitive,
@@ -996,7 +929,7 @@ extension GPUMultisampleStateExtension on GPUMultisampleState {
 @JS()
 @staticInterop
 @anonymous
-class GPUFragmentState extends GPUProgrammableStage {
+class GPUFragmentState implements GPUProgrammableStage {
   external factory GPUFragmentState({required JSArray targets});
 }
 
@@ -1048,8 +981,6 @@ external $GPUColorWrite get GPUColorWrite;
 @JS('GPUColorWrite')
 @staticInterop
 abstract class $GPUColorWrite {
-  external factory $GPUColorWrite();
-
   external static GPUFlagsConstant get RED;
   external static GPUFlagsConstant get GREEN;
   external static GPUFlagsConstant get BLUE;
@@ -1144,7 +1075,7 @@ extension GPUStencilFaceStateExtension on GPUStencilFaceState {
 @JS()
 @staticInterop
 @anonymous
-class GPUVertexState extends GPUProgrammableStage {
+class GPUVertexState implements GPUProgrammableStage {
   external factory GPUVertexState({JSArray buffers = const []});
 }
 
@@ -1216,7 +1147,7 @@ extension GPUImageDataLayoutExtension on GPUImageDataLayout {
 @JS()
 @staticInterop
 @anonymous
-class GPUImageCopyBuffer extends GPUImageDataLayout {
+class GPUImageCopyBuffer implements GPUImageDataLayout {
   external factory GPUImageCopyBuffer({required GPUBuffer buffer});
 }
 
@@ -1251,7 +1182,7 @@ extension GPUImageCopyTextureExtension on GPUImageCopyTexture {
 @JS()
 @staticInterop
 @anonymous
-class GPUImageCopyTextureTagged extends GPUImageCopyTexture {
+class GPUImageCopyTextureTagged implements GPUImageCopyTexture {
   external factory GPUImageCopyTextureTagged({
     PredefinedColorSpace colorSpace = 'srgb',
     JSBoolean premultipliedAlpha = false,
@@ -1287,36 +1218,29 @@ extension GPUImageCopyExternalImageExtension on GPUImageCopyExternalImage {
 
 @JS('GPUCommandBuffer')
 @staticInterop
-class GPUCommandBuffer implements GPUObjectBase {
-  external factory GPUCommandBuffer();
-}
+class GPUCommandBuffer implements GPUObjectBase {}
 
 @JS()
 @staticInterop
 @anonymous
-class GPUCommandBufferDescriptor extends GPUObjectDescriptorBase {
+class GPUCommandBufferDescriptor implements GPUObjectDescriptorBase {
   external factory GPUCommandBufferDescriptor();
 }
 
 @JS('GPUCommandsMixin')
 @staticInterop
-class GPUCommandsMixin {
-  external factory GPUCommandsMixin();
-}
+class GPUCommandsMixin {}
 
 @JS('GPUCommandEncoder')
 @staticInterop
 class GPUCommandEncoder
-    implements GPUObjectBase, GPUCommandsMixin, GPUDebugCommandsMixin {
-  external factory GPUCommandEncoder();
-}
+    implements GPUObjectBase, GPUCommandsMixin, GPUDebugCommandsMixin {}
 
 extension GPUCommandEncoderExtension on GPUCommandEncoder {
   external GPURenderPassEncoder beginRenderPass(
       GPURenderPassDescriptor descriptor);
-  external GPUComputePassEncoder beginComputePass();
-  external GPUComputePassEncoder beginComputePass1(
-      GPUComputePassDescriptor descriptor);
+  external GPUComputePassEncoder beginComputePass(
+      [GPUComputePassDescriptor descriptor]);
   external JSVoid copyBufferToBuffer(
     GPUBuffer source,
     GPUSize64 sourceOffset,
@@ -1339,16 +1263,11 @@ extension GPUCommandEncoderExtension on GPUCommandEncoder {
     GPUImageCopyTexture destination,
     GPUExtent3D copySize,
   );
-  external JSVoid clearBuffer(GPUBuffer buffer);
-  external JSVoid clearBuffer1(
-    GPUBuffer buffer,
-    GPUSize64 offset,
-  );
-  external JSVoid clearBuffer2(
-    GPUBuffer buffer,
+  external JSVoid clearBuffer(
+    GPUBuffer buffer, [
     GPUSize64 offset,
     GPUSize64 size,
-  );
+  ]);
   external JSVoid writeTimestamp(
     GPUQuerySet querySet,
     GPUSize32 queryIndex,
@@ -1360,48 +1279,33 @@ extension GPUCommandEncoderExtension on GPUCommandEncoder {
     GPUBuffer destination,
     GPUSize64 destinationOffset,
   );
-  external GPUCommandBuffer finish();
-  external GPUCommandBuffer finish1(GPUCommandBufferDescriptor descriptor);
+  external GPUCommandBuffer finish([GPUCommandBufferDescriptor descriptor]);
 }
 
 @JS()
 @staticInterop
 @anonymous
-class GPUCommandEncoderDescriptor extends GPUObjectDescriptorBase {
+class GPUCommandEncoderDescriptor implements GPUObjectDescriptorBase {
   external factory GPUCommandEncoderDescriptor();
 }
 
 @JS('GPUBindingCommandsMixin')
 @staticInterop
-class GPUBindingCommandsMixin {
-  external factory GPUBindingCommandsMixin();
-}
+class GPUBindingCommandsMixin {}
 
 extension GPUBindingCommandsMixinExtension on GPUBindingCommandsMixin {
   external JSVoid setBindGroup(
     GPUIndex32 index,
-    GPUBindGroup bindGroup,
-  );
-  external JSVoid setBindGroup1(
-    GPUIndex32 index,
-    GPUBindGroup bindGroup,
-    JSArray dynamicOffsets,
-  );
-  @JS('setBindGroup')
-  external JSVoid setBindGroup_1_(
-    GPUIndex32 index,
-    GPUBindGroup bindGroup,
-    JSUint32Array dynamicOffsetsData,
+    GPUBindGroup bindGroup, [
+    JSAny dynamicOffsetsOrDynamicOffsetsData,
     GPUSize64 dynamicOffsetsDataStart,
     GPUSize32 dynamicOffsetsDataLength,
-  );
+  ]);
 }
 
 @JS('GPUDebugCommandsMixin')
 @staticInterop
-class GPUDebugCommandsMixin {
-  external factory GPUDebugCommandsMixin();
-}
+class GPUDebugCommandsMixin {}
 
 extension GPUDebugCommandsMixinExtension on GPUDebugCommandsMixin {
   external JSVoid pushDebugGroup(JSString groupLabel);
@@ -1416,22 +1320,15 @@ class GPUComputePassEncoder
         GPUObjectBase,
         GPUCommandsMixin,
         GPUDebugCommandsMixin,
-        GPUBindingCommandsMixin {
-  external factory GPUComputePassEncoder();
-}
+        GPUBindingCommandsMixin {}
 
 extension GPUComputePassEncoderExtension on GPUComputePassEncoder {
   external JSVoid setPipeline(GPUComputePipeline pipeline);
-  external JSVoid dispatchWorkgroups(GPUSize32 workgroupCountX);
-  external JSVoid dispatchWorkgroups1(
-    GPUSize32 workgroupCountX,
-    GPUSize32 workgroupCountY,
-  );
-  external JSVoid dispatchWorkgroups2(
-    GPUSize32 workgroupCountX,
+  external JSVoid dispatchWorkgroups(
+    GPUSize32 workgroupCountX, [
     GPUSize32 workgroupCountY,
     GPUSize32 workgroupCountZ,
-  );
+  ]);
   external JSVoid dispatchWorkgroupsIndirect(
     GPUBuffer indirectBuffer,
     GPUSize64 indirectOffset,
@@ -1463,7 +1360,7 @@ extension GPUComputePassTimestampWriteExtension
 @JS()
 @staticInterop
 @anonymous
-class GPUComputePassDescriptor extends GPUObjectDescriptorBase {
+class GPUComputePassDescriptor implements GPUObjectDescriptorBase {
   external factory GPUComputePassDescriptor(
       {GPUComputePassTimestampWrites timestampWrites = const []});
 }
@@ -1481,9 +1378,7 @@ class GPURenderPassEncoder
         GPUCommandsMixin,
         GPUDebugCommandsMixin,
         GPUBindingCommandsMixin,
-        GPURenderCommandsMixin {
-  external factory GPURenderPassEncoder();
-}
+        GPURenderCommandsMixin {}
 
 extension GPURenderPassEncoderExtension on GPURenderPassEncoder {
   external JSVoid setViewport(
@@ -1531,7 +1426,7 @@ extension GPURenderPassTimestampWriteExtension on GPURenderPassTimestampWrite {
 @JS()
 @staticInterop
 @anonymous
-class GPURenderPassDescriptor extends GPUObjectDescriptorBase {
+class GPURenderPassDescriptor implements GPUObjectDescriptorBase {
   external factory GPURenderPassDescriptor({
     required JSArray colorAttachments,
     GPURenderPassDepthStencilAttachment depthStencilAttachment,
@@ -1624,7 +1519,7 @@ extension GPURenderPassDepthStencilAttachmentExtension
 @JS()
 @staticInterop
 @anonymous
-class GPURenderPassLayout extends GPUObjectDescriptorBase {
+class GPURenderPassLayout implements GPUObjectDescriptorBase {
   external factory GPURenderPassLayout({
     required JSArray colorFormats,
     GPUTextureFormat depthStencilFormat,
@@ -1643,81 +1538,35 @@ extension GPURenderPassLayoutExtension on GPURenderPassLayout {
 
 @JS('GPURenderCommandsMixin')
 @staticInterop
-class GPURenderCommandsMixin {
-  external factory GPURenderCommandsMixin();
-}
+class GPURenderCommandsMixin {}
 
 extension GPURenderCommandsMixinExtension on GPURenderCommandsMixin {
   external JSVoid setPipeline(GPURenderPipeline pipeline);
   external JSVoid setIndexBuffer(
     GPUBuffer buffer,
-    GPUIndexFormat indexFormat,
-  );
-  external JSVoid setIndexBuffer1(
-    GPUBuffer buffer,
-    GPUIndexFormat indexFormat,
-    GPUSize64 offset,
-  );
-  external JSVoid setIndexBuffer2(
-    GPUBuffer buffer,
-    GPUIndexFormat indexFormat,
+    GPUIndexFormat indexFormat, [
     GPUSize64 offset,
     GPUSize64 size,
-  );
+  ]);
   external JSVoid setVertexBuffer(
     GPUIndex32 slot,
-    GPUBuffer buffer,
-  );
-  external JSVoid setVertexBuffer1(
-    GPUIndex32 slot,
-    GPUBuffer buffer,
-    GPUSize64 offset,
-  );
-  external JSVoid setVertexBuffer2(
-    GPUIndex32 slot,
-    GPUBuffer buffer,
+    GPUBuffer buffer, [
     GPUSize64 offset,
     GPUSize64 size,
-  );
-  external JSVoid draw(GPUSize32 vertexCount);
-  external JSVoid draw1(
-    GPUSize32 vertexCount,
-    GPUSize32 instanceCount,
-  );
-  external JSVoid draw2(
-    GPUSize32 vertexCount,
-    GPUSize32 instanceCount,
-    GPUSize32 firstVertex,
-  );
-  external JSVoid draw3(
-    GPUSize32 vertexCount,
+  ]);
+  external JSVoid draw(
+    GPUSize32 vertexCount, [
     GPUSize32 instanceCount,
     GPUSize32 firstVertex,
     GPUSize32 firstInstance,
-  );
-  external JSVoid drawIndexed(GPUSize32 indexCount);
-  external JSVoid drawIndexed1(
-    GPUSize32 indexCount,
-    GPUSize32 instanceCount,
-  );
-  external JSVoid drawIndexed2(
-    GPUSize32 indexCount,
-    GPUSize32 instanceCount,
-    GPUSize32 firstIndex,
-  );
-  external JSVoid drawIndexed3(
-    GPUSize32 indexCount,
-    GPUSize32 instanceCount,
-    GPUSize32 firstIndex,
-    GPUSignedOffset32 baseVertex,
-  );
-  external JSVoid drawIndexed4(
-    GPUSize32 indexCount,
+  ]);
+  external JSVoid drawIndexed(
+    GPUSize32 indexCount, [
     GPUSize32 instanceCount,
     GPUSize32 firstIndex,
     GPUSignedOffset32 baseVertex,
     GPUSize32 firstInstance,
-  );
+  ]);
   external JSVoid drawIndirect(
     GPUBuffer indirectBuffer,
     GPUSize64 indirectOffset,
@@ -1730,14 +1579,12 @@ extension GPURenderCommandsMixinExtension on GPURenderCommandsMixin {
 
 @JS('GPURenderBundle')
 @staticInterop
-class GPURenderBundle implements GPUObjectBase {
-  external factory GPURenderBundle();
-}
+class GPURenderBundle implements GPUObjectBase {}
 
 @JS()
 @staticInterop
 @anonymous
-class GPURenderBundleDescriptor extends GPUObjectDescriptorBase {
+class GPURenderBundleDescriptor implements GPUObjectDescriptorBase {
   external factory GPURenderBundleDescriptor();
 }
 
@@ -1749,19 +1596,16 @@ class GPURenderBundleEncoder
         GPUCommandsMixin,
         GPUDebugCommandsMixin,
         GPUBindingCommandsMixin,
-        GPURenderCommandsMixin {
-  external factory GPURenderBundleEncoder();
-}
+        GPURenderCommandsMixin {}
 
 extension GPURenderBundleEncoderExtension on GPURenderBundleEncoder {
-  external GPURenderBundle finish();
-  external GPURenderBundle finish1(GPURenderBundleDescriptor descriptor);
+  external GPURenderBundle finish([GPURenderBundleDescriptor descriptor]);
 }
 
 @JS()
 @staticInterop
 @anonymous
-class GPURenderBundleEncoderDescriptor extends GPURenderPassLayout {
+class GPURenderBundleEncoderDescriptor implements GPURenderPassLayout {
   external factory GPURenderBundleEncoderDescriptor({
     JSBoolean depthReadOnly = false,
     JSBoolean stencilReadOnly = false,
@@ -1779,15 +1623,13 @@ extension GPURenderBundleEncoderDescriptorExtension
 @JS()
 @staticInterop
 @anonymous
-class GPUQueueDescriptor extends GPUObjectDescriptorBase {
+class GPUQueueDescriptor implements GPUObjectDescriptorBase {
   external factory GPUQueueDescriptor();
 }
 
 @JS('GPUQueue')
 @staticInterop
-class GPUQueue implements GPUObjectBase {
-  external factory GPUQueue();
-}
+class GPUQueue implements GPUObjectBase {}
 
 extension GPUQueueExtension on GPUQueue {
   external JSVoid submit(JSArray commandBuffers);
@@ -1795,21 +1637,10 @@ extension GPUQueueExtension on GPUQueue {
   external JSVoid writeBuffer(
     GPUBuffer buffer,
     GPUSize64 bufferOffset,
-    BufferSource data,
-  );
-  external JSVoid writeBuffer1(
-    GPUBuffer buffer,
-    GPUSize64 bufferOffset,
-    BufferSource data,
-    GPUSize64 dataOffset,
-  );
-  external JSVoid writeBuffer2(
-    GPUBuffer buffer,
-    GPUSize64 bufferOffset,
-    BufferSource data,
+    BufferSource data, [
     GPUSize64 dataOffset,
     GPUSize64 size,
-  );
+  ]);
   external JSVoid writeTexture(
     GPUImageCopyTexture destination,
     BufferSource data,
@@ -1825,9 +1656,7 @@ extension GPUQueueExtension on GPUQueue {
 
 @JS('GPUQuerySet')
 @staticInterop
-class GPUQuerySet implements GPUObjectBase {
-  external factory GPUQuerySet();
-}
+class GPUQuerySet implements GPUObjectBase {}
 
 extension GPUQuerySetExtension on GPUQuerySet {
   external JSVoid destroy();
@@ -1838,7 +1667,7 @@ extension GPUQuerySetExtension on GPUQuerySet {
 @JS()
 @staticInterop
 @anonymous
-class GPUQuerySetDescriptor extends GPUObjectDescriptorBase {
+class GPUQuerySetDescriptor implements GPUObjectDescriptorBase {
   external factory GPUQuerySetDescriptor({
     required GPUQueryType type,
     required GPUSize32 count,
@@ -1854,15 +1683,13 @@ extension GPUQuerySetDescriptorExtension on GPUQuerySetDescriptor {
 
 @JS('GPUCanvasContext')
 @staticInterop
-class GPUCanvasContext {
-  external factory GPUCanvasContext();
-}
+class GPUCanvasContext {}
 
 extension GPUCanvasContextExtension on GPUCanvasContext {
-  external JSAny get canvas;
   external JSVoid configure(GPUCanvasConfiguration configuration);
   external JSVoid unconfigure();
   external GPUTexture getCurrentTexture();
+  external JSAny get canvas;
 }
 
 @JS()
@@ -1896,9 +1723,7 @@ extension GPUCanvasConfigurationExtension on GPUCanvasConfiguration {
 
 @JS('GPUDeviceLostInfo')
 @staticInterop
-class GPUDeviceLostInfo {
-  external factory GPUDeviceLostInfo();
-}
+class GPUDeviceLostInfo {}
 
 extension GPUDeviceLostInfoExtension on GPUDeviceLostInfo {
   external JSAny get reason;
@@ -1907,9 +1732,7 @@ extension GPUDeviceLostInfoExtension on GPUDeviceLostInfo {
 
 @JS('GPUError')
 @staticInterop
-class GPUError {
-  external factory GPUError();
-}
+class GPUError {}
 
 extension GPUErrorExtension on GPUError {
   external JSString get message;
@@ -1917,34 +1740,26 @@ extension GPUErrorExtension on GPUError {
 
 @JS('GPUValidationError')
 @staticInterop
-class GPUValidationError extends GPUError {
-  external factory GPUValidationError();
-
-  external factory GPUValidationError.a1(JSString message);
+class GPUValidationError implements GPUError {
+  external factory GPUValidationError(JSString message);
 }
 
 @JS('GPUOutOfMemoryError')
 @staticInterop
-class GPUOutOfMemoryError extends GPUError {
-  external factory GPUOutOfMemoryError();
-
-  external factory GPUOutOfMemoryError.a1(JSString message);
+class GPUOutOfMemoryError implements GPUError {
+  external factory GPUOutOfMemoryError(JSString message);
 }
 
 @JS('GPUInternalError')
 @staticInterop
-class GPUInternalError extends GPUError {
-  external factory GPUInternalError();
-
-  external factory GPUInternalError.a1(JSString message);
+class GPUInternalError implements GPUError {
+  external factory GPUInternalError(JSString message);
 }
 
 @JS('GPUUncapturedErrorEvent')
 @staticInterop
-class GPUUncapturedErrorEvent extends Event {
-  external factory GPUUncapturedErrorEvent();
-
-  external factory GPUUncapturedErrorEvent.a1(
+class GPUUncapturedErrorEvent implements Event {
+  external factory GPUUncapturedErrorEvent(
     JSString type,
     GPUUncapturedErrorEventInit gpuUncapturedErrorEventInitDict,
   );
@@ -1957,7 +1772,7 @@ extension GPUUncapturedErrorEventExtension on GPUUncapturedErrorEvent {
 @JS()
 @staticInterop
 @anonymous
-class GPUUncapturedErrorEventInit extends EventInit {
+class GPUUncapturedErrorEventInit implements EventInit {
   external factory GPUUncapturedErrorEventInit({required GPUError error});
 }
 

--- a/lib/src/dom/webhid.dart
+++ b/lib/src/dom/webhid.dart
@@ -16,17 +16,15 @@ typedef HIDUnitSystem = JSString;
 
 @JS('HID')
 @staticInterop
-class HID extends EventTarget {
-  external factory HID();
-}
+class HID implements EventTarget {}
 
 extension HIDExtension on HID {
+  external JSPromise getDevices();
+  external JSPromise requestDevice(HIDDeviceRequestOptions options);
   external set onconnect(EventHandler value);
   external EventHandler get onconnect;
   external set ondisconnect(EventHandler value);
   external EventHandler get ondisconnect;
-  external JSPromise getDevices();
-  external JSPromise requestDevice(HIDDeviceRequestOptions options);
 }
 
 @JS()
@@ -71,18 +69,9 @@ extension HIDDeviceFilterExtension on HIDDeviceFilter {
 
 @JS('HIDDevice')
 @staticInterop
-class HIDDevice extends EventTarget {
-  external factory HIDDevice();
-}
+class HIDDevice implements EventTarget {}
 
 extension HIDDeviceExtension on HIDDevice {
-  external set oninputreport(EventHandler value);
-  external EventHandler get oninputreport;
-  external JSBoolean get opened;
-  external JSNumber get vendorId;
-  external JSNumber get productId;
-  external JSString get productName;
-  external JSArray get collections;
   external JSPromise open();
   external JSPromise close();
   external JSPromise forget();
@@ -95,14 +84,19 @@ extension HIDDeviceExtension on HIDDevice {
     BufferSource data,
   );
   external JSPromise receiveFeatureReport(JSNumber reportId);
+  external set oninputreport(EventHandler value);
+  external EventHandler get oninputreport;
+  external JSBoolean get opened;
+  external JSNumber get vendorId;
+  external JSNumber get productId;
+  external JSString get productName;
+  external JSArray get collections;
 }
 
 @JS('HIDConnectionEvent')
 @staticInterop
-class HIDConnectionEvent extends Event {
-  external factory HIDConnectionEvent();
-
-  external factory HIDConnectionEvent.a1(
+class HIDConnectionEvent implements Event {
+  external factory HIDConnectionEvent(
     JSString type,
     HIDConnectionEventInit eventInitDict,
   );
@@ -115,7 +109,7 @@ extension HIDConnectionEventExtension on HIDConnectionEvent {
 @JS()
 @staticInterop
 @anonymous
-class HIDConnectionEventInit extends EventInit {
+class HIDConnectionEventInit implements EventInit {
   external factory HIDConnectionEventInit({required HIDDevice device});
 }
 
@@ -126,10 +120,8 @@ extension HIDConnectionEventInitExtension on HIDConnectionEventInit {
 
 @JS('HIDInputReportEvent')
 @staticInterop
-class HIDInputReportEvent extends Event {
-  external factory HIDInputReportEvent();
-
-  external factory HIDInputReportEvent.a1(
+class HIDInputReportEvent implements Event {
+  external factory HIDInputReportEvent(
     JSString type,
     HIDInputReportEventInit eventInitDict,
   );
@@ -144,7 +136,7 @@ extension HIDInputReportEventExtension on HIDInputReportEvent {
 @JS()
 @staticInterop
 @anonymous
-class HIDInputReportEventInit extends EventInit {
+class HIDInputReportEventInit implements EventInit {
   external factory HIDInputReportEventInit({
     required HIDDevice device,
     required JSNumber reportId,

--- a/lib/src/dom/webidl.dart
+++ b/lib/src/dom/webidl.dart
@@ -16,16 +16,10 @@ typedef VoidFunction = JSFunction;
 @JS('DOMException')
 @staticInterop
 class DOMException {
-  external factory DOMException();
-
-  external factory DOMException.a1();
-
-  external factory DOMException.a2(JSString message);
-
-  external factory DOMException.a3(
+  external factory DOMException([
     JSString message,
     JSString name,
-  );
+  ]);
 
   external static JSNumber get INDEX_SIZE_ERR;
   external static JSNumber get DOMSTRING_SIZE_ERR;

--- a/lib/src/dom/webmidi.dart
+++ b/lib/src/dom/webmidi.dart
@@ -20,7 +20,7 @@ typedef MIDIPortConnectionState = JSString;
 @JS()
 @staticInterop
 @anonymous
-class MidiPermissionDescriptor extends PermissionDescriptor {
+class MidiPermissionDescriptor implements PermissionDescriptor {
   external factory MidiPermissionDescriptor({JSBoolean sysex = false});
 }
 
@@ -48,25 +48,19 @@ extension MIDIOptionsExtension on MIDIOptions {
 
 @JS('MIDIInputMap')
 @staticInterop
-class MIDIInputMap {
-  external factory MIDIInputMap();
-}
+class MIDIInputMap {}
 
 extension MIDIInputMapExtension on MIDIInputMap {}
 
 @JS('MIDIOutputMap')
 @staticInterop
-class MIDIOutputMap {
-  external factory MIDIOutputMap();
-}
+class MIDIOutputMap {}
 
 extension MIDIOutputMapExtension on MIDIOutputMap {}
 
 @JS('MIDIAccess')
 @staticInterop
-class MIDIAccess extends EventTarget {
-  external factory MIDIAccess();
-}
+class MIDIAccess implements EventTarget {}
 
 extension MIDIAccessExtension on MIDIAccess {
   external MIDIInputMap get inputs;
@@ -78,11 +72,11 @@ extension MIDIAccessExtension on MIDIAccess {
 
 @JS('MIDIPort')
 @staticInterop
-class MIDIPort extends EventTarget {
-  external factory MIDIPort();
-}
+class MIDIPort implements EventTarget {}
 
 extension MIDIPortExtension on MIDIPort {
+  external JSPromise open();
+  external JSPromise close();
   external JSString get id;
   external JSString? get manufacturer;
   external JSString? get name;
@@ -92,15 +86,11 @@ extension MIDIPortExtension on MIDIPort {
   external MIDIPortConnectionState get connection;
   external set onstatechange(EventHandler value);
   external EventHandler get onstatechange;
-  external JSPromise open();
-  external JSPromise close();
 }
 
 @JS('MIDIInput')
 @staticInterop
-class MIDIInput extends MIDIPort {
-  external factory MIDIInput();
-}
+class MIDIInput implements MIDIPort {}
 
 extension MIDIInputExtension on MIDIInput {
   external set onmidimessage(EventHandler value);
@@ -109,30 +99,23 @@ extension MIDIInputExtension on MIDIInput {
 
 @JS('MIDIOutput')
 @staticInterop
-class MIDIOutput extends MIDIPort {
-  external factory MIDIOutput();
-}
+class MIDIOutput implements MIDIPort {}
 
 extension MIDIOutputExtension on MIDIOutput {
-  external JSVoid send(JSArray data);
-  external JSVoid send1(
-    JSArray data,
+  external JSVoid send(
+    JSArray data, [
     DOMHighResTimeStamp timestamp,
-  );
+  ]);
   external JSVoid clear();
 }
 
 @JS('MIDIMessageEvent')
 @staticInterop
-class MIDIMessageEvent extends Event {
-  external factory MIDIMessageEvent();
-
-  external factory MIDIMessageEvent.a1(JSString type);
-
-  external factory MIDIMessageEvent.a2(
-    JSString type,
+class MIDIMessageEvent implements Event {
+  external factory MIDIMessageEvent(
+    JSString type, [
     MIDIMessageEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension MIDIMessageEventExtension on MIDIMessageEvent {
@@ -142,7 +125,7 @@ extension MIDIMessageEventExtension on MIDIMessageEvent {
 @JS()
 @staticInterop
 @anonymous
-class MIDIMessageEventInit extends EventInit {
+class MIDIMessageEventInit implements EventInit {
   external factory MIDIMessageEventInit({JSUint8Array data});
 }
 
@@ -153,15 +136,11 @@ extension MIDIMessageEventInitExtension on MIDIMessageEventInit {
 
 @JS('MIDIConnectionEvent')
 @staticInterop
-class MIDIConnectionEvent extends Event {
-  external factory MIDIConnectionEvent();
-
-  external factory MIDIConnectionEvent.a1(JSString type);
-
-  external factory MIDIConnectionEvent.a2(
-    JSString type,
+class MIDIConnectionEvent implements Event {
+  external factory MIDIConnectionEvent(
+    JSString type, [
     MIDIConnectionEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension MIDIConnectionEventExtension on MIDIConnectionEvent {
@@ -171,7 +150,7 @@ extension MIDIConnectionEventExtension on MIDIConnectionEvent {
 @JS()
 @staticInterop
 @anonymous
-class MIDIConnectionEventInit extends EventInit {
+class MIDIConnectionEventInit implements EventInit {
   external factory MIDIConnectionEventInit({MIDIPort port});
 }
 

--- a/lib/src/dom/webnn.dart
+++ b/lib/src/dom/webnn.dart
@@ -31,9 +31,7 @@ typedef MLInterpolationMode = JSString;
 
 @JS('NavigatorML')
 @staticInterop
-class NavigatorML {
-  external factory NavigatorML();
-}
+class NavigatorML {}
 
 extension NavigatorMLExtension on NavigatorML {
   external ML get ml;
@@ -58,26 +56,16 @@ extension MLContextOptionsExtension on MLContextOptions {
 
 @JS('ML')
 @staticInterop
-class ML {
-  external factory ML();
-}
+class ML {}
 
 extension MLExtension on ML {
-  external JSPromise createContext();
-  external JSPromise createContext1(MLContextOptions options);
-  @JS('createContext')
-  external JSPromise createContext_1_(GPUDevice gpuDevice);
-  external MLContext createContextSync();
-  external MLContext createContextSync1(MLContextOptions options);
-  @JS('createContextSync')
-  external MLContext createContextSync_1_(GPUDevice gpuDevice);
+  external JSPromise createContext([JSAny gpuDeviceOrOptions]);
+  external MLContext createContextSync([JSAny gpuDeviceOrOptions]);
 }
 
 @JS('MLGraph')
 @staticInterop
-class MLGraph {
-  external factory MLGraph();
-}
+class MLGraph {}
 
 @JS()
 @staticInterop
@@ -98,21 +86,15 @@ extension MLOperandDescriptorExtension on MLOperandDescriptor {
 
 @JS('MLOperand')
 @staticInterop
-class MLOperand {
-  external factory MLOperand();
-}
+class MLOperand {}
 
 @JS('MLActivation')
 @staticInterop
-class MLActivation {
-  external factory MLActivation();
-}
+class MLActivation {}
 
 @JS('MLContext')
 @staticInterop
-class MLContext {
-  external factory MLContext();
-}
+class MLContext {}
 
 extension MLContextExtension on MLContext {
   external JSVoid computeSync(
@@ -147,9 +129,7 @@ extension MLComputeResultExtension on MLComputeResult {
 
 @JS('MLCommandEncoder')
 @staticInterop
-class MLCommandEncoder {
-  external factory MLCommandEncoder();
-}
+class MLCommandEncoder {}
 
 extension MLCommandEncoderExtension on MLCommandEncoder {
   external JSVoid initializeGraph(MLGraph graph);
@@ -158,8 +138,7 @@ extension MLCommandEncoderExtension on MLCommandEncoder {
     MLNamedGPUResources inputs,
     MLNamedGPUResources outputs,
   );
-  external GPUCommandBuffer finish();
-  external GPUCommandBuffer finish1(GPUCommandBufferDescriptor descriptor);
+  external GPUCommandBuffer finish([GPUCommandBufferDescriptor descriptor]);
 }
 
 @JS()
@@ -185,9 +164,7 @@ extension MLBufferResourceViewExtension on MLBufferResourceView {
 @JS('MLGraphBuilder')
 @staticInterop
 class MLGraphBuilder {
-  external factory MLGraphBuilder();
-
-  external factory MLGraphBuilder.a1(MLContext context);
+  external factory MLGraphBuilder(MLContext context);
 }
 
 extension MLGraphBuilderExtension on MLGraphBuilder {
@@ -196,60 +173,35 @@ extension MLGraphBuilderExtension on MLGraphBuilder {
     MLOperandDescriptor desc,
   );
   external MLOperand constant(
-    MLOperandDescriptor desc,
-    MLBufferView bufferView,
-  );
-  @JS('constant')
-  external MLOperand constant_1_(JSNumber value);
-  @JS('constant')
-  external MLOperand constant_1_1(
-    JSNumber value,
-    MLOperandType type,
-  );
+    JSAny descOrValue, [
+    JSAny bufferViewOrType,
+  ]);
   external JSPromise build(MLNamedOperands outputs);
   external MLGraph buildSync(MLNamedOperands outputs);
   external MLOperand batchNormalization(
     MLOperand input,
     MLOperand mean,
-    MLOperand variance,
-  );
-  external MLOperand batchNormalization1(
-    MLOperand input,
-    MLOperand mean,
-    MLOperand variance,
+    MLOperand variance, [
     MLBatchNormalizationOptions options,
-  );
-  external MLOperand clamp(MLOperand x);
-  external MLOperand clamp1(
-    MLOperand x,
+  ]);
+  external JSAny clamp([
+    JSAny optionsOrX,
     MLClampOptions options,
-  );
-  @JS('clamp')
-  external MLActivation clamp_1_();
-  @JS('clamp')
-  external MLActivation clamp_1_1(MLClampOptions options);
+  ]);
   external MLOperand concat(
     JSArray inputs,
     JSNumber axis,
   );
   external MLOperand conv2d(
     MLOperand input,
-    MLOperand filter,
-  );
-  external MLOperand conv2d1(
-    MLOperand input,
-    MLOperand filter,
+    MLOperand filter, [
     MLConv2dOptions options,
-  );
+  ]);
   external MLOperand convTranspose2d(
     MLOperand input,
-    MLOperand filter,
-  );
-  external MLOperand convTranspose2d1(
-    MLOperand input,
-    MLOperand filter,
+    MLOperand filter, [
     MLConvTranspose2dOptions options,
-  );
+  ]);
   external MLOperand add(
     MLOperand a,
     MLOperand b,
@@ -287,262 +239,162 @@ extension MLGraphBuilderExtension on MLGraphBuilder {
   external MLOperand neg(MLOperand x);
   external MLOperand sin(MLOperand x);
   external MLOperand tan(MLOperand x);
-  external MLOperand elu(MLOperand x);
-  external MLOperand elu1(
-    MLOperand x,
+  external JSAny elu([
+    JSAny optionsOrX,
     MLEluOptions options,
-  );
-  @JS('elu')
-  external MLActivation elu_1_();
-  @JS('elu')
-  external MLActivation elu_1_1(MLEluOptions options);
+  ]);
   external MLOperand gemm(
     MLOperand a,
-    MLOperand b,
-  );
-  external MLOperand gemm1(
-    MLOperand a,
-    MLOperand b,
+    MLOperand b, [
     MLGemmOptions options,
-  );
+  ]);
   external JSArray gru(
     MLOperand input,
     MLOperand weight,
     MLOperand recurrentWeight,
     JSNumber steps,
-    JSNumber hiddenSize,
-  );
-  external JSArray gru1(
-    MLOperand input,
-    MLOperand weight,
-    MLOperand recurrentWeight,
-    JSNumber steps,
-    JSNumber hiddenSize,
+    JSNumber hiddenSize, [
     MLGruOptions options,
-  );
+  ]);
   external MLOperand gruCell(
     MLOperand input,
     MLOperand weight,
     MLOperand recurrentWeight,
     MLOperand hiddenState,
-    JSNumber hiddenSize,
-  );
-  external MLOperand gruCell1(
-    MLOperand input,
-    MLOperand weight,
-    MLOperand recurrentWeight,
-    MLOperand hiddenState,
-    JSNumber hiddenSize,
+    JSNumber hiddenSize, [
     MLGruCellOptions options,
-  );
-  external MLOperand hardSigmoid(MLOperand x);
-  external MLOperand hardSigmoid1(
-    MLOperand x,
+  ]);
+  external JSAny hardSigmoid([
+    JSAny optionsOrX,
     MLHardSigmoidOptions options,
-  );
-  @JS('hardSigmoid')
-  external MLActivation hardSigmoid_1_();
-  @JS('hardSigmoid')
-  external MLActivation hardSigmoid_1_1(MLHardSigmoidOptions options);
-  external MLOperand hardSwish(MLOperand x);
-  @JS('hardSwish')
-  external MLActivation hardSwish_1_();
-  external MLOperand instanceNormalization(MLOperand input);
-  external MLOperand instanceNormalization1(
-    MLOperand input,
+  ]);
+  external JSAny hardSwish([MLOperand x]);
+  external MLOperand instanceNormalization(
+    MLOperand input, [
     MLInstanceNormalizationOptions options,
-  );
-  external MLOperand leakyRelu(MLOperand x);
-  external MLOperand leakyRelu1(
-    MLOperand x,
+  ]);
+  external JSAny leakyRelu([
+    JSAny optionsOrX,
     MLLeakyReluOptions options,
-  );
-  @JS('leakyRelu')
-  external MLActivation leakyRelu_1_();
-  @JS('leakyRelu')
-  external MLActivation leakyRelu_1_1(MLLeakyReluOptions options);
-  external MLOperand linear(MLOperand x);
-  external MLOperand linear1(
-    MLOperand x,
+  ]);
+  external JSAny linear([
+    JSAny optionsOrX,
     MLLinearOptions options,
-  );
-  @JS('linear')
-  external MLActivation linear_1_();
-  @JS('linear')
-  external MLActivation linear_1_1(MLLinearOptions options);
+  ]);
   external JSArray lstm(
     MLOperand input,
     MLOperand weight,
     MLOperand recurrentWeight,
     JSNumber steps,
-    JSNumber hiddenSize,
-  );
-  external JSArray lstm1(
-    MLOperand input,
-    MLOperand weight,
-    MLOperand recurrentWeight,
-    JSNumber steps,
-    JSNumber hiddenSize,
+    JSNumber hiddenSize, [
     MLLstmOptions options,
-  );
+  ]);
   external JSArray lstmCell(
     MLOperand input,
     MLOperand weight,
     MLOperand recurrentWeight,
     MLOperand hiddenState,
     MLOperand cellState,
-    JSNumber hiddenSize,
-  );
-  external JSArray lstmCell1(
-    MLOperand input,
-    MLOperand weight,
-    MLOperand recurrentWeight,
-    MLOperand hiddenState,
-    MLOperand cellState,
-    JSNumber hiddenSize,
+    JSNumber hiddenSize, [
     MLLstmCellOptions options,
-  );
+  ]);
   external MLOperand matmul(
     MLOperand a,
     MLOperand b,
   );
   external MLOperand pad(
     MLOperand input,
-    MLOperand padding,
-  );
-  external MLOperand pad1(
-    MLOperand input,
-    MLOperand padding,
+    MLOperand padding, [
     MLPadOptions options,
-  );
-  external MLOperand averagePool2d(MLOperand input);
-  external MLOperand averagePool2d1(
-    MLOperand input,
+  ]);
+  external MLOperand averagePool2d(
+    MLOperand input, [
     MLPool2dOptions options,
-  );
-  external MLOperand l2Pool2d(MLOperand input);
-  external MLOperand l2Pool2d1(
-    MLOperand input,
+  ]);
+  external MLOperand l2Pool2d(
+    MLOperand input, [
     MLPool2dOptions options,
-  );
-  external MLOperand maxPool2d(MLOperand input);
-  external MLOperand maxPool2d1(
-    MLOperand input,
+  ]);
+  external MLOperand maxPool2d(
+    MLOperand input, [
     MLPool2dOptions options,
-  );
-  external MLOperand reduceL1(MLOperand input);
-  external MLOperand reduceL11(
-    MLOperand input,
+  ]);
+  external MLOperand reduceL1(
+    MLOperand input, [
     MLReduceOptions options,
-  );
-  external MLOperand reduceL2(MLOperand input);
-  external MLOperand reduceL21(
-    MLOperand input,
+  ]);
+  external MLOperand reduceL2(
+    MLOperand input, [
     MLReduceOptions options,
-  );
-  external MLOperand reduceLogSum(MLOperand input);
-  external MLOperand reduceLogSum1(
-    MLOperand input,
+  ]);
+  external MLOperand reduceLogSum(
+    MLOperand input, [
     MLReduceOptions options,
-  );
-  external MLOperand reduceLogSumExp(MLOperand input);
-  external MLOperand reduceLogSumExp1(
-    MLOperand input,
+  ]);
+  external MLOperand reduceLogSumExp(
+    MLOperand input, [
     MLReduceOptions options,
-  );
-  external MLOperand reduceMax(MLOperand input);
-  external MLOperand reduceMax1(
-    MLOperand input,
+  ]);
+  external MLOperand reduceMax(
+    MLOperand input, [
     MLReduceOptions options,
-  );
-  external MLOperand reduceMean(MLOperand input);
-  external MLOperand reduceMean1(
-    MLOperand input,
+  ]);
+  external MLOperand reduceMean(
+    MLOperand input, [
     MLReduceOptions options,
-  );
-  external MLOperand reduceMin(MLOperand input);
-  external MLOperand reduceMin1(
-    MLOperand input,
+  ]);
+  external MLOperand reduceMin(
+    MLOperand input, [
     MLReduceOptions options,
-  );
-  external MLOperand reduceProduct(MLOperand input);
-  external MLOperand reduceProduct1(
-    MLOperand input,
+  ]);
+  external MLOperand reduceProduct(
+    MLOperand input, [
     MLReduceOptions options,
-  );
-  external MLOperand reduceSum(MLOperand input);
-  external MLOperand reduceSum1(
-    MLOperand input,
+  ]);
+  external MLOperand reduceSum(
+    MLOperand input, [
     MLReduceOptions options,
-  );
-  external MLOperand reduceSumSquare(MLOperand input);
-  external MLOperand reduceSumSquare1(
-    MLOperand input,
+  ]);
+  external MLOperand reduceSumSquare(
+    MLOperand input, [
     MLReduceOptions options,
-  );
-  external MLOperand relu(MLOperand x);
-  @JS('relu')
-  external MLActivation relu_1_();
-  external MLOperand resample2d(MLOperand input);
-  external MLOperand resample2d1(
-    MLOperand input,
+  ]);
+  external JSAny relu([MLOperand x]);
+  external MLOperand resample2d(
+    MLOperand input, [
     MLResample2dOptions options,
-  );
+  ]);
   external MLOperand reshape(
     MLOperand input,
     JSArray newShape,
   );
-  external MLOperand sigmoid(MLOperand x);
-  @JS('sigmoid')
-  external MLActivation sigmoid_1_();
+  external JSAny sigmoid([MLOperand x]);
   external MLOperand slice(
     MLOperand input,
     JSArray starts,
-    JSArray sizes,
-  );
-  external MLOperand slice1(
-    MLOperand input,
-    JSArray starts,
-    JSArray sizes,
+    JSArray sizes, [
     MLSliceOptions options,
-  );
-  external MLOperand softmax(MLOperand x);
-  @JS('softmax')
-  external MLActivation softmax_1_();
-  external MLOperand softplus(MLOperand x);
-  external MLOperand softplus1(
-    MLOperand x,
+  ]);
+  external JSAny softmax([MLOperand x]);
+  external JSAny softplus([
+    JSAny optionsOrX,
     MLSoftplusOptions options,
-  );
-  @JS('softplus')
-  external MLActivation softplus_1_();
-  @JS('softplus')
-  external MLActivation softplus_1_1(MLSoftplusOptions options);
-  external MLOperand softsign(MLOperand x);
-  @JS('softsign')
-  external MLActivation softsign_1_();
+  ]);
+  external JSAny softsign([MLOperand x]);
   external JSArray split(
     MLOperand input,
-    JSAny splits,
-  );
-  external JSArray split1(
-    MLOperand input,
-    JSAny splits,
+    JSAny splits, [
     MLSplitOptions options,
-  );
-  external MLOperand squeeze(MLOperand input);
-  external MLOperand squeeze1(
-    MLOperand input,
+  ]);
+  external MLOperand squeeze(
+    MLOperand input, [
     MLSqueezeOptions options,
-  );
-  external MLOperand tanh(MLOperand x);
-  @JS('tanh')
-  external MLActivation tanh_1_();
-  external MLOperand transpose(MLOperand input);
-  external MLOperand transpose1(
-    MLOperand input,
+  ]);
+  external JSAny tanh([MLOperand x]);
+  external MLOperand transpose(
+    MLOperand input, [
     MLTransposeOptions options,
-  );
+  ]);
 }
 
 @JS()

--- a/lib/src/dom/webrtc.dart
+++ b/lib/src/dom/webrtc.dart
@@ -9,7 +9,6 @@ import 'dart:js_interop';
 import 'package:js/js.dart' hide JS;
 
 import 'dom.dart';
-import 'fileapi.dart';
 import 'hr_time.dart';
 import 'html.dart';
 import 'mediacapture_streams.dart';
@@ -109,7 +108,7 @@ class RTCOfferAnswerOptions {
 @JS()
 @staticInterop
 @anonymous
-class RTCOfferOptions extends RTCOfferAnswerOptions {
+class RTCOfferOptions implements RTCOfferAnswerOptions {
   external factory RTCOfferOptions({
     JSBoolean iceRestart = false,
     JSBoolean offerToReceiveAudio,
@@ -129,60 +128,84 @@ extension RTCOfferOptionsExtension on RTCOfferOptions {
 @JS()
 @staticInterop
 @anonymous
-class RTCAnswerOptions extends RTCOfferAnswerOptions {
+class RTCAnswerOptions implements RTCOfferAnswerOptions {
   external factory RTCAnswerOptions();
 }
 
 @JS('RTCPeerConnection')
 @staticInterop
-class RTCPeerConnection extends EventTarget {
-  external factory RTCPeerConnection();
-
-  external factory RTCPeerConnection.a1();
-
-  external factory RTCPeerConnection.a2(RTCConfiguration configuration);
+class RTCPeerConnection implements EventTarget {
+  external factory RTCPeerConnection([RTCConfiguration configuration]);
 
   external static JSPromise generateCertificate(
       AlgorithmIdentifier keygenAlgorithm);
 }
 
 extension RTCPeerConnectionExtension on RTCPeerConnection {
-  external JSVoid setIdentityProvider(JSString provider);
-  external JSVoid setIdentityProvider1(
-    JSString provider,
+  external JSVoid setIdentityProvider(
+    JSString provider, [
     RTCIdentityProviderOptions options,
-  );
+  ]);
   external JSPromise getIdentityAssertion();
+  external JSPromise createOffer([
+    JSAny optionsOrSuccessCallback,
+    RTCPeerConnectionErrorCallback failureCallback,
+    RTCOfferOptions options,
+  ]);
+  external JSPromise createAnswer([
+    JSAny optionsOrSuccessCallback,
+    RTCPeerConnectionErrorCallback failureCallback,
+  ]);
+  external JSPromise setLocalDescription([
+    RTCLocalSessionDescriptionInit description,
+    VoidFunction successCallback,
+    RTCPeerConnectionErrorCallback failureCallback,
+  ]);
+  external JSPromise setRemoteDescription(
+    RTCSessionDescriptionInit description, [
+    VoidFunction successCallback,
+    RTCPeerConnectionErrorCallback failureCallback,
+  ]);
+  external JSPromise addIceCandidate([
+    RTCIceCandidateInit candidate,
+    VoidFunction successCallback,
+    RTCPeerConnectionErrorCallback failureCallback,
+  ]);
+  external JSVoid restartIce();
+  external RTCConfiguration getConfiguration();
+  external JSVoid setConfiguration([RTCConfiguration configuration]);
+  external JSVoid close();
+  external JSArray getSenders();
+  external JSArray getReceivers();
+  external JSArray getTransceivers();
+  external RTCRtpSender addTrack(
+    MediaStreamTrack track,
+    MediaStream streams,
+  );
+  external JSVoid removeTrack(RTCRtpSender sender);
+  external RTCRtpTransceiver addTransceiver(
+    JSAny trackOrKind, [
+    RTCRtpTransceiverInit init,
+  ]);
+  external RTCDataChannel createDataChannel(
+    JSString label, [
+    RTCDataChannelInit dataChannelDict,
+  ]);
+  external JSPromise getStats([MediaStreamTrack? selector]);
   external JSPromise get peerIdentity;
   external JSString? get idpLoginUrl;
   external JSString? get idpErrorInfo;
-  external JSPromise createOffer();
-  external JSPromise createOffer1(RTCOfferOptions options);
-  external JSPromise createAnswer();
-  external JSPromise createAnswer1(RTCAnswerOptions options);
-  external JSPromise setLocalDescription();
-  external JSPromise setLocalDescription1(
-      RTCLocalSessionDescriptionInit description);
   external RTCSessionDescription? get localDescription;
   external RTCSessionDescription? get currentLocalDescription;
   external RTCSessionDescription? get pendingLocalDescription;
-  external JSPromise setRemoteDescription(
-      RTCSessionDescriptionInit description);
   external RTCSessionDescription? get remoteDescription;
   external RTCSessionDescription? get currentRemoteDescription;
   external RTCSessionDescription? get pendingRemoteDescription;
-  external JSPromise addIceCandidate();
-  external JSPromise addIceCandidate1(RTCIceCandidateInit candidate);
   external RTCSignalingState get signalingState;
   external RTCIceGatheringState get iceGatheringState;
   external RTCIceConnectionState get iceConnectionState;
   external RTCPeerConnectionState get connectionState;
   external JSBoolean? get canTrickleIceCandidates;
-  external JSVoid restartIce();
-  external RTCConfiguration getConfiguration();
-  external JSVoid setConfiguration();
-  external JSVoid setConfiguration1(RTCConfiguration configuration);
-  external JSVoid close();
   external set onnegotiationneeded(EventHandler value);
   external EventHandler get onnegotiationneeded;
   external set onicecandidate(EventHandler value);
@@ -197,80 +220,24 @@ extension RTCPeerConnectionExtension on RTCPeerConnection {
   external EventHandler get onicegatheringstatechange;
   external set onconnectionstatechange(EventHandler value);
   external EventHandler get onconnectionstatechange;
-  @JS('createOffer')
-  external JSPromise createOffer_1_(
-    RTCSessionDescriptionCallback successCallback,
-    RTCPeerConnectionErrorCallback failureCallback,
-  );
-  @JS('createOffer')
-  external JSPromise createOffer_1_1(
-    RTCSessionDescriptionCallback successCallback,
-    RTCPeerConnectionErrorCallback failureCallback,
-    RTCOfferOptions options,
-  );
-  @JS('setLocalDescription')
-  external JSPromise setLocalDescription_1_(
-    RTCLocalSessionDescriptionInit description,
-    VoidFunction successCallback,
-    RTCPeerConnectionErrorCallback failureCallback,
-  );
-  @JS('createAnswer')
-  external JSPromise createAnswer_1_(
-    RTCSessionDescriptionCallback successCallback,
-    RTCPeerConnectionErrorCallback failureCallback,
-  );
-  @JS('setRemoteDescription')
-  external JSPromise setRemoteDescription_1_(
-    RTCSessionDescriptionInit description,
-    VoidFunction successCallback,
-    RTCPeerConnectionErrorCallback failureCallback,
-  );
-  @JS('addIceCandidate')
-  external JSPromise addIceCandidate_1_(
-    RTCIceCandidateInit candidate,
-    VoidFunction successCallback,
-    RTCPeerConnectionErrorCallback failureCallback,
-  );
-  external JSArray getSenders();
-  external JSArray getReceivers();
-  external JSArray getTransceivers();
-  external RTCRtpSender addTrack(
-    MediaStreamTrack track,
-    MediaStream streams,
-  );
-  external JSVoid removeTrack(RTCRtpSender sender);
-  external RTCRtpTransceiver addTransceiver(JSAny trackOrKind);
-  external RTCRtpTransceiver addTransceiver1(
-    JSAny trackOrKind,
-    RTCRtpTransceiverInit init,
-  );
   external set ontrack(EventHandler value);
   external EventHandler get ontrack;
   external RTCSctpTransport? get sctp;
-  external RTCDataChannel createDataChannel(JSString label);
-  external RTCDataChannel createDataChannel1(
-    JSString label,
-    RTCDataChannelInit dataChannelDict,
-  );
   external set ondatachannel(EventHandler value);
   external EventHandler get ondatachannel;
-  external JSPromise getStats();
-  external JSPromise getStats1(MediaStreamTrack? selector);
 }
 
 @JS('RTCSessionDescription')
 @staticInterop
 class RTCSessionDescription {
-  external factory RTCSessionDescription();
-
-  external factory RTCSessionDescription.a1(
+  external factory RTCSessionDescription(
       RTCSessionDescriptionInit descriptionInitDict);
 }
 
 extension RTCSessionDescriptionExtension on RTCSessionDescription {
+  external JSObject toJSON();
   external RTCSdpType get type;
   external JSString get sdp;
-  external JSObject toJSON();
 }
 
 @JS()
@@ -311,14 +278,11 @@ extension RTCLocalSessionDescriptionInitExtension
 @JS('RTCIceCandidate')
 @staticInterop
 class RTCIceCandidate {
-  external factory RTCIceCandidate();
-
-  external factory RTCIceCandidate.a1();
-
-  external factory RTCIceCandidate.a2(RTCIceCandidateInit candidateInitDict);
+  external factory RTCIceCandidate([RTCIceCandidateInit candidateInitDict]);
 }
 
 extension RTCIceCandidateExtension on RTCIceCandidate {
+  external RTCIceCandidateInit toJSON();
   external JSString get candidate;
   external JSString? get sdpMid;
   external JSNumber? get sdpMLineIndex;
@@ -335,7 +299,6 @@ extension RTCIceCandidateExtension on RTCIceCandidate {
   external JSString? get usernameFragment;
   external RTCIceServerTransportProtocol? get relayProtocol;
   external JSString? get url;
-  external RTCIceCandidateInit toJSON();
 }
 
 @JS()
@@ -363,15 +326,11 @@ extension RTCIceCandidateInitExtension on RTCIceCandidateInit {
 
 @JS('RTCPeerConnectionIceEvent')
 @staticInterop
-class RTCPeerConnectionIceEvent extends Event {
-  external factory RTCPeerConnectionIceEvent();
-
-  external factory RTCPeerConnectionIceEvent.a1(JSString type);
-
-  external factory RTCPeerConnectionIceEvent.a2(
-    JSString type,
+class RTCPeerConnectionIceEvent implements Event {
+  external factory RTCPeerConnectionIceEvent(
+    JSString type, [
     RTCPeerConnectionIceEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension RTCPeerConnectionIceEventExtension on RTCPeerConnectionIceEvent {
@@ -382,7 +341,7 @@ extension RTCPeerConnectionIceEventExtension on RTCPeerConnectionIceEvent {
 @JS()
 @staticInterop
 @anonymous
-class RTCPeerConnectionIceEventInit extends EventInit {
+class RTCPeerConnectionIceEventInit implements EventInit {
   external factory RTCPeerConnectionIceEventInit({
     RTCIceCandidate? candidate,
     JSString? url,
@@ -399,10 +358,8 @@ extension RTCPeerConnectionIceEventInitExtension
 
 @JS('RTCPeerConnectionIceErrorEvent')
 @staticInterop
-class RTCPeerConnectionIceErrorEvent extends Event {
-  external factory RTCPeerConnectionIceErrorEvent();
-
-  external factory RTCPeerConnectionIceErrorEvent.a1(
+class RTCPeerConnectionIceErrorEvent implements Event {
+  external factory RTCPeerConnectionIceErrorEvent(
     JSString type,
     RTCPeerConnectionIceErrorEventInit eventInitDict,
   );
@@ -420,7 +377,7 @@ extension RTCPeerConnectionIceErrorEventExtension
 @JS()
 @staticInterop
 @anonymous
-class RTCPeerConnectionIceErrorEventInit extends EventInit {
+class RTCPeerConnectionIceErrorEventInit implements EventInit {
   external factory RTCPeerConnectionIceErrorEventInit({
     JSString? address,
     JSNumber? port,
@@ -458,13 +415,11 @@ extension RTCCertificateExpirationExtension on RTCCertificateExpiration {
 
 @JS('RTCCertificate')
 @staticInterop
-class RTCCertificate {
-  external factory RTCCertificate();
-}
+class RTCCertificate {}
 
 extension RTCCertificateExtension on RTCCertificate {
-  external EpochTimeStamp get expires;
   external JSArray getFingerprints();
+  external EpochTimeStamp get expires;
 }
 
 @JS()
@@ -490,23 +445,20 @@ extension RTCRtpTransceiverInitExtension on RTCRtpTransceiverInit {
 @JS('RTCRtpSender')
 @staticInterop
 class RTCRtpSender {
-  external factory RTCRtpSender();
-
   external static RTCRtpCapabilities? getCapabilities(JSString kind);
 }
 
 extension RTCRtpSenderExtension on RTCRtpSender {
-  external set transform(RTCRtpTransform? value);
-  external RTCRtpTransform? get transform;
-  external JSPromise generateKeyFrame();
-  external JSPromise generateKeyFrame1(JSArray rids);
-  external MediaStreamTrack? get track;
-  external RTCDtlsTransport? get transport;
+  external JSPromise generateKeyFrame([JSArray rids]);
   external JSPromise setParameters(RTCRtpSendParameters parameters);
   external RTCRtpSendParameters getParameters();
   external JSPromise replaceTrack(MediaStreamTrack? withTrack);
   external JSVoid setStreams(MediaStream streams);
   external JSPromise getStats();
+  external set transform(RTCRtpTransform? value);
+  external RTCRtpTransform? get transform;
+  external MediaStreamTrack? get track;
+  external RTCDtlsTransport? get transport;
   external RTCDTMFSender? get dtmf;
 }
 
@@ -533,7 +485,7 @@ extension RTCRtpParametersExtension on RTCRtpParameters {
 @JS()
 @staticInterop
 @anonymous
-class RTCRtpSendParameters extends RTCRtpParameters {
+class RTCRtpSendParameters implements RTCRtpParameters {
   external factory RTCRtpSendParameters({
     RTCDegradationPreference degradationPreference,
     required JSString transactionId,
@@ -553,7 +505,7 @@ extension RTCRtpSendParametersExtension on RTCRtpSendParameters {
 @JS()
 @staticInterop
 @anonymous
-class RTCRtpReceiveParameters extends RTCRtpParameters {
+class RTCRtpReceiveParameters implements RTCRtpParameters {
   external factory RTCRtpReceiveParameters();
 }
 
@@ -572,7 +524,7 @@ extension RTCRtpCodingParametersExtension on RTCRtpCodingParameters {
 @JS()
 @staticInterop
 @anonymous
-class RTCRtpEncodingParameters extends RTCRtpCodingParameters {
+class RTCRtpEncodingParameters implements RTCRtpCodingParameters {
   external factory RTCRtpEncodingParameters({
     RTCPriorityType priority = 'low',
     RTCPriorityType networkPriority,
@@ -721,20 +673,18 @@ extension RTCRtpHeaderExtensionCapabilityExtension
 @JS('RTCRtpReceiver')
 @staticInterop
 class RTCRtpReceiver {
-  external factory RTCRtpReceiver();
-
   external static RTCRtpCapabilities? getCapabilities(JSString kind);
 }
 
 extension RTCRtpReceiverExtension on RTCRtpReceiver {
-  external set transform(RTCRtpTransform? value);
-  external RTCRtpTransform? get transform;
-  external MediaStreamTrack get track;
-  external RTCDtlsTransport? get transport;
   external RTCRtpReceiveParameters getParameters();
   external JSArray getContributingSources();
   external JSArray getSynchronizationSources();
   external JSPromise getStats();
+  external set transform(RTCRtpTransform? value);
+  external RTCRtpTransform? get transform;
+  external MediaStreamTrack get track;
+  external RTCDtlsTransport? get transport;
 }
 
 @JS()
@@ -763,37 +713,33 @@ extension RTCRtpContributingSourceExtension on RTCRtpContributingSource {
 @JS()
 @staticInterop
 @anonymous
-class RTCRtpSynchronizationSource extends RTCRtpContributingSource {
+class RTCRtpSynchronizationSource implements RTCRtpContributingSource {
   external factory RTCRtpSynchronizationSource();
 }
 
 @JS('RTCRtpTransceiver')
 @staticInterop
-class RTCRtpTransceiver {
-  external factory RTCRtpTransceiver();
-}
+class RTCRtpTransceiver {}
 
 extension RTCRtpTransceiverExtension on RTCRtpTransceiver {
+  external JSVoid stop();
+  external JSVoid setCodecPreferences(JSArray codecs);
   external JSString? get mid;
   external RTCRtpSender get sender;
   external RTCRtpReceiver get receiver;
   external set direction(RTCRtpTransceiverDirection value);
   external RTCRtpTransceiverDirection get direction;
   external RTCRtpTransceiverDirection? get currentDirection;
-  external JSVoid stop();
-  external JSVoid setCodecPreferences(JSArray codecs);
 }
 
 @JS('RTCDtlsTransport')
 @staticInterop
-class RTCDtlsTransport extends EventTarget {
-  external factory RTCDtlsTransport();
-}
+class RTCDtlsTransport implements EventTarget {}
 
 extension RTCDtlsTransportExtension on RTCDtlsTransport {
+  external JSArray getRemoteCertificates();
   external RTCIceTransport get iceTransport;
   external RTCDtlsTransportState get state;
-  external JSArray getRemoteCertificates();
   external set onstatechange(EventHandler value);
   external EventHandler get onstatechange;
   external set onerror(EventHandler value);
@@ -819,22 +765,23 @@ extension RTCDtlsFingerprintExtension on RTCDtlsFingerprint {
 
 @JS('RTCIceTransport')
 @staticInterop
-class RTCIceTransport extends EventTarget {
-  external factory RTCIceTransport.a0();
+class RTCIceTransport implements EventTarget {
+  external factory RTCIceTransport();
 }
 
 extension RTCIceTransportExtension on RTCIceTransport {
-  external JSVoid gather();
-  external JSVoid gather1(RTCIceGatherOptions options);
-  external JSVoid start();
-  external JSVoid start1(RTCIceParameters remoteParameters);
-  external JSVoid start2(
+  external JSVoid gather([RTCIceGatherOptions options]);
+  external JSVoid start([
     RTCIceParameters remoteParameters,
     RTCIceRole role,
-  );
+  ]);
   external JSVoid stop();
-  external JSVoid addRemoteCandidate();
-  external JSVoid addRemoteCandidate1(RTCIceCandidateInit remoteCandidate);
+  external JSVoid addRemoteCandidate([RTCIceCandidateInit remoteCandidate]);
+  external JSArray getLocalCandidates();
+  external JSArray getRemoteCandidates();
+  external RTCIceCandidatePair? getSelectedCandidatePair();
+  external RTCIceParameters? getLocalParameters();
+  external RTCIceParameters? getRemoteParameters();
   external set onerror(EventHandler value);
   external EventHandler get onerror;
   external set onicecandidate(EventHandler value);
@@ -843,11 +790,6 @@ extension RTCIceTransportExtension on RTCIceTransport {
   external RTCIceComponent get component;
   external RTCIceTransportState get state;
   external RTCIceGathererState get gatheringState;
-  external JSArray getLocalCandidates();
-  external JSArray getRemoteCandidates();
-  external RTCIceCandidatePair? getSelectedCandidatePair();
-  external RTCIceParameters? getLocalParameters();
-  external RTCIceParameters? getRemoteParameters();
   external set onstatechange(EventHandler value);
   external EventHandler get onstatechange;
   external set ongatheringstatechange(EventHandler value);
@@ -895,10 +837,8 @@ extension RTCIceCandidatePairExtension on RTCIceCandidatePair {
 
 @JS('RTCTrackEvent')
 @staticInterop
-class RTCTrackEvent extends Event {
-  external factory RTCTrackEvent();
-
-  external factory RTCTrackEvent.a1(
+class RTCTrackEvent implements Event {
+  external factory RTCTrackEvent(
     JSString type,
     RTCTrackEventInit eventInitDict,
   );
@@ -914,7 +854,7 @@ extension RTCTrackEventExtension on RTCTrackEvent {
 @JS()
 @staticInterop
 @anonymous
-class RTCTrackEventInit extends EventInit {
+class RTCTrackEventInit implements EventInit {
   external factory RTCTrackEventInit({
     required RTCRtpReceiver receiver,
     required MediaStreamTrack track,
@@ -936,9 +876,7 @@ extension RTCTrackEventInitExtension on RTCTrackEventInit {
 
 @JS('RTCSctpTransport')
 @staticInterop
-class RTCSctpTransport extends EventTarget {
-  external factory RTCSctpTransport();
-}
+class RTCSctpTransport implements EventTarget {}
 
 extension RTCSctpTransportExtension on RTCSctpTransport {
   external RTCDtlsTransport get transport;
@@ -951,11 +889,11 @@ extension RTCSctpTransportExtension on RTCSctpTransport {
 
 @JS('RTCDataChannel')
 @staticInterop
-class RTCDataChannel extends EventTarget {
-  external factory RTCDataChannel();
-}
+class RTCDataChannel implements EventTarget {}
 
 extension RTCDataChannelExtension on RTCDataChannel {
+  external JSVoid close();
+  external JSVoid send(JSAny data);
   external RTCPriorityType get priority;
   external JSString get label;
   external JSBoolean get ordered;
@@ -978,18 +916,10 @@ extension RTCDataChannelExtension on RTCDataChannel {
   external EventHandler get onclosing;
   external set onclose(EventHandler value);
   external EventHandler get onclose;
-  external JSVoid close();
   external set onmessage(EventHandler value);
   external EventHandler get onmessage;
   external set binaryType(BinaryType value);
   external BinaryType get binaryType;
-  external JSVoid send(JSString data);
-  @JS('send')
-  external JSVoid send_1_(Blob data);
-  @JS('send')
-  external JSVoid send_2_(JSArrayBuffer data);
-  @JS('send')
-  external JSVoid send_3_(ArrayBufferView data);
 }
 
 @JS()
@@ -1026,10 +956,8 @@ extension RTCDataChannelInitExtension on RTCDataChannelInit {
 
 @JS('RTCDataChannelEvent')
 @staticInterop
-class RTCDataChannelEvent extends Event {
-  external factory RTCDataChannelEvent();
-
-  external factory RTCDataChannelEvent.a1(
+class RTCDataChannelEvent implements Event {
+  external factory RTCDataChannelEvent(
     JSString type,
     RTCDataChannelEventInit eventInitDict,
   );
@@ -1042,7 +970,7 @@ extension RTCDataChannelEventExtension on RTCDataChannelEvent {
 @JS()
 @staticInterop
 @anonymous
-class RTCDataChannelEventInit extends EventInit {
+class RTCDataChannelEventInit implements EventInit {
   external factory RTCDataChannelEventInit({required RTCDataChannel channel});
 }
 
@@ -1053,21 +981,14 @@ extension RTCDataChannelEventInitExtension on RTCDataChannelEventInit {
 
 @JS('RTCDTMFSender')
 @staticInterop
-class RTCDTMFSender extends EventTarget {
-  external factory RTCDTMFSender();
-}
+class RTCDTMFSender implements EventTarget {}
 
 extension RTCDTMFSenderExtension on RTCDTMFSender {
-  external JSVoid insertDTMF(JSString tones);
-  external JSVoid insertDTMF1(
-    JSString tones,
-    JSNumber duration,
-  );
-  external JSVoid insertDTMF2(
-    JSString tones,
+  external JSVoid insertDTMF(
+    JSString tones, [
     JSNumber duration,
     JSNumber interToneGap,
-  );
+  ]);
   external set ontonechange(EventHandler value);
   external EventHandler get ontonechange;
   external JSBoolean get canInsertDTMF;
@@ -1076,15 +997,11 @@ extension RTCDTMFSenderExtension on RTCDTMFSender {
 
 @JS('RTCDTMFToneChangeEvent')
 @staticInterop
-class RTCDTMFToneChangeEvent extends Event {
-  external factory RTCDTMFToneChangeEvent();
-
-  external factory RTCDTMFToneChangeEvent.a1(JSString type);
-
-  external factory RTCDTMFToneChangeEvent.a2(
-    JSString type,
+class RTCDTMFToneChangeEvent implements Event {
+  external factory RTCDTMFToneChangeEvent(
+    JSString type, [
     RTCDTMFToneChangeEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension RTCDTMFToneChangeEventExtension on RTCDTMFToneChangeEvent {
@@ -1094,7 +1011,7 @@ extension RTCDTMFToneChangeEventExtension on RTCDTMFToneChangeEvent {
 @JS()
 @staticInterop
 @anonymous
-class RTCDTMFToneChangeEventInit extends EventInit {
+class RTCDTMFToneChangeEventInit implements EventInit {
   external factory RTCDTMFToneChangeEventInit({JSString tone = ''});
 }
 
@@ -1105,9 +1022,7 @@ extension RTCDTMFToneChangeEventInitExtension on RTCDTMFToneChangeEventInit {
 
 @JS('RTCStatsReport')
 @staticInterop
-class RTCStatsReport {
-  external factory RTCStatsReport();
-}
+class RTCStatsReport {}
 
 extension RTCStatsReportExtension on RTCStatsReport {}
 
@@ -1133,15 +1048,11 @@ extension RTCStatsExtension on RTCStats {
 
 @JS('RTCError')
 @staticInterop
-class RTCError extends DOMException {
-  external factory RTCError();
-
-  external factory RTCError.a1(RTCErrorInit init);
-
-  external factory RTCError.a2(
-    RTCErrorInit init,
+class RTCError implements DOMException {
+  external factory RTCError(
+    RTCErrorInit init, [
     JSString message,
-  );
+  ]);
 }
 
 extension RTCErrorExtension on RTCError {
@@ -1184,10 +1095,8 @@ extension RTCErrorInitExtension on RTCErrorInit {
 
 @JS('RTCErrorEvent')
 @staticInterop
-class RTCErrorEvent extends Event {
-  external factory RTCErrorEvent();
-
-  external factory RTCErrorEvent.a1(
+class RTCErrorEvent implements Event {
+  external factory RTCErrorEvent(
     JSString type,
     RTCErrorEventInit eventInitDict,
   );
@@ -1200,7 +1109,7 @@ extension RTCErrorEventExtension on RTCErrorEvent {
 @JS()
 @staticInterop
 @anonymous
-class RTCErrorEventInit extends EventInit {
+class RTCErrorEventInit implements EventInit {
   external factory RTCErrorEventInit({required RTCError error});
 }
 

--- a/lib/src/dom/webrtc_encoded_transform.dart
+++ b/lib/src/dom/webrtc_encoded_transform.dart
@@ -36,29 +36,22 @@ extension SFrameTransformOptionsExtension on SFrameTransformOptions {
 @JS('SFrameTransform')
 @staticInterop
 class SFrameTransform implements GenericTransformStream {
-  external factory SFrameTransform();
-
-  external factory SFrameTransform.a1();
-
-  external factory SFrameTransform.a2(SFrameTransformOptions options);
+  external factory SFrameTransform([SFrameTransformOptions options]);
 }
 
 extension SFrameTransformExtension on SFrameTransform {
-  external JSPromise setEncryptionKey(CryptoKey key);
-  external JSPromise setEncryptionKey1(
-    CryptoKey key,
+  external JSPromise setEncryptionKey(
+    CryptoKey key, [
     CryptoKeyID keyID,
-  );
+  ]);
   external set onerror(EventHandler value);
   external EventHandler get onerror;
 }
 
 @JS('SFrameTransformErrorEvent')
 @staticInterop
-class SFrameTransformErrorEvent extends Event {
-  external factory SFrameTransformErrorEvent();
-
-  external factory SFrameTransformErrorEvent.a1(
+class SFrameTransformErrorEvent implements Event {
+  external factory SFrameTransformErrorEvent(
     JSString type,
     SFrameTransformErrorEventInit eventInitDict,
   );
@@ -73,7 +66,7 @@ extension SFrameTransformErrorEventExtension on SFrameTransformErrorEvent {
 @JS()
 @staticInterop
 @anonymous
-class SFrameTransformErrorEventInit extends EventInit {
+class SFrameTransformErrorEventInit implements EventInit {
   external factory SFrameTransformErrorEventInit({
     required SFrameTransformErrorEventType errorType,
     required JSAny frame,
@@ -132,16 +125,14 @@ extension RTCEncodedVideoFrameMetadataExtension
 
 @JS('RTCEncodedVideoFrame')
 @staticInterop
-class RTCEncodedVideoFrame {
-  external factory RTCEncodedVideoFrame();
-}
+class RTCEncodedVideoFrame {}
 
 extension RTCEncodedVideoFrameExtension on RTCEncodedVideoFrame {
+  external RTCEncodedVideoFrameMetadata getMetadata();
   external RTCEncodedVideoFrameType get type;
   external JSNumber get timestamp;
   external set data(JSArrayBuffer value);
   external JSArrayBuffer get data;
-  external RTCEncodedVideoFrameMetadata getMetadata();
 }
 
 @JS()
@@ -170,22 +161,18 @@ extension RTCEncodedAudioFrameMetadataExtension
 
 @JS('RTCEncodedAudioFrame')
 @staticInterop
-class RTCEncodedAudioFrame {
-  external factory RTCEncodedAudioFrame();
-}
+class RTCEncodedAudioFrame {}
 
 extension RTCEncodedAudioFrameExtension on RTCEncodedAudioFrame {
+  external RTCEncodedAudioFrameMetadata getMetadata();
   external JSNumber get timestamp;
   external set data(JSArrayBuffer value);
   external JSArrayBuffer get data;
-  external RTCEncodedAudioFrameMetadata getMetadata();
 }
 
 @JS('RTCTransformEvent')
 @staticInterop
-class RTCTransformEvent extends Event {
-  external factory RTCTransformEvent();
-}
+class RTCTransformEvent implements Event {}
 
 extension RTCTransformEventExtension on RTCTransformEvent {
   external RTCRtpScriptTransformer get transformer;
@@ -193,34 +180,22 @@ extension RTCTransformEventExtension on RTCTransformEvent {
 
 @JS('RTCRtpScriptTransformer')
 @staticInterop
-class RTCRtpScriptTransformer {
-  external factory RTCRtpScriptTransformer();
-}
+class RTCRtpScriptTransformer {}
 
 extension RTCRtpScriptTransformerExtension on RTCRtpScriptTransformer {
+  external JSPromise generateKeyFrame([JSString rid]);
+  external JSPromise sendKeyFrameRequest();
   external ReadableStream get readable;
   external WritableStream get writable;
   external JSAny get options;
-  external JSPromise generateKeyFrame();
-  external JSPromise generateKeyFrame1(JSString rid);
-  external JSPromise sendKeyFrameRequest();
 }
 
 @JS('RTCRtpScriptTransform')
 @staticInterop
 class RTCRtpScriptTransform {
-  external factory RTCRtpScriptTransform();
-
-  external factory RTCRtpScriptTransform.a1(Worker worker);
-
-  external factory RTCRtpScriptTransform.a2(
-    Worker worker,
-    JSAny options,
-  );
-
-  external factory RTCRtpScriptTransform.a3(
-    Worker worker,
+  external factory RTCRtpScriptTransform(
+    Worker worker, [
     JSAny options,
     JSArray transfer,
-  );
+  ]);
 }

--- a/lib/src/dom/webrtc_identity.dart
+++ b/lib/src/dom/webrtc_identity.dart
@@ -16,9 +16,7 @@ typedef RTCErrorDetailTypeIdp = JSString;
 
 @JS('RTCIdentityProviderGlobalScope')
 @staticInterop
-class RTCIdentityProviderGlobalScope extends WorkerGlobalScope {
-  external factory RTCIdentityProviderGlobalScope();
-}
+class RTCIdentityProviderGlobalScope implements WorkerGlobalScope {}
 
 extension RTCIdentityProviderGlobalScopeExtension
     on RTCIdentityProviderGlobalScope {
@@ -27,9 +25,7 @@ extension RTCIdentityProviderGlobalScopeExtension
 
 @JS('RTCIdentityProviderRegistrar')
 @staticInterop
-class RTCIdentityProviderRegistrar {
-  external factory RTCIdentityProviderRegistrar();
-}
+class RTCIdentityProviderRegistrar {}
 
 extension RTCIdentityProviderRegistrarExtension
     on RTCIdentityProviderRegistrar {
@@ -127,9 +123,7 @@ extension RTCIdentityProviderOptionsExtension on RTCIdentityProviderOptions {
 @JS('RTCIdentityAssertion')
 @staticInterop
 class RTCIdentityAssertion {
-  external factory RTCIdentityAssertion();
-
-  external factory RTCIdentityAssertion.a1(
+  external factory RTCIdentityAssertion(
     JSString idp,
     JSString name,
   );

--- a/lib/src/dom/webrtc_stats.dart
+++ b/lib/src/dom/webrtc_stats.dart
@@ -19,7 +19,7 @@ typedef RTCStatsIceCandidatePairState = JSString;
 @JS()
 @staticInterop
 @anonymous
-class RTCRtpStreamStats extends RTCStats {
+class RTCRtpStreamStats implements RTCStats {
   external factory RTCRtpStreamStats({
     required JSNumber ssrc,
     required JSString kind,
@@ -42,7 +42,7 @@ extension RTCRtpStreamStatsExtension on RTCRtpStreamStats {
 @JS()
 @staticInterop
 @anonymous
-class RTCCodecStats extends RTCStats {
+class RTCCodecStats implements RTCStats {
   external factory RTCCodecStats({
     required JSNumber payloadType,
     required JSString transportId,
@@ -71,7 +71,7 @@ extension RTCCodecStatsExtension on RTCCodecStats {
 @JS()
 @staticInterop
 @anonymous
-class RTCReceivedRtpStreamStats extends RTCRtpStreamStats {
+class RTCReceivedRtpStreamStats implements RTCRtpStreamStats {
   external factory RTCReceivedRtpStreamStats({
     JSNumber packetsReceived,
     JSNumber packetsLost,
@@ -91,7 +91,7 @@ extension RTCReceivedRtpStreamStatsExtension on RTCReceivedRtpStreamStats {
 @JS()
 @staticInterop
 @anonymous
-class RTCInboundRtpStreamStats extends RTCReceivedRtpStreamStats {
+class RTCInboundRtpStreamStats implements RTCReceivedRtpStreamStats {
   external factory RTCInboundRtpStreamStats({
     required JSString trackIdentifier,
     required JSString kind,
@@ -249,7 +249,7 @@ extension RTCInboundRtpStreamStatsExtension on RTCInboundRtpStreamStats {
 @JS()
 @staticInterop
 @anonymous
-class RTCRemoteInboundRtpStreamStats extends RTCReceivedRtpStreamStats {
+class RTCRemoteInboundRtpStreamStats implements RTCReceivedRtpStreamStats {
   external factory RTCRemoteInboundRtpStreamStats({
     JSString localId,
     JSNumber roundTripTime,
@@ -276,7 +276,7 @@ extension RTCRemoteInboundRtpStreamStatsExtension
 @JS()
 @staticInterop
 @anonymous
-class RTCSentRtpStreamStats extends RTCRtpStreamStats {
+class RTCSentRtpStreamStats implements RTCRtpStreamStats {
   external factory RTCSentRtpStreamStats({
     JSNumber packetsSent,
     JSNumber bytesSent,
@@ -293,7 +293,7 @@ extension RTCSentRtpStreamStatsExtension on RTCSentRtpStreamStats {
 @JS()
 @staticInterop
 @anonymous
-class RTCOutboundRtpStreamStats extends RTCSentRtpStreamStats {
+class RTCOutboundRtpStreamStats implements RTCSentRtpStreamStats {
   external factory RTCOutboundRtpStreamStats({
     JSString mid,
     JSString mediaSourceId,
@@ -391,7 +391,7 @@ extension RTCOutboundRtpStreamStatsExtension on RTCOutboundRtpStreamStats {
 @JS()
 @staticInterop
 @anonymous
-class RTCRemoteOutboundRtpStreamStats extends RTCSentRtpStreamStats {
+class RTCRemoteOutboundRtpStreamStats implements RTCSentRtpStreamStats {
   external factory RTCRemoteOutboundRtpStreamStats({
     JSString localId,
     DOMHighResTimeStamp remoteTimestamp,
@@ -421,7 +421,7 @@ extension RTCRemoteOutboundRtpStreamStatsExtension
 @JS()
 @staticInterop
 @anonymous
-class RTCMediaSourceStats extends RTCStats {
+class RTCMediaSourceStats implements RTCStats {
   external factory RTCMediaSourceStats({
     required JSString trackIdentifier,
     required JSString kind,
@@ -438,7 +438,7 @@ extension RTCMediaSourceStatsExtension on RTCMediaSourceStats {
 @JS()
 @staticInterop
 @anonymous
-class RTCAudioSourceStats extends RTCMediaSourceStats {
+class RTCAudioSourceStats implements RTCMediaSourceStats {
   external factory RTCAudioSourceStats({
     JSNumber audioLevel,
     JSNumber totalAudioEnergy,
@@ -476,7 +476,7 @@ extension RTCAudioSourceStatsExtension on RTCAudioSourceStats {
 @JS()
 @staticInterop
 @anonymous
-class RTCVideoSourceStats extends RTCMediaSourceStats {
+class RTCVideoSourceStats implements RTCMediaSourceStats {
   external factory RTCVideoSourceStats({
     JSNumber width,
     JSNumber height,
@@ -499,7 +499,7 @@ extension RTCVideoSourceStatsExtension on RTCVideoSourceStats {
 @JS()
 @staticInterop
 @anonymous
-class RTCAudioPlayoutStats extends RTCStats {
+class RTCAudioPlayoutStats implements RTCStats {
   external factory RTCAudioPlayoutStats({
     required JSString kind,
     JSNumber synthesizedSamplesDuration,
@@ -528,7 +528,7 @@ extension RTCAudioPlayoutStatsExtension on RTCAudioPlayoutStats {
 @JS()
 @staticInterop
 @anonymous
-class RTCPeerConnectionStats extends RTCStats {
+class RTCPeerConnectionStats implements RTCStats {
   external factory RTCPeerConnectionStats({
     JSNumber dataChannelsOpened,
     JSNumber dataChannelsClosed,
@@ -545,7 +545,7 @@ extension RTCPeerConnectionStatsExtension on RTCPeerConnectionStats {
 @JS()
 @staticInterop
 @anonymous
-class RTCDataChannelStats extends RTCStats {
+class RTCDataChannelStats implements RTCStats {
   external factory RTCDataChannelStats({
     JSString label,
     JSString protocol,
@@ -580,7 +580,7 @@ extension RTCDataChannelStatsExtension on RTCDataChannelStats {
 @JS()
 @staticInterop
 @anonymous
-class RTCTransportStats extends RTCStats {
+class RTCTransportStats implements RTCStats {
   external factory RTCTransportStats({
     JSNumber packetsSent,
     JSNumber packetsReceived,
@@ -639,7 +639,7 @@ extension RTCTransportStatsExtension on RTCTransportStats {
 @JS()
 @staticInterop
 @anonymous
-class RTCIceCandidateStats extends RTCStats {
+class RTCIceCandidateStats implements RTCStats {
   external factory RTCIceCandidateStats({
     required JSString transportId,
     JSString? address,
@@ -689,7 +689,7 @@ extension RTCIceCandidateStatsExtension on RTCIceCandidateStats {
 @JS()
 @staticInterop
 @anonymous
-class RTCIceCandidatePairStats extends RTCStats {
+class RTCIceCandidatePairStats implements RTCStats {
   external factory RTCIceCandidatePairStats({
     required JSString transportId,
     required JSString localCandidateId,
@@ -766,7 +766,7 @@ extension RTCIceCandidatePairStatsExtension on RTCIceCandidatePairStats {
 @JS()
 @staticInterop
 @anonymous
-class RTCCertificateStats extends RTCStats {
+class RTCCertificateStats implements RTCStats {
   external factory RTCCertificateStats({
     required JSString fingerprint,
     required JSString fingerprintAlgorithm,

--- a/lib/src/dom/websockets.dart
+++ b/lib/src/dom/websockets.dart
@@ -15,15 +15,11 @@ typedef BinaryType = JSString;
 
 @JS('WebSocket')
 @staticInterop
-class WebSocket extends EventTarget {
-  external factory WebSocket();
-
-  external factory WebSocket.a1(JSString url);
-
-  external factory WebSocket.a2(
-    JSString url,
+class WebSocket implements EventTarget {
+  external factory WebSocket(
+    JSString url, [
     JSAny protocols,
-  );
+  ]);
 
   external static JSNumber get CONNECTING;
   external static JSNumber get OPEN;
@@ -32,6 +28,11 @@ class WebSocket extends EventTarget {
 }
 
 extension WebSocketExtension on WebSocket {
+  external JSVoid close([
+    JSNumber code,
+    JSString reason,
+  ]);
+  external JSVoid send(JSAny data);
   external JSString get url;
   external JSNumber get readyState;
   external JSNumber get bufferedAmount;
@@ -43,30 +44,19 @@ extension WebSocketExtension on WebSocket {
   external EventHandler get onclose;
   external JSString get extensions;
   external JSString get protocol;
-  external JSVoid close();
-  external JSVoid close1(JSNumber code);
-  external JSVoid close2(
-    JSNumber code,
-    JSString reason,
-  );
   external set onmessage(EventHandler value);
   external EventHandler get onmessage;
   external set binaryType(BinaryType value);
   external BinaryType get binaryType;
-  external JSVoid send(JSAny data);
 }
 
 @JS('CloseEvent')
 @staticInterop
-class CloseEvent extends Event {
-  external factory CloseEvent();
-
-  external factory CloseEvent.a1(JSString type);
-
-  external factory CloseEvent.a2(
-    JSString type,
+class CloseEvent implements Event {
+  external factory CloseEvent(
+    JSString type, [
     CloseEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension CloseEventExtension on CloseEvent {
@@ -78,7 +68,7 @@ extension CloseEventExtension on CloseEvent {
 @JS()
 @staticInterop
 @anonymous
-class CloseEventInit extends EventInit {
+class CloseEventInit implements EventInit {
   external factory CloseEventInit({
     JSBoolean wasClean = false,
     JSNumber code = 0,

--- a/lib/src/dom/webtransport.dart
+++ b/lib/src/dom/webtransport.dart
@@ -18,9 +18,7 @@ typedef WebTransportErrorSource = JSString;
 
 @JS('WebTransportDatagramDuplexStream')
 @staticInterop
-class WebTransportDatagramDuplexStream {
-  external factory WebTransportDatagramDuplexStream();
-}
+class WebTransportDatagramDuplexStream {}
 
 extension WebTransportDatagramDuplexStreamExtension
     on WebTransportDatagramDuplexStream {
@@ -40,32 +38,25 @@ extension WebTransportDatagramDuplexStreamExtension
 @JS('WebTransport')
 @staticInterop
 class WebTransport {
-  external factory WebTransport();
-
-  external factory WebTransport.a1(JSString url);
-
-  external factory WebTransport.a2(
-    JSString url,
+  external factory WebTransport(
+    JSString url, [
     WebTransportOptions options,
-  );
+  ]);
 }
 
 extension WebTransportExtension on WebTransport {
   external JSPromise getStats();
+  external JSVoid close([WebTransportCloseInfo closeInfo]);
+  external JSPromise createBidirectionalStream(
+      [WebTransportSendStreamOptions options]);
+  external JSPromise createUnidirectionalStream(
+      [WebTransportSendStreamOptions options]);
   external JSPromise get ready;
   external WebTransportReliabilityMode get reliability;
   external WebTransportCongestionControl get congestionControl;
   external JSPromise get closed;
-  external JSVoid close();
-  external JSVoid close1(WebTransportCloseInfo closeInfo);
   external WebTransportDatagramDuplexStream get datagrams;
-  external JSPromise createBidirectionalStream();
-  external JSPromise createBidirectionalStream1(
-      WebTransportSendStreamOptions options);
   external ReadableStream get incomingBidirectionalStreams;
-  external JSPromise createUnidirectionalStream();
-  external JSPromise createUnidirectionalStream1(
-      WebTransportSendStreamOptions options);
   external ReadableStream get incomingUnidirectionalStreams;
 }
 
@@ -211,9 +202,7 @@ extension WebTransportDatagramStatsExtension on WebTransportDatagramStats {
 
 @JS('WebTransportSendStream')
 @staticInterop
-class WebTransportSendStream extends WritableStream {
-  external factory WebTransportSendStream();
-}
+class WebTransportSendStream implements WritableStream {}
 
 extension WebTransportSendStreamExtension on WebTransportSendStream {
   external JSPromise getStats();
@@ -244,9 +233,7 @@ extension WebTransportSendStreamStatsExtension on WebTransportSendStreamStats {
 
 @JS('WebTransportReceiveStream')
 @staticInterop
-class WebTransportReceiveStream extends ReadableStream {
-  external factory WebTransportReceiveStream();
-}
+class WebTransportReceiveStream implements ReadableStream {}
 
 extension WebTransportReceiveStreamExtension on WebTransportReceiveStream {
   external JSPromise getStats();
@@ -275,9 +262,7 @@ extension WebTransportReceiveStreamStatsExtension
 
 @JS('WebTransportBidirectionalStream')
 @staticInterop
-class WebTransportBidirectionalStream {
-  external factory WebTransportBidirectionalStream();
-}
+class WebTransportBidirectionalStream {}
 
 extension WebTransportBidirectionalStreamExtension
     on WebTransportBidirectionalStream {
@@ -287,12 +272,8 @@ extension WebTransportBidirectionalStreamExtension
 
 @JS('WebTransportError')
 @staticInterop
-class WebTransportError extends DOMException {
-  external factory WebTransportError();
-
-  external factory WebTransportError.a1();
-
-  external factory WebTransportError.a2(WebTransportErrorInit init);
+class WebTransportError implements DOMException {
+  external factory WebTransportError([WebTransportErrorInit init]);
 }
 
 extension WebTransportErrorExtension on WebTransportError {

--- a/lib/src/dom/webusb.dart
+++ b/lib/src/dom/webusb.dart
@@ -62,23 +62,21 @@ extension USBDeviceRequestOptionsExtension on USBDeviceRequestOptions {
 
 @JS('USB')
 @staticInterop
-class USB extends EventTarget {
-  external factory USB();
-}
+class USB implements EventTarget {}
 
 extension USBExtension on USB {
+  external JSPromise getDevices();
+  external JSPromise requestDevice(USBDeviceRequestOptions options);
   external set onconnect(EventHandler value);
   external EventHandler get onconnect;
   external set ondisconnect(EventHandler value);
   external EventHandler get ondisconnect;
-  external JSPromise getDevices();
-  external JSPromise requestDevice(USBDeviceRequestOptions options);
 }
 
 @JS()
 @staticInterop
 @anonymous
-class USBConnectionEventInit extends EventInit {
+class USBConnectionEventInit implements EventInit {
   external factory USBConnectionEventInit({required USBDevice device});
 }
 
@@ -89,10 +87,8 @@ extension USBConnectionEventInitExtension on USBConnectionEventInit {
 
 @JS('USBConnectionEvent')
 @staticInterop
-class USBConnectionEvent extends Event {
-  external factory USBConnectionEvent();
-
-  external factory USBConnectionEvent.a1(
+class USBConnectionEvent implements Event {
+  external factory USBConnectionEvent(
     JSString type,
     USBConnectionEventInit eventInitDict,
   );
@@ -105,14 +101,10 @@ extension USBConnectionEventExtension on USBConnectionEvent {
 @JS('USBInTransferResult')
 @staticInterop
 class USBInTransferResult {
-  external factory USBInTransferResult();
-
-  external factory USBInTransferResult.a1(USBTransferStatus status);
-
-  external factory USBInTransferResult.a2(
-    USBTransferStatus status,
+  external factory USBInTransferResult(
+    USBTransferStatus status, [
     JSDataView? data,
-  );
+  ]);
 }
 
 extension USBInTransferResultExtension on USBInTransferResult {
@@ -123,14 +115,10 @@ extension USBInTransferResultExtension on USBInTransferResult {
 @JS('USBOutTransferResult')
 @staticInterop
 class USBOutTransferResult {
-  external factory USBOutTransferResult();
-
-  external factory USBOutTransferResult.a1(USBTransferStatus status);
-
-  external factory USBOutTransferResult.a2(
-    USBTransferStatus status,
+  external factory USBOutTransferResult(
+    USBTransferStatus status, [
     JSNumber bytesWritten,
-  );
+  ]);
 }
 
 extension USBOutTransferResultExtension on USBOutTransferResult {
@@ -141,14 +129,10 @@ extension USBOutTransferResultExtension on USBOutTransferResult {
 @JS('USBIsochronousInTransferPacket')
 @staticInterop
 class USBIsochronousInTransferPacket {
-  external factory USBIsochronousInTransferPacket();
-
-  external factory USBIsochronousInTransferPacket.a1(USBTransferStatus status);
-
-  external factory USBIsochronousInTransferPacket.a2(
-    USBTransferStatus status,
+  external factory USBIsochronousInTransferPacket(
+    USBTransferStatus status, [
     JSDataView? data,
-  );
+  ]);
 }
 
 extension USBIsochronousInTransferPacketExtension
@@ -160,14 +144,10 @@ extension USBIsochronousInTransferPacketExtension
 @JS('USBIsochronousInTransferResult')
 @staticInterop
 class USBIsochronousInTransferResult {
-  external factory USBIsochronousInTransferResult();
-
-  external factory USBIsochronousInTransferResult.a1(JSArray packets);
-
-  external factory USBIsochronousInTransferResult.a2(
-    JSArray packets,
+  external factory USBIsochronousInTransferResult(
+    JSArray packets, [
     JSDataView? data,
-  );
+  ]);
 }
 
 extension USBIsochronousInTransferResultExtension
@@ -179,14 +159,10 @@ extension USBIsochronousInTransferResultExtension
 @JS('USBIsochronousOutTransferPacket')
 @staticInterop
 class USBIsochronousOutTransferPacket {
-  external factory USBIsochronousOutTransferPacket();
-
-  external factory USBIsochronousOutTransferPacket.a1(USBTransferStatus status);
-
-  external factory USBIsochronousOutTransferPacket.a2(
-    USBTransferStatus status,
+  external factory USBIsochronousOutTransferPacket(
+    USBTransferStatus status, [
     JSNumber bytesWritten,
-  );
+  ]);
 }
 
 extension USBIsochronousOutTransferPacketExtension
@@ -198,9 +174,7 @@ extension USBIsochronousOutTransferPacketExtension
 @JS('USBIsochronousOutTransferResult')
 @staticInterop
 class USBIsochronousOutTransferResult {
-  external factory USBIsochronousOutTransferResult();
-
-  external factory USBIsochronousOutTransferResult.a1(JSArray packets);
+  external factory USBIsochronousOutTransferResult(JSArray packets);
 }
 
 extension USBIsochronousOutTransferResultExtension
@@ -210,28 +184,9 @@ extension USBIsochronousOutTransferResultExtension
 
 @JS('USBDevice')
 @staticInterop
-class USBDevice {
-  external factory USBDevice();
-}
+class USBDevice {}
 
 extension USBDeviceExtension on USBDevice {
-  external JSNumber get usbVersionMajor;
-  external JSNumber get usbVersionMinor;
-  external JSNumber get usbVersionSubminor;
-  external JSNumber get deviceClass;
-  external JSNumber get deviceSubclass;
-  external JSNumber get deviceProtocol;
-  external JSNumber get vendorId;
-  external JSNumber get productId;
-  external JSNumber get deviceVersionMajor;
-  external JSNumber get deviceVersionMinor;
-  external JSNumber get deviceVersionSubminor;
-  external JSString? get manufacturerName;
-  external JSString? get productName;
-  external JSString? get serialNumber;
-  external USBConfiguration? get configuration;
-  external JSArray get configurations;
-  external JSBoolean get opened;
   external JSPromise open();
   external JSPromise close();
   external JSPromise forget();
@@ -246,11 +201,10 @@ extension USBDeviceExtension on USBDevice {
     USBControlTransferParameters setup,
     JSNumber length,
   );
-  external JSPromise controlTransferOut(USBControlTransferParameters setup);
-  external JSPromise controlTransferOut1(
-    USBControlTransferParameters setup,
+  external JSPromise controlTransferOut(
+    USBControlTransferParameters setup, [
     BufferSource data,
-  );
+  ]);
   external JSPromise clearHalt(
     USBDirection direction,
     JSNumber endpointNumber,
@@ -273,6 +227,23 @@ extension USBDeviceExtension on USBDevice {
     JSArray packetLengths,
   );
   external JSPromise reset();
+  external JSNumber get usbVersionMajor;
+  external JSNumber get usbVersionMinor;
+  external JSNumber get usbVersionSubminor;
+  external JSNumber get deviceClass;
+  external JSNumber get deviceSubclass;
+  external JSNumber get deviceProtocol;
+  external JSNumber get vendorId;
+  external JSNumber get productId;
+  external JSNumber get deviceVersionMajor;
+  external JSNumber get deviceVersionMinor;
+  external JSNumber get deviceVersionSubminor;
+  external JSString? get manufacturerName;
+  external JSString? get productName;
+  external JSString? get serialNumber;
+  external USBConfiguration? get configuration;
+  external JSArray get configurations;
+  external JSBoolean get opened;
 }
 
 @JS()
@@ -305,9 +276,7 @@ extension USBControlTransferParametersExtension
 @JS('USBConfiguration')
 @staticInterop
 class USBConfiguration {
-  external factory USBConfiguration();
-
-  external factory USBConfiguration.a1(
+  external factory USBConfiguration(
     USBDevice device,
     JSNumber configurationValue,
   );
@@ -322,9 +291,7 @@ extension USBConfigurationExtension on USBConfiguration {
 @JS('USBInterface')
 @staticInterop
 class USBInterface {
-  external factory USBInterface();
-
-  external factory USBInterface.a1(
+  external factory USBInterface(
     USBConfiguration configuration,
     JSNumber interfaceNumber,
   );
@@ -340,9 +307,7 @@ extension USBInterfaceExtension on USBInterface {
 @JS('USBAlternateInterface')
 @staticInterop
 class USBAlternateInterface {
-  external factory USBAlternateInterface();
-
-  external factory USBAlternateInterface.a1(
+  external factory USBAlternateInterface(
     USBInterface deviceInterface,
     JSNumber alternateSetting,
   );
@@ -360,9 +325,7 @@ extension USBAlternateInterfaceExtension on USBAlternateInterface {
 @JS('USBEndpoint')
 @staticInterop
 class USBEndpoint {
-  external factory USBEndpoint();
-
-  external factory USBEndpoint.a1(
+  external factory USBEndpoint(
     USBAlternateInterface alternate,
     JSNumber endpointNumber,
     USBDirection direction,
@@ -379,7 +342,7 @@ extension USBEndpointExtension on USBEndpoint {
 @JS()
 @staticInterop
 @anonymous
-class USBPermissionDescriptor extends PermissionDescriptor {
+class USBPermissionDescriptor implements PermissionDescriptor {
   external factory USBPermissionDescriptor({JSArray filters});
 }
 
@@ -422,9 +385,7 @@ extension USBPermissionStorageExtension on USBPermissionStorage {
 
 @JS('USBPermissionResult')
 @staticInterop
-class USBPermissionResult extends PermissionStatus {
-  external factory USBPermissionResult();
-}
+class USBPermissionResult implements PermissionStatus {}
 
 extension USBPermissionResultExtension on USBPermissionResult {
   external set devices(JSArray value);

--- a/lib/src/dom/webvtt.dart
+++ b/lib/src/dom/webvtt.dart
@@ -21,10 +21,8 @@ typedef ScrollSetting = JSString;
 
 @JS('VTTCue')
 @staticInterop
-class VTTCue extends TextTrackCue {
-  external factory VTTCue();
-
-  external factory VTTCue.a1(
+class VTTCue implements TextTrackCue {
+  external factory VTTCue(
     JSNumber startTime,
     JSNumber endTime,
     JSString text,
@@ -32,6 +30,7 @@ class VTTCue extends TextTrackCue {
 }
 
 extension VTTCueExtension on VTTCue {
+  external DocumentFragment getCueAsHTML();
   external set region(VTTRegion? value);
   external VTTRegion? get region;
   external set vertical(DirectionSetting value);
@@ -52,13 +51,12 @@ extension VTTCueExtension on VTTCue {
   external AlignSetting get align;
   external set text(JSString value);
   external JSString get text;
-  external DocumentFragment getCueAsHTML();
 }
 
 @JS('VTTRegion')
 @staticInterop
 class VTTRegion {
-  external factory VTTRegion.a0();
+  external factory VTTRegion();
 }
 
 extension VTTRegionExtension on VTTRegion {

--- a/lib/src/dom/webxr.dart
+++ b/lib/src/dom/webxr.dart
@@ -35,17 +35,14 @@ typedef XRTargetRayMode = JSString;
 
 @JS('XRSystem')
 @staticInterop
-class XRSystem extends EventTarget {
-  external factory XRSystem();
-}
+class XRSystem implements EventTarget {}
 
 extension XRSystemExtension on XRSystem {
   external JSPromise isSessionSupported(XRSessionMode mode);
-  external JSPromise requestSession(XRSessionMode mode);
-  external JSPromise requestSession1(
-    XRSessionMode mode,
+  external JSPromise requestSession(
+    XRSessionMode mode, [
     XRSessionInit options,
-  );
+  ]);
   external set ondevicechange(EventHandler value);
   external EventHandler get ondevicechange;
 }
@@ -75,23 +72,26 @@ extension XRSessionInitExtension on XRSessionInit {
 
 @JS('XRSession')
 @staticInterop
-class XRSession extends EventTarget {
-  external factory XRSession();
-}
+class XRSession implements EventTarget {}
 
 extension XRSessionExtension on XRSession {
   external JSPromise restorePersistentAnchor(JSString uuid);
   external JSPromise deletePersistentAnchor(JSString uuid);
+  external JSPromise requestHitTestSource(XRHitTestOptionsInit options);
+  external JSPromise requestHitTestSourceForTransientInput(
+      XRTransientInputHitTestOptionsInit options);
+  external JSPromise requestLightProbe([XRLightProbeInit options]);
+  external JSVoid updateRenderState([XRRenderStateInit state]);
+  external JSPromise updateTargetFrameRate(JSNumber rate);
+  external JSPromise requestReferenceSpace(XRReferenceSpaceType type);
+  external JSNumber requestAnimationFrame(XRFrameRequestCallback callback);
+  external JSVoid cancelAnimationFrame(JSNumber handle);
+  external JSPromise end();
   external XREnvironmentBlendMode get environmentBlendMode;
   external XRInteractionMode get interactionMode;
   external XRDepthUsage get depthUsage;
   external XRDepthDataFormat get depthDataFormat;
   external XRDOMOverlayState? get domOverlayState;
-  external JSPromise requestHitTestSource(XRHitTestOptionsInit options);
-  external JSPromise requestHitTestSourceForTransientInput(
-      XRTransientInputHitTestOptionsInit options);
-  external JSPromise requestLightProbe();
-  external JSPromise requestLightProbe1(XRLightProbeInit options);
   external XRReflectionFormat get preferredReflectionFormat;
   external XRVisibilityState get visibilityState;
   external JSNumber? get frameRate;
@@ -99,13 +99,6 @@ extension XRSessionExtension on XRSession {
   external XRRenderState get renderState;
   external XRInputSourceArray get inputSources;
   external JSArray get enabledFeatures;
-  external JSVoid updateRenderState();
-  external JSVoid updateRenderState1(XRRenderStateInit state);
-  external JSPromise updateTargetFrameRate(JSNumber rate);
-  external JSPromise requestReferenceSpace(XRReferenceSpaceType type);
-  external JSNumber requestAnimationFrame(XRFrameRequestCallback callback);
-  external JSVoid cancelAnimationFrame(JSNumber handle);
-  external JSPromise end();
   external set onend(EventHandler value);
   external EventHandler get onend;
   external set oninputsourceschange(EventHandler value);
@@ -156,9 +149,7 @@ extension XRRenderStateInitExtension on XRRenderStateInit {
 
 @JS('XRRenderState')
 @staticInterop
-class XRRenderState {
-  external factory XRRenderState();
-}
+class XRRenderState {}
 
 extension XRRenderStateExtension on XRRenderState {
   external JSNumber get depthNear;
@@ -170,16 +161,13 @@ extension XRRenderStateExtension on XRRenderState {
 
 @JS('XRFrame')
 @staticInterop
-class XRFrame {
-  external factory XRFrame();
-}
+class XRFrame {}
 
 extension XRFrameExtension on XRFrame {
   external JSPromise createAnchor(
     XRRigidTransform pose,
     XRSpace space,
   );
-  external XRAnchorSet get trackedAnchors;
   external XRCPUDepthInformation? getDepthInformation(XRView view);
   external XRJointPose? getJointPose(
     XRJointSpace joint,
@@ -198,26 +186,23 @@ extension XRFrameExtension on XRFrame {
   external JSArray getHitTestResultsForTransientInput(
       XRTransientInputHitTestSource hitTestSource);
   external XRLightEstimate? getLightEstimate(XRLightProbe lightProbe);
-  external XRSession get session;
-  external DOMHighResTimeStamp get predictedDisplayTime;
   external XRViewerPose? getViewerPose(XRReferenceSpace referenceSpace);
   external XRPose? getPose(
     XRSpace space,
     XRSpace baseSpace,
   );
+  external XRAnchorSet get trackedAnchors;
+  external XRSession get session;
+  external DOMHighResTimeStamp get predictedDisplayTime;
 }
 
 @JS('XRSpace')
 @staticInterop
-class XRSpace extends EventTarget {
-  external factory XRSpace();
-}
+class XRSpace implements EventTarget {}
 
 @JS('XRReferenceSpace')
 @staticInterop
-class XRReferenceSpace extends XRSpace {
-  external factory XRReferenceSpace();
-}
+class XRReferenceSpace implements XRSpace {}
 
 extension XRReferenceSpaceExtension on XRReferenceSpace {
   external XRReferenceSpace getOffsetReferenceSpace(
@@ -228,9 +213,7 @@ extension XRReferenceSpaceExtension on XRReferenceSpace {
 
 @JS('XRBoundedReferenceSpace')
 @staticInterop
-class XRBoundedReferenceSpace extends XRReferenceSpace {
-  external factory XRBoundedReferenceSpace();
-}
+class XRBoundedReferenceSpace implements XRReferenceSpace {}
 
 extension XRBoundedReferenceSpaceExtension on XRBoundedReferenceSpace {
   external JSArray get boundsGeometry;
@@ -238,25 +221,21 @@ extension XRBoundedReferenceSpaceExtension on XRBoundedReferenceSpace {
 
 @JS('XRView')
 @staticInterop
-class XRView {
-  external factory XRView();
-}
+class XRView {}
 
 extension XRViewExtension on XRView {
+  external JSVoid requestViewportScale(JSNumber? scale);
   external XRCamera? get camera;
   external JSBoolean get isFirstPersonObserver;
   external XREye get eye;
   external JSFloat32Array get projectionMatrix;
   external XRRigidTransform get transform;
   external JSNumber? get recommendedViewportScale;
-  external JSVoid requestViewportScale(JSNumber? scale);
 }
 
 @JS('XRViewport')
 @staticInterop
-class XRViewport {
-  external factory XRViewport();
-}
+class XRViewport {}
 
 extension XRViewportExtension on XRViewport {
   external JSNumber get x;
@@ -268,16 +247,10 @@ extension XRViewportExtension on XRViewport {
 @JS('XRRigidTransform')
 @staticInterop
 class XRRigidTransform {
-  external factory XRRigidTransform();
-
-  external factory XRRigidTransform.a1();
-
-  external factory XRRigidTransform.a2(DOMPointInit position);
-
-  external factory XRRigidTransform.a3(
+  external factory XRRigidTransform([
     DOMPointInit position,
     DOMPointInit orientation,
-  );
+  ]);
 }
 
 extension XRRigidTransformExtension on XRRigidTransform {
@@ -289,9 +262,7 @@ extension XRRigidTransformExtension on XRRigidTransform {
 
 @JS('XRPose')
 @staticInterop
-class XRPose {
-  external factory XRPose();
-}
+class XRPose {}
 
 extension XRPoseExtension on XRPose {
   external XRRigidTransform get transform;
@@ -302,9 +273,7 @@ extension XRPoseExtension on XRPose {
 
 @JS('XRViewerPose')
 @staticInterop
-class XRViewerPose extends XRPose {
-  external factory XRViewerPose();
-}
+class XRViewerPose implements XRPose {}
 
 extension XRViewerPoseExtension on XRViewerPose {
   external JSArray get views;
@@ -312,9 +281,7 @@ extension XRViewerPoseExtension on XRViewerPose {
 
 @JS('XRInputSource')
 @staticInterop
-class XRInputSource {
-  external factory XRInputSource();
-}
+class XRInputSource {}
 
 extension XRInputSourceExtension on XRInputSource {
   external Gamepad? get gamepad;
@@ -328,9 +295,7 @@ extension XRInputSourceExtension on XRInputSource {
 
 @JS('XRInputSourceArray')
 @staticInterop
-class XRInputSourceArray {
-  external factory XRInputSourceArray();
-}
+class XRInputSourceArray {}
 
 extension XRInputSourceArrayExtension on XRInputSourceArray {
   external JSNumber get length;
@@ -338,9 +303,7 @@ extension XRInputSourceArrayExtension on XRInputSourceArray {
 
 @JS('XRLayer')
 @staticInterop
-class XRLayer extends EventTarget {
-  external factory XRLayer();
-}
+class XRLayer implements EventTarget {}
 
 @JS()
 @staticInterop
@@ -373,24 +336,18 @@ extension XRWebGLLayerInitExtension on XRWebGLLayerInit {
 
 @JS('XRWebGLLayer')
 @staticInterop
-class XRWebGLLayer extends XRLayer {
-  external factory XRWebGLLayer();
-
-  external factory XRWebGLLayer.a1(
+class XRWebGLLayer implements XRLayer {
+  external factory XRWebGLLayer(
     XRSession session,
-    XRWebGLRenderingContext context,
-  );
-
-  external factory XRWebGLLayer.a2(
-    XRSession session,
-    XRWebGLRenderingContext context,
+    XRWebGLRenderingContext context, [
     XRWebGLLayerInit layerInit,
-  );
+  ]);
 
   external static JSNumber getNativeFramebufferScaleFactor(XRSession session);
 }
 
 extension XRWebGLLayerExtension on XRWebGLLayer {
+  external XRViewport? getViewport(XRView view);
   external JSBoolean get antialias;
   external JSBoolean get ignoreDepthValues;
   external set fixedFoveation(JSNumber? value);
@@ -398,15 +355,12 @@ extension XRWebGLLayerExtension on XRWebGLLayer {
   external WebGLFramebuffer? get framebuffer;
   external JSNumber get framebufferWidth;
   external JSNumber get framebufferHeight;
-  external XRViewport? getViewport(XRView view);
 }
 
 @JS('XRSessionEvent')
 @staticInterop
-class XRSessionEvent extends Event {
-  external factory XRSessionEvent();
-
-  external factory XRSessionEvent.a1(
+class XRSessionEvent implements Event {
+  external factory XRSessionEvent(
     JSString type,
     XRSessionEventInit eventInitDict,
   );
@@ -419,7 +373,7 @@ extension XRSessionEventExtension on XRSessionEvent {
 @JS()
 @staticInterop
 @anonymous
-class XRSessionEventInit extends EventInit {
+class XRSessionEventInit implements EventInit {
   external factory XRSessionEventInit({required XRSession session});
 }
 
@@ -430,10 +384,8 @@ extension XRSessionEventInitExtension on XRSessionEventInit {
 
 @JS('XRInputSourceEvent')
 @staticInterop
-class XRInputSourceEvent extends Event {
-  external factory XRInputSourceEvent();
-
-  external factory XRInputSourceEvent.a1(
+class XRInputSourceEvent implements Event {
+  external factory XRInputSourceEvent(
     JSString type,
     XRInputSourceEventInit eventInitDict,
   );
@@ -447,7 +399,7 @@ extension XRInputSourceEventExtension on XRInputSourceEvent {
 @JS()
 @staticInterop
 @anonymous
-class XRInputSourceEventInit extends EventInit {
+class XRInputSourceEventInit implements EventInit {
   external factory XRInputSourceEventInit({
     required XRFrame frame,
     required XRInputSource inputSource,
@@ -463,10 +415,8 @@ extension XRInputSourceEventInitExtension on XRInputSourceEventInit {
 
 @JS('XRInputSourcesChangeEvent')
 @staticInterop
-class XRInputSourcesChangeEvent extends Event {
-  external factory XRInputSourcesChangeEvent();
-
-  external factory XRInputSourcesChangeEvent.a1(
+class XRInputSourcesChangeEvent implements Event {
+  external factory XRInputSourcesChangeEvent(
     JSString type,
     XRInputSourcesChangeEventInit eventInitDict,
   );
@@ -481,7 +431,7 @@ extension XRInputSourcesChangeEventExtension on XRInputSourcesChangeEvent {
 @JS()
 @staticInterop
 @anonymous
-class XRInputSourcesChangeEventInit extends EventInit {
+class XRInputSourcesChangeEventInit implements EventInit {
   external factory XRInputSourcesChangeEventInit({
     required XRSession session,
     required JSArray added,
@@ -501,10 +451,8 @@ extension XRInputSourcesChangeEventInitExtension
 
 @JS('XRReferenceSpaceEvent')
 @staticInterop
-class XRReferenceSpaceEvent extends Event {
-  external factory XRReferenceSpaceEvent();
-
-  external factory XRReferenceSpaceEvent.a1(
+class XRReferenceSpaceEvent implements Event {
+  external factory XRReferenceSpaceEvent(
     JSString type,
     XRReferenceSpaceEventInit eventInitDict,
   );
@@ -518,7 +466,7 @@ extension XRReferenceSpaceEventExtension on XRReferenceSpaceEvent {
 @JS()
 @staticInterop
 @anonymous
-class XRReferenceSpaceEventInit extends EventInit {
+class XRReferenceSpaceEventInit implements EventInit {
   external factory XRReferenceSpaceEventInit({
     required XRReferenceSpace referenceSpace,
     XRRigidTransform? transform,
@@ -535,7 +483,7 @@ extension XRReferenceSpaceEventInitExtension on XRReferenceSpaceEventInit {
 @JS()
 @staticInterop
 @anonymous
-class XRSessionSupportedPermissionDescriptor extends PermissionDescriptor {
+class XRSessionSupportedPermissionDescriptor implements PermissionDescriptor {
   external factory XRSessionSupportedPermissionDescriptor({XRSessionMode mode});
 }
 
@@ -548,7 +496,7 @@ extension XRSessionSupportedPermissionDescriptorExtension
 @JS()
 @staticInterop
 @anonymous
-class XRPermissionDescriptor extends PermissionDescriptor {
+class XRPermissionDescriptor implements PermissionDescriptor {
   external factory XRPermissionDescriptor({
     XRSessionMode mode,
     JSArray requiredFeatures,
@@ -567,9 +515,7 @@ extension XRPermissionDescriptorExtension on XRPermissionDescriptor {
 
 @JS('XRPermissionStatus')
 @staticInterop
-class XRPermissionStatus extends PermissionStatus {
-  external factory XRPermissionStatus();
-}
+class XRPermissionStatus implements PermissionStatus {}
 
 extension XRPermissionStatusExtension on XRPermissionStatus {
   external set granted(JSArray value);

--- a/lib/src/dom/webxr_depth_sensing.dart
+++ b/lib/src/dom/webxr_depth_sensing.dart
@@ -33,9 +33,7 @@ extension XRDepthStateInitExtension on XRDepthStateInit {
 
 @JS('XRDepthInformation')
 @staticInterop
-class XRDepthInformation {
-  external factory XRDepthInformation();
-}
+class XRDepthInformation {}
 
 extension XRDepthInformationExtension on XRDepthInformation {
   external JSNumber get width;
@@ -46,23 +44,19 @@ extension XRDepthInformationExtension on XRDepthInformation {
 
 @JS('XRCPUDepthInformation')
 @staticInterop
-class XRCPUDepthInformation extends XRDepthInformation {
-  external factory XRCPUDepthInformation();
-}
+class XRCPUDepthInformation implements XRDepthInformation {}
 
 extension XRCPUDepthInformationExtension on XRCPUDepthInformation {
-  external JSArrayBuffer get data;
   external JSNumber getDepthInMeters(
     JSNumber x,
     JSNumber y,
   );
+  external JSArrayBuffer get data;
 }
 
 @JS('XRWebGLDepthInformation')
 @staticInterop
-class XRWebGLDepthInformation extends XRDepthInformation {
-  external factory XRWebGLDepthInformation();
-}
+class XRWebGLDepthInformation implements XRDepthInformation {}
 
 extension XRWebGLDepthInformationExtension on XRWebGLDepthInformation {
   external WebGLTexture get texture;

--- a/lib/src/dom/webxr_hand_input.dart
+++ b/lib/src/dom/webxr_hand_input.dart
@@ -14,20 +14,16 @@ typedef XRHandJoint = JSString;
 
 @JS('XRHand')
 @staticInterop
-class XRHand {
-  external factory XRHand();
-}
+class XRHand {}
 
 extension XRHandExtension on XRHand {
-  external JSNumber get size;
   external XRJointSpace get(XRHandJoint key);
+  external JSNumber get size;
 }
 
 @JS('XRJointSpace')
 @staticInterop
-class XRJointSpace extends XRSpace {
-  external factory XRJointSpace();
-}
+class XRJointSpace implements XRSpace {}
 
 extension XRJointSpaceExtension on XRJointSpace {
   external XRHandJoint get jointName;
@@ -35,9 +31,7 @@ extension XRJointSpaceExtension on XRJointSpace {
 
 @JS('XRJointPose')
 @staticInterop
-class XRJointPose extends XRPose {
-  external factory XRJointPose();
-}
+class XRJointPose implements XRPose {}
 
 extension XRJointPoseExtension on XRJointPose {
   external JSNumber get radius;

--- a/lib/src/dom/webxr_hit_test.dart
+++ b/lib/src/dom/webxr_hit_test.dart
@@ -56,9 +56,7 @@ extension XRTransientInputHitTestOptionsInitExtension
 
 @JS('XRHitTestSource')
 @staticInterop
-class XRHitTestSource {
-  external factory XRHitTestSource();
-}
+class XRHitTestSource {}
 
 extension XRHitTestSourceExtension on XRHitTestSource {
   external JSVoid cancel();
@@ -66,9 +64,7 @@ extension XRHitTestSourceExtension on XRHitTestSource {
 
 @JS('XRTransientInputHitTestSource')
 @staticInterop
-class XRTransientInputHitTestSource {
-  external factory XRTransientInputHitTestSource();
-}
+class XRTransientInputHitTestSource {}
 
 extension XRTransientInputHitTestSourceExtension
     on XRTransientInputHitTestSource {
@@ -77,9 +73,7 @@ extension XRTransientInputHitTestSourceExtension
 
 @JS('XRHitTestResult')
 @staticInterop
-class XRHitTestResult {
-  external factory XRHitTestResult();
-}
+class XRHitTestResult {}
 
 extension XRHitTestResultExtension on XRHitTestResult {
   external JSPromise createAnchor();
@@ -88,9 +82,7 @@ extension XRHitTestResultExtension on XRHitTestResult {
 
 @JS('XRTransientInputHitTestResult')
 @staticInterop
-class XRTransientInputHitTestResult {
-  external factory XRTransientInputHitTestResult();
-}
+class XRTransientInputHitTestResult {}
 
 extension XRTransientInputHitTestResultExtension
     on XRTransientInputHitTestResult {
@@ -124,18 +116,10 @@ extension XRRayDirectionInitExtension on XRRayDirectionInit {
 @JS('XRRay')
 @staticInterop
 class XRRay {
-  external factory XRRay();
-
-  external factory XRRay.a1();
-
-  external factory XRRay.a2(DOMPointInit origin);
-
-  external factory XRRay.a3(
-    DOMPointInit origin,
+  external factory XRRay([
+    JSAny originOrTransform,
     XRRayDirectionInit direction,
-  );
-
-  external factory XRRay.a4(XRRigidTransform transform);
+  ]);
 }
 
 extension XRRayExtension on XRRay {

--- a/lib/src/dom/webxr_lighting_estimation.dart
+++ b/lib/src/dom/webxr_lighting_estimation.dart
@@ -17,9 +17,7 @@ typedef XRReflectionFormat = JSString;
 
 @JS('XRLightProbe')
 @staticInterop
-class XRLightProbe extends EventTarget {
-  external factory XRLightProbe();
-}
+class XRLightProbe implements EventTarget {}
 
 extension XRLightProbeExtension on XRLightProbe {
   external XRSpace get probeSpace;
@@ -29,9 +27,7 @@ extension XRLightProbeExtension on XRLightProbe {
 
 @JS('XRLightEstimate')
 @staticInterop
-class XRLightEstimate {
-  external factory XRLightEstimate();
-}
+class XRLightEstimate {}
 
 extension XRLightEstimateExtension on XRLightEstimate {
   external JSFloat32Array get sphericalHarmonicsCoefficients;

--- a/lib/src/dom/webxrlayers.dart
+++ b/lib/src/dom/webxrlayers.dart
@@ -22,11 +22,10 @@ typedef XRTextureType = JSString;
 
 @JS('XRCompositionLayer')
 @staticInterop
-class XRCompositionLayer extends XRLayer {
-  external factory XRCompositionLayer();
-}
+class XRCompositionLayer implements XRLayer {}
 
 extension XRCompositionLayerExtension on XRCompositionLayer {
+  external JSVoid destroy();
   external XRLayerLayout get layout;
   external set blendTextureSourceAlpha(JSBoolean value);
   external JSBoolean get blendTextureSourceAlpha;
@@ -36,14 +35,11 @@ extension XRCompositionLayerExtension on XRCompositionLayer {
   external JSNumber get opacity;
   external JSNumber get mipLevels;
   external JSBoolean get needsRedraw;
-  external JSVoid destroy();
 }
 
 @JS('XRProjectionLayer')
 @staticInterop
-class XRProjectionLayer extends XRCompositionLayer {
-  external factory XRProjectionLayer();
-}
+class XRProjectionLayer implements XRCompositionLayer {}
 
 extension XRProjectionLayerExtension on XRProjectionLayer {
   external JSNumber get textureWidth;
@@ -58,9 +54,7 @@ extension XRProjectionLayerExtension on XRProjectionLayer {
 
 @JS('XRQuadLayer')
 @staticInterop
-class XRQuadLayer extends XRCompositionLayer {
-  external factory XRQuadLayer();
-}
+class XRQuadLayer implements XRCompositionLayer {}
 
 extension XRQuadLayerExtension on XRQuadLayer {
   external set space(XRSpace value);
@@ -77,9 +71,7 @@ extension XRQuadLayerExtension on XRQuadLayer {
 
 @JS('XRCylinderLayer')
 @staticInterop
-class XRCylinderLayer extends XRCompositionLayer {
-  external factory XRCylinderLayer();
-}
+class XRCylinderLayer implements XRCompositionLayer {}
 
 extension XRCylinderLayerExtension on XRCylinderLayer {
   external set space(XRSpace value);
@@ -98,9 +90,7 @@ extension XRCylinderLayerExtension on XRCylinderLayer {
 
 @JS('XREquirectLayer')
 @staticInterop
-class XREquirectLayer extends XRCompositionLayer {
-  external factory XREquirectLayer();
-}
+class XREquirectLayer implements XRCompositionLayer {}
 
 extension XREquirectLayerExtension on XREquirectLayer {
   external set space(XRSpace value);
@@ -121,9 +111,7 @@ extension XREquirectLayerExtension on XREquirectLayer {
 
 @JS('XRCubeLayer')
 @staticInterop
-class XRCubeLayer extends XRCompositionLayer {
-  external factory XRCubeLayer();
-}
+class XRCubeLayer implements XRCompositionLayer {}
 
 extension XRCubeLayerExtension on XRCubeLayer {
   external set space(XRSpace value);
@@ -136,9 +124,7 @@ extension XRCubeLayerExtension on XRCubeLayer {
 
 @JS('XRSubImage')
 @staticInterop
-class XRSubImage {
-  external factory XRSubImage();
-}
+class XRSubImage {}
 
 extension XRSubImageExtension on XRSubImage {
   external XRViewport get viewport;
@@ -146,9 +132,7 @@ extension XRSubImageExtension on XRSubImage {
 
 @JS('XRWebGLSubImage')
 @staticInterop
-class XRWebGLSubImage extends XRSubImage {
-  external factory XRWebGLSubImage();
-}
+class XRWebGLSubImage implements XRSubImage {}
 
 extension XRWebGLSubImageExtension on XRWebGLSubImage {
   external WebGLTexture get colorTexture;
@@ -224,7 +208,7 @@ extension XRLayerInitExtension on XRLayerInit {
 @JS()
 @staticInterop
 @anonymous
-class XRQuadLayerInit extends XRLayerInit {
+class XRQuadLayerInit implements XRLayerInit {
   external factory XRQuadLayerInit({
     XRTextureType textureType = 'texture',
     XRRigidTransform? transform,
@@ -247,7 +231,7 @@ extension XRQuadLayerInitExtension on XRQuadLayerInit {
 @JS()
 @staticInterop
 @anonymous
-class XRCylinderLayerInit extends XRLayerInit {
+class XRCylinderLayerInit implements XRLayerInit {
   external factory XRCylinderLayerInit({
     XRTextureType textureType = 'texture',
     XRRigidTransform? transform,
@@ -273,7 +257,7 @@ extension XRCylinderLayerInitExtension on XRCylinderLayerInit {
 @JS()
 @staticInterop
 @anonymous
-class XREquirectLayerInit extends XRLayerInit {
+class XREquirectLayerInit implements XRLayerInit {
   external factory XREquirectLayerInit({
     XRTextureType textureType = 'texture',
     XRRigidTransform? transform,
@@ -302,7 +286,7 @@ extension XREquirectLayerInitExtension on XREquirectLayerInit {
 @JS()
 @staticInterop
 @anonymous
-class XRCubeLayerInit extends XRLayerInit {
+class XRCubeLayerInit implements XRLayerInit {
   external factory XRCubeLayerInit({DOMPointReadOnly? orientation});
 }
 
@@ -314,9 +298,7 @@ extension XRCubeLayerInitExtension on XRCubeLayerInit {
 @JS('XRWebGLBinding')
 @staticInterop
 class XRWebGLBinding {
-  external factory XRWebGLBinding();
-
-  external factory XRWebGLBinding.a1(
+  external factory XRWebGLBinding(
     XRSession session,
     XRWebGLRenderingContext context,
   );
@@ -326,31 +308,23 @@ extension XRWebGLBindingExtension on XRWebGLBinding {
   external WebGLTexture? getCameraImage(XRCamera camera);
   external XRWebGLDepthInformation? getDepthInformation(XRView view);
   external WebGLTexture? getReflectionCubeMap(XRLightProbe lightProbe);
-  external JSNumber get nativeProjectionScaleFactor;
-  external JSBoolean get usesDepthValues;
-  external XRProjectionLayer createProjectionLayer();
-  external XRProjectionLayer createProjectionLayer1(XRProjectionLayerInit init);
-  external XRQuadLayer createQuadLayer();
-  external XRQuadLayer createQuadLayer1(XRQuadLayerInit init);
-  external XRCylinderLayer createCylinderLayer();
-  external XRCylinderLayer createCylinderLayer1(XRCylinderLayerInit init);
-  external XREquirectLayer createEquirectLayer();
-  external XREquirectLayer createEquirectLayer1(XREquirectLayerInit init);
-  external XRCubeLayer createCubeLayer();
-  external XRCubeLayer createCubeLayer1(XRCubeLayerInit init);
+  external XRProjectionLayer createProjectionLayer(
+      [XRProjectionLayerInit init]);
+  external XRQuadLayer createQuadLayer([XRQuadLayerInit init]);
+  external XRCylinderLayer createCylinderLayer([XRCylinderLayerInit init]);
+  external XREquirectLayer createEquirectLayer([XREquirectLayerInit init]);
+  external XRCubeLayer createCubeLayer([XRCubeLayerInit init]);
   external XRWebGLSubImage getSubImage(
     XRCompositionLayer layer,
-    XRFrame frame,
-  );
-  external XRWebGLSubImage getSubImage1(
-    XRCompositionLayer layer,
-    XRFrame frame,
+    XRFrame frame, [
     XREye eye,
-  );
+  ]);
   external XRWebGLSubImage getViewSubImage(
     XRProjectionLayer layer,
     XRView view,
   );
+  external JSNumber get nativeProjectionScaleFactor;
+  external JSBoolean get usesDepthValues;
 }
 
 @JS()
@@ -376,7 +350,7 @@ extension XRMediaLayerInitExtension on XRMediaLayerInit {
 @JS()
 @staticInterop
 @anonymous
-class XRMediaQuadLayerInit extends XRMediaLayerInit {
+class XRMediaQuadLayerInit implements XRMediaLayerInit {
   external factory XRMediaQuadLayerInit({
     XRRigidTransform? transform,
     JSNumber? width,
@@ -396,7 +370,7 @@ extension XRMediaQuadLayerInitExtension on XRMediaQuadLayerInit {
 @JS()
 @staticInterop
 @anonymous
-class XRMediaCylinderLayerInit extends XRMediaLayerInit {
+class XRMediaCylinderLayerInit implements XRMediaLayerInit {
   external factory XRMediaCylinderLayerInit({
     XRRigidTransform? transform,
     JSNumber radius = 2.0,
@@ -419,7 +393,7 @@ extension XRMediaCylinderLayerInitExtension on XRMediaCylinderLayerInit {
 @JS()
 @staticInterop
 @anonymous
-class XRMediaEquirectLayerInit extends XRMediaLayerInit {
+class XRMediaEquirectLayerInit implements XRMediaLayerInit {
   external factory XRMediaEquirectLayerInit({
     XRRigidTransform? transform,
     JSNumber radius = 0.0,
@@ -445,35 +419,28 @@ extension XRMediaEquirectLayerInitExtension on XRMediaEquirectLayerInit {
 @JS('XRMediaBinding')
 @staticInterop
 class XRMediaBinding {
-  external factory XRMediaBinding();
-
-  external factory XRMediaBinding.a1(XRSession session);
+  external factory XRMediaBinding(XRSession session);
 }
 
 extension XRMediaBindingExtension on XRMediaBinding {
-  external XRQuadLayer createQuadLayer(HTMLVideoElement video);
-  external XRQuadLayer createQuadLayer1(
-    HTMLVideoElement video,
+  external XRQuadLayer createQuadLayer(
+    HTMLVideoElement video, [
     XRMediaQuadLayerInit init,
-  );
-  external XRCylinderLayer createCylinderLayer(HTMLVideoElement video);
-  external XRCylinderLayer createCylinderLayer1(
-    HTMLVideoElement video,
+  ]);
+  external XRCylinderLayer createCylinderLayer(
+    HTMLVideoElement video, [
     XRMediaCylinderLayerInit init,
-  );
-  external XREquirectLayer createEquirectLayer(HTMLVideoElement video);
-  external XREquirectLayer createEquirectLayer1(
-    HTMLVideoElement video,
+  ]);
+  external XREquirectLayer createEquirectLayer(
+    HTMLVideoElement video, [
     XRMediaEquirectLayerInit init,
-  );
+  ]);
 }
 
 @JS('XRLayerEvent')
 @staticInterop
-class XRLayerEvent extends Event {
-  external factory XRLayerEvent();
-
-  external factory XRLayerEvent.a1(
+class XRLayerEvent implements Event {
+  external factory XRLayerEvent(
     JSString type,
     XRLayerEventInit eventInitDict,
   );
@@ -486,7 +453,7 @@ extension XRLayerEventExtension on XRLayerEvent {
 @JS()
 @staticInterop
 @anonymous
-class XRLayerEventInit extends EventInit {
+class XRLayerEventInit implements EventInit {
   external factory XRLayerEventInit({required XRLayer layer});
 }
 

--- a/lib/src/dom/window_controls_overlay.dart
+++ b/lib/src/dom/window_controls_overlay.dart
@@ -14,23 +14,19 @@ import 'html.dart';
 
 @JS('WindowControlsOverlay')
 @staticInterop
-class WindowControlsOverlay extends EventTarget {
-  external factory WindowControlsOverlay();
-}
+class WindowControlsOverlay implements EventTarget {}
 
 extension WindowControlsOverlayExtension on WindowControlsOverlay {
-  external JSBoolean get visible;
   external DOMRect getTitlebarAreaRect();
+  external JSBoolean get visible;
   external set ongeometrychange(EventHandler value);
   external EventHandler get ongeometrychange;
 }
 
 @JS('WindowControlsOverlayGeometryChangeEvent')
 @staticInterop
-class WindowControlsOverlayGeometryChangeEvent extends Event {
-  external factory WindowControlsOverlayGeometryChangeEvent();
-
-  external factory WindowControlsOverlayGeometryChangeEvent.a1(
+class WindowControlsOverlayGeometryChangeEvent implements Event {
+  external factory WindowControlsOverlayGeometryChangeEvent(
     JSString type,
     WindowControlsOverlayGeometryChangeEventInit eventInitDict,
   );
@@ -45,7 +41,7 @@ extension WindowControlsOverlayGeometryChangeEventExtension
 @JS()
 @staticInterop
 @anonymous
-class WindowControlsOverlayGeometryChangeEventInit extends EventInit {
+class WindowControlsOverlayGeometryChangeEventInit implements EventInit {
   external factory WindowControlsOverlayGeometryChangeEventInit({
     required DOMRect titlebarAreaRect,
     JSBoolean visible = false,

--- a/lib/src/dom/window_placement.dart
+++ b/lib/src/dom/window_placement.dart
@@ -14,9 +14,7 @@ import 'html.dart';
 
 @JS('ScreenDetails')
 @staticInterop
-class ScreenDetails extends EventTarget {
-  external factory ScreenDetails();
-}
+class ScreenDetails implements EventTarget {}
 
 extension ScreenDetailsExtension on ScreenDetails {
   external JSArray get screens;
@@ -29,9 +27,7 @@ extension ScreenDetailsExtension on ScreenDetails {
 
 @JS('ScreenDetailed')
 @staticInterop
-class ScreenDetailed extends Screen {
-  external factory ScreenDetailed();
-}
+class ScreenDetailed implements Screen {}
 
 extension ScreenDetailedExtension on ScreenDetailed {
   external JSNumber get availLeft;

--- a/lib/src/dom/xhr.dart
+++ b/lib/src/dom/xhr.dart
@@ -9,7 +9,6 @@ import 'dart:js_interop';
 import 'package:js/js.dart' hide JS;
 
 import 'dom.dart';
-import 'fileapi.dart';
 import 'html.dart';
 
 typedef FormDataEntryValue = JSAny;
@@ -17,9 +16,7 @@ typedef XMLHttpRequestResponseType = JSString;
 
 @JS('XMLHttpRequestEventTarget')
 @staticInterop
-class XMLHttpRequestEventTarget extends EventTarget {
-  external factory XMLHttpRequestEventTarget();
-}
+class XMLHttpRequestEventTarget implements EventTarget {}
 
 extension XMLHttpRequestEventTargetExtension on XMLHttpRequestEventTarget {
   external set onloadstart(EventHandler value);
@@ -40,14 +37,12 @@ extension XMLHttpRequestEventTargetExtension on XMLHttpRequestEventTarget {
 
 @JS('XMLHttpRequestUpload')
 @staticInterop
-class XMLHttpRequestUpload extends XMLHttpRequestEventTarget {
-  external factory XMLHttpRequestUpload();
-}
+class XMLHttpRequestUpload implements XMLHttpRequestEventTarget {}
 
 @JS('XMLHttpRequest')
 @staticInterop
-class XMLHttpRequest extends XMLHttpRequestEventTarget {
-  external factory XMLHttpRequest.a0();
+class XMLHttpRequest implements XMLHttpRequestEventTarget {
+  external factory XMLHttpRequest();
 
   external static JSNumber get UNSENT;
   external static JSNumber get OPENED;
@@ -57,52 +52,33 @@ class XMLHttpRequest extends XMLHttpRequestEventTarget {
 }
 
 extension XMLHttpRequestExtension on XMLHttpRequest {
-  external set onreadystatechange(EventHandler value);
-  external EventHandler get onreadystatechange;
-  external JSNumber get readyState;
   external JSVoid open(
     JSString method,
-    JSString url,
-  );
-  @JS('open')
-  external JSVoid open_1_(
-    JSString method,
-    JSString url,
-    JSBoolean async,
-  );
-  @JS('open')
-  external JSVoid open_1_1(
-    JSString method,
-    JSString url,
-    JSBoolean async,
-    JSString? username,
-  );
-  @JS('open')
-  external JSVoid open_1_2(
-    JSString method,
-    JSString url,
+    JSString url, [
     JSBoolean async,
     JSString? username,
     JSString? password,
-  );
+  ]);
   external JSVoid setRequestHeader(
     JSString name,
     JSString value,
   );
+  external JSVoid send([JSAny? body]);
+  external JSVoid abort();
+  external JSString? getResponseHeader(JSString name);
+  external JSString getAllResponseHeaders();
+  external JSVoid overrideMimeType(JSString mime);
+  external set onreadystatechange(EventHandler value);
+  external EventHandler get onreadystatechange;
+  external JSNumber get readyState;
   external set timeout(JSNumber value);
   external JSNumber get timeout;
   external set withCredentials(JSBoolean value);
   external JSBoolean get withCredentials;
   external XMLHttpRequestUpload get upload;
-  external JSVoid send();
-  external JSVoid send1(JSAny? body);
-  external JSVoid abort();
   external JSString get responseURL;
   external JSNumber get status;
   external JSString get statusText;
-  external JSString? getResponseHeader(JSString name);
-  external JSString getAllResponseHeaders();
-  external JSVoid overrideMimeType(JSString mime);
   external set responseType(XMLHttpRequestResponseType value);
   external XMLHttpRequestResponseType get responseType;
   external JSAny get response;
@@ -113,66 +89,36 @@ extension XMLHttpRequestExtension on XMLHttpRequest {
 @JS('FormData')
 @staticInterop
 class FormData {
-  external factory FormData();
-
-  external factory FormData.a1();
-
-  external factory FormData.a2(HTMLFormElement form);
-
-  external factory FormData.a3(
+  external factory FormData([
     HTMLFormElement form,
     HTMLElement? submitter,
-  );
+  ]);
 }
 
 extension FormDataExtension on FormData {
   external JSVoid append(
     JSString name,
-    JSString value,
-  );
-  @JS('append')
-  external JSVoid append_1_(
-    JSString name,
-    Blob blobValue,
-  );
-  @JS('append')
-  external JSVoid append_1_1(
-    JSString name,
-    Blob blobValue,
+    JSAny blobValueOrValue, [
     JSString filename,
-  );
+  ]);
   external JSVoid delete(JSString name);
   external FormDataEntryValue? get(JSString name);
   external JSArray getAll(JSString name);
   external JSBoolean has(JSString name);
   external JSVoid set(
     JSString name,
-    JSString value,
-  );
-  @JS('set')
-  external JSVoid set_1_(
-    JSString name,
-    Blob blobValue,
-  );
-  @JS('set')
-  external JSVoid set_1_1(
-    JSString name,
-    Blob blobValue,
+    JSAny blobValueOrValue, [
     JSString filename,
-  );
+  ]);
 }
 
 @JS('ProgressEvent')
 @staticInterop
-class ProgressEvent extends Event {
-  external factory ProgressEvent();
-
-  external factory ProgressEvent.a1(JSString type);
-
-  external factory ProgressEvent.a2(
-    JSString type,
+class ProgressEvent implements Event {
+  external factory ProgressEvent(
+    JSString type, [
     ProgressEventInit eventInitDict,
-  );
+  ]);
 }
 
 extension ProgressEventExtension on ProgressEvent {
@@ -184,7 +130,7 @@ extension ProgressEventExtension on ProgressEvent {
 @JS()
 @staticInterop
 @anonymous
-class ProgressEventInit extends EventInit {
+class ProgressEventInit implements EventInit {
   external factory ProgressEventInit({
     JSBoolean lengthComputable = false,
     JSNumber loaded = 0,

--- a/tool/bindings_generator/util.dart
+++ b/tool/bindings_generator/util.dart
@@ -44,3 +44,6 @@ extension StringExt on String {
 final _snakeBit = RegExp('_[a-zA-Z]');
 
 const packageRoot = 'package:web';
+
+String capitalize(String s) =>
+    s.isEmpty ? '' : '${s[0].toUpperCase()}${s.substring(1)}';


### PR DESCRIPTION
* Adds support for optional parameters, and uses them to support overridden functions / constructors.
* Changes all uses of `extends` to `implements`. This is to avoid having to generate empty factory constructors.

Fixes #9 