### PR TITLE
Refactor typeofEquals usage and remove isInstanceOfDomType

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: ${{ matrix.sdk }}
+          flavor: ${{ matrix.flavor }}
       - id: install
         name: Install dependencies
         run: dart pub get
@@ -37,9 +38,10 @@ jobs:
         run: dart analyze --fatal-infos
         if: always() && steps.install.outcome == 'success'
 
-  # Run tests on a matrix consisting of two dimensions:
+  # Run tests on a matrix consisting of three dimensions:
   # 1. OS: ubuntu-latest, (macos-latest, windows-latest)
-  # 2. release channel: dev
+  # 2. release channel: main, dev
+  # 3. flavor: raw
   test:
     needs: analyze
     runs-on: ${{ matrix.os }}
@@ -55,6 +57,7 @@ jobs:
       - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: ${{ matrix.sdk }}
+          flavor: ${{ matrix.flavor }}
       - id: install
         name: Install dependencies
         run: dart pub get

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.2-beta
+
+- Updates SDK version minimum to 3.2.0-194.0.dev.
+- Removes `isInstanceOfDomType` as `dart:js_interop` now exposes
+  `instanceOfString`.
+
 ## 0.2.1-beta
 
 - `helpers.dart`

--- a/lib/helpers.dart
+++ b/lib/helpers.dart
@@ -51,10 +51,3 @@ external JSFunction get _audioConstructor;
 HTMLAudioElement createAudioElement() => _audioConstructor.callAsConstructor();
 
 Element? querySelector(String selectors) => document.querySelector(selectors);
-
-bool isInstanceOfDomType(JSObject? o, String domType) {
-  if (o == null) return false;
-  final constructor = globalContext[domType];
-  if (constructor == null) return false;
-  return o.instanceof(constructor as JSFunction).toDart;
-}

--- a/lib/src/helpers/events/providers.dart
+++ b/lib/src/helpers/events/providers.dart
@@ -612,7 +612,7 @@ String _determineTransitionEventType(EventTarget e) {
 }
 
 String _determineVisibilityChangeEventType(EventTarget e) {
-  if (e.typeofEquals('undefined'.toJS).toDart) {
+  if (e.typeofEquals('undefined')) {
     return 'visibilitychange';
   } else if (e.hasProperty('mozHidden'.toJS).toDart) {
     return 'mozvisibilitychange';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: web
 description: >-
   Lightweight DOM and JS bindings built around JS static interop.
-version: 0.2.1-beta
+version: 0.2.2-beta
 
 repository: https://github.com/dart-lang/web
 
 environment:
-  sdk: ">=3.2.0-157.0.dev <4.0.0"
+  sdk: ">=3.2.0-194.0.dev <4.0.0"
 
 dev_dependencies:
   args: ^2.4.0

--- a/test/helpers_test.dart
+++ b/test/helpers_test.dart
@@ -5,14 +5,16 @@
 @TestOn('browser')
 library;
 
+import 'dart:js_interop';
+
 import 'package:test/test.dart';
 import 'package:web/helpers.dart';
 
 void main() {
-  test('isInstanceOfDomType', () {
+  test('instanceOfString works with package:web types', () {
     final div = document.createElement('div');
 
-    expect(isInstanceOfDomType(div, 'bob'), false);
-    expect(isInstanceOfDomType(div, 'HTMLDivElement'), true);
+    expect(div.instanceOfString('bob'), false);
+    expect(div.instanceOfString('HTMLDivElement'), true);
   });
 }


### PR DESCRIPTION
Closes https://github.com/dart-lang/web/issues/77

typeofEquals now takes a String and returns a bool, and instanceOfString is the canonical replacement for isInstanceOfDomType. Removes now unneeded test as well. Updates min SDK version.