### PR TITLE
Update JSArray extension to use `int` types.

### DIFF
--- a/tool/bindings_generator/generate_bindings.dart
+++ b/tool/bindings_generator/generate_bindings.dart
@@ -13,27 +13,26 @@ import 'webref_idl_api.dart';
 Future<List<String>> _generateCSSStyleDeclarations() async {
   final cssStyleDeclarations = <String>{};
   final array = objectEntries(await css.listAll().toDart as JSObject);
-  for (var i = 0; i < array.length.toDart; i++) {
-    final entry = array[i.toJS] as JSArray;
-    final data = entry[1.toJS] as CSSEntries;
+  for (var i = 0; i < array.length; i++) {
+    final entry = array[i] as JSArray;
+    final data = entry[1] as CSSEntries;
     final properties = data.properties;
     if (properties != null) {
-      for (var j = 0; j < properties.length.toDart; j++) {
-        final property = properties[j.toJS] as CSSEntry;
+      for (var j = 0; j < properties.length; j++) {
+        final property = properties[j] as CSSEntry;
         // There are thre cases for [styleDeclaration]:
         //   1) Length == 1, a single word CSS property.
         //   2) Length == 2, a kebab case property + a camel case property.
         //   3) Length == 3, webkit CSS properties.
         final styleDeclaration = property.styleDeclaration;
         if (styleDeclaration != null) {
-          final length = styleDeclaration.length.toDart.toInt();
+          final length = styleDeclaration.length;
           if (length < 0 || length > 3) {
             throw Exception('Unexpected style declaration $styleDeclaration');
           }
           // For now we ignore browser specific properties.
           if (length == 3) continue;
-          final style =
-              (styleDeclaration[(length - 1).toJS] as JSString).toDart;
+          final style = (styleDeclaration[length - 1] as JSString).toDart;
           if (style.contains('-')) {
             throw Exception('Unexpected style declaration $styleDeclaration');
           }
@@ -50,10 +49,10 @@ Future<TranslationResult> generateBindings(
   final cssStyleDeclarations = await _generateCSSStyleDeclarations();
   final translator = Translator(librarySubDir, cssStyleDeclarations);
   final array = objectEntries(await idl.parseAll().toDart as JSObject);
-  for (var i = 0; i < array.length.toDart; i++) {
-    final entry = array[i.toJS] as JSArray;
-    final shortname = (entry[0.toJS] as JSString).toDart.kebabToSnake;
-    final ast = entry[1.toJS] as JSArray;
+  for (var i = 0; i < array.length; i++) {
+    final entry = array[i] as JSArray;
+    final shortname = (entry[0] as JSString).toDart.kebabToSnake;
+    final ast = entry[1] as JSArray;
     translator.collect(shortname, ast);
   }
   return translator.translate();

--- a/tool/bindings_generator/translator.dart
+++ b/tool/bindings_generator/translator.dart
@@ -154,20 +154,20 @@ class _OverridableMember {
   final List<_Parameter> parameters = [];
 
   _OverridableMember(JSArray rawParameters) {
-    for (var i = 0; i < rawParameters.length.toDart; i++) {
-      parameters.add(_Parameter(rawParameters[i.toJS] as idl.Argument));
+    for (var i = 0; i < rawParameters.length; i++) {
+      parameters.add(_Parameter(rawParameters[i] as idl.Argument));
     }
   }
 
   void _processParameters(JSArray thoseParameters) {
     // Assume if we have extra arguments beyond what was provided in some other
     // method, that these are all optional.
-    final thatLength = thoseParameters.length.toDart.toInt();
+    final thatLength = thoseParameters.length;
     for (var i = thatLength; i < parameters.length; i++) {
       parameters[i].isOptional = true;
     }
     for (var i = 0; i < thatLength; i++) {
-      final argument = thoseParameters[i.toJS] as idl.Argument;
+      final argument = thoseParameters[i] as idl.Argument;
       if (i >= parameters.length) {
         // We assume these parameters must be optional, regardless of what the
         // IDL says.
@@ -232,8 +232,8 @@ class _PartialInterfacelike {
   }
 
   void _processMembers(JSArray nodeMembers) {
-    for (var i = 0; i < nodeMembers.length.toDart; i++) {
-      final member = nodeMembers[i.toJS] as idl.Member;
+    for (var i = 0; i < nodeMembers.length; i++) {
+      final member = nodeMembers[i] as idl.Member;
       final type = member.type.toDart;
       switch (type) {
         case 'constructor':
@@ -341,8 +341,8 @@ class Translator {
     assert(!_libraries.containsKey(libraryPath));
     final library = _Library(this, '$packageRoot/$libraryPath');
     _libraries[libraryPath] = library;
-    for (var i = 0; i < ast.length.toDart; i++) {
-      library.add(ast[i.toJS] as idl.Node);
+    for (var i = 0; i < ast.length; i++) {
+      library.add(ast[i] as idl.Node);
     }
   }
 

--- a/tool/bindings_generator/util.dart
+++ b/tool/bindings_generator/util.dart
@@ -11,8 +11,8 @@ import 'filesystem_api.dart';
 external JSArray objectEntries(JSObject o);
 
 extension JSArrayExtension on JSArray {
-  external JSAny? operator [](JSNumber i);
-  external JSNumber get length;
+  external JSAny? operator [](int i);
+  external int get length;
 }
 
 extension JSStringHelpers on JSString? {


### PR DESCRIPTION
This adapts the generator to work with latest Dart SDK. Recently the SDK removed `JSNumber.toDart`. I could have replaced the calls with `.toDartInt`, but instead, I switched the `JSArray.length` to specify an `int` return value. In the process I also updated the indexing operator to accept `int` values, and remove the need to explicitly convert indices to a JSNumber as well.
