### PR TITLE
Fix any nullability and refactor typing model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.3.1-dev
 
 - Updated types to account for union types.
+- Fixed issue where all `JSAny`s were treated as nullable.
+- Changed `JSVoid` to `void`.
 
 ## 0.3.0
 

--- a/lib/src/dom/anchors.dart
+++ b/lib/src/dom/anchors.dart
@@ -12,7 +12,7 @@ class XRAnchor implements JSObject {}
 
 extension XRAnchorExtension on XRAnchor {
   external JSPromise requestPersistentHandle();
-  external JSVoid delete();
+  external void delete();
   external XRSpace get anchorSpace;
 }
 

--- a/lib/src/dom/angle_instanced_arrays.dart
+++ b/lib/src/dom/angle_instanced_arrays.dart
@@ -13,20 +13,20 @@ class ANGLE_instanced_arrays implements JSObject {
 }
 
 extension ANGLEInstancedArraysExtension on ANGLE_instanced_arrays {
-  external JSVoid drawArraysInstancedANGLE(
+  external void drawArraysInstancedANGLE(
     GLenum mode,
     GLint first,
     GLsizei count,
     GLsizei primcount,
   );
-  external JSVoid drawElementsInstancedANGLE(
+  external void drawElementsInstancedANGLE(
     GLenum mode,
     GLsizei count,
     GLenum type,
     GLintptr offset,
     GLsizei primcount,
   );
-  external JSVoid vertexAttribDivisorANGLE(
+  external void vertexAttribDivisorANGLE(
     GLuint index,
     GLuint divisor,
   );

--- a/lib/src/dom/background_fetch.dart
+++ b/lib/src/dom/background_fetch.dart
@@ -19,7 +19,7 @@ class BackgroundFetchManager implements JSObject {}
 extension BackgroundFetchManagerExtension on BackgroundFetchManager {
   external JSPromise fetch(
     String id,
-    JSAny? requests, [
+    JSAny requests, [
     BackgroundFetchOptions options,
   ]);
   external JSPromise get(String id);

--- a/lib/src/dom/clipboard_apis.dart
+++ b/lib/src/dom/clipboard_apis.dart
@@ -41,7 +41,7 @@ extension ClipboardEventExtension on ClipboardEvent {
 @staticInterop
 class ClipboardItem implements JSObject {
   external factory ClipboardItem(
-    JSAny? items, [
+    JSAny items, [
     ClipboardItemOptions options,
   ]);
 

--- a/lib/src/dom/compute_pressure.dart
+++ b/lib/src/dom/compute_pressure.dart
@@ -23,8 +23,8 @@ class PressureObserver implements JSObject {
 
 extension PressureObserverExtension on PressureObserver {
   external JSPromise observe(PressureSource source);
-  external JSVoid unobserve(PressureSource source);
-  external JSVoid disconnect();
+  external void unobserve(PressureSource source);
+  external void disconnect();
   external JSArray takeRecords();
 }
 

--- a/lib/src/dom/console.dart
+++ b/lib/src/dom/console.dart
@@ -13,35 +13,35 @@ abstract class $Console {}
 
 extension $ConsoleExtension on $Console {
   @JS('assert')
-  external JSVoid assert_(
+  external void assert_(
     JSAny? data, [
     bool condition,
   ]);
-  external JSVoid clear();
-  external JSVoid debug(JSAny? data);
-  external JSVoid error(JSAny? data);
-  external JSVoid info(JSAny? data);
-  external JSVoid log(JSAny? data);
-  external JSVoid table([
+  external void clear();
+  external void debug(JSAny? data);
+  external void error(JSAny? data);
+  external void info(JSAny? data);
+  external void log(JSAny? data);
+  external void table([
     JSAny? tabularData,
     JSArray properties,
   ]);
-  external JSVoid trace(JSAny? data);
-  external JSVoid warn(JSAny? data);
-  external JSVoid dir([
+  external void trace(JSAny? data);
+  external void warn(JSAny? data);
+  external void dir([
     JSAny? item,
     JSObject? options,
   ]);
-  external JSVoid dirxml(JSAny? data);
-  external JSVoid count([String label]);
-  external JSVoid countReset([String label]);
-  external JSVoid group(JSAny? data);
-  external JSVoid groupCollapsed(JSAny? data);
-  external JSVoid groupEnd();
-  external JSVoid time([String label]);
-  external JSVoid timeLog(
+  external void dirxml(JSAny? data);
+  external void count([String label]);
+  external void countReset([String label]);
+  external void group(JSAny? data);
+  external void groupCollapsed(JSAny? data);
+  external void groupEnd();
+  external void time([String label]);
+  external void timeLog(
     JSAny? data, [
     String label,
   ]);
-  external JSVoid timeEnd([String label]);
+  external void timeEnd([String label]);
 }

--- a/lib/src/dom/cookie_store.dart
+++ b/lib/src/dom/cookie_store.dart
@@ -17,13 +17,13 @@ typedef CookieSameSite = String;
 class CookieStore implements EventTarget {}
 
 extension CookieStoreExtension on CookieStore {
-  external JSPromise get([JSAny? nameOrOptions]);
-  external JSPromise getAll([JSAny? nameOrOptions]);
+  external JSPromise get([JSAny nameOrOptions]);
+  external JSPromise getAll([JSAny nameOrOptions]);
   external JSPromise set(
-    JSAny? nameOrOptions, [
+    JSAny nameOrOptions, [
     String value,
   ]);
-  external JSPromise delete(JSAny? nameOrOptions);
+  external JSPromise delete(JSAny nameOrOptions);
   external set onchange(EventHandler value);
   external EventHandler get onchange;
 }

--- a/lib/src/dom/css_animation_worklet.dart
+++ b/lib/src/dom/css_animation_worklet.dart
@@ -14,7 +14,7 @@ typedef AnimatorInstanceConstructor = JSFunction;
 class AnimationWorkletGlobalScope implements WorkletGlobalScope {}
 
 extension AnimationWorkletGlobalScopeExtension on AnimationWorkletGlobalScope {
-  external JSVoid registerAnimator(
+  external void registerAnimator(
     String name,
     AnimatorInstanceConstructor animatorCtor,
   );

--- a/lib/src/dom/css_animations.dart
+++ b/lib/src/dom/css_animations.dart
@@ -57,8 +57,8 @@ extension CSSKeyframeRuleExtension on CSSKeyframeRule {
 class CSSKeyframesRule implements CSSRule {}
 
 extension CSSKeyframesRuleExtension on CSSKeyframesRule {
-  external JSVoid appendRule(String rule);
-  external JSVoid deleteRule(String select);
+  external void appendRule(String rule);
+  external void deleteRule(String select);
   external CSSKeyframeRule? findRule(String select);
   external set name(String value);
   external String get name;

--- a/lib/src/dom/css_font_loading.dart
+++ b/lib/src/dom/css_font_loading.dart
@@ -57,7 +57,7 @@ extension FontFaceDescriptorsExtension on FontFaceDescriptors {
 class FontFace implements JSObject {
   external factory FontFace(
     String family,
-    JSAny? source, [
+    JSAny source, [
     FontFaceDescriptors descriptors,
   ]);
 }
@@ -167,7 +167,7 @@ class FontFaceSet implements EventTarget {
 extension FontFaceSetExtension on FontFaceSet {
   external FontFaceSet add(FontFace font);
   external bool delete(FontFace font);
-  external JSVoid clear();
+  external void clear();
   external JSPromise load(
     String font, [
     String text,

--- a/lib/src/dom/css_fonts.dart
+++ b/lib/src/dom/css_fonts.dart
@@ -34,9 +34,9 @@ extension CSSFontFeatureValuesRuleExtension on CSSFontFeatureValuesRule {
 class CSSFontFeatureValuesMap implements JSObject {}
 
 extension CSSFontFeatureValuesMapExtension on CSSFontFeatureValuesMap {
-  external JSVoid set(
+  external void set(
     String featureValueName,
-    JSAny? values,
+    JSAny values,
   );
 }
 

--- a/lib/src/dom/css_layout_api.dart
+++ b/lib/src/dom/css_layout_api.dart
@@ -18,7 +18,7 @@ typedef BreakType = String;
 class LayoutWorkletGlobalScope implements WorkletGlobalScope {}
 
 extension LayoutWorkletGlobalScopeExtension on LayoutWorkletGlobalScope {
-  external JSVoid registerLayout(
+  external void registerLayout(
     String name,
     VoidFunction layoutCtor,
   );

--- a/lib/src/dom/css_paint_api.dart
+++ b/lib/src/dom/css_paint_api.dart
@@ -12,7 +12,7 @@ import 'webidl.dart';
 class PaintWorkletGlobalScope implements WorkletGlobalScope {}
 
 extension PaintWorkletGlobalScopeExtension on PaintWorkletGlobalScope {
-  external JSVoid registerPaint(
+  external void registerPaint(
     String name,
     VoidFunction paintCtor,
   );

--- a/lib/src/dom/css_parser_api.dart
+++ b/lib/src/dom/css_parser_api.dart
@@ -4,8 +4,8 @@
 
 import 'dart:js_interop';
 
-typedef CSSStringSource = JSAny?;
-typedef CSSToken = JSAny?;
+typedef CSSStringSource = JSAny;
+typedef CSSToken = JSAny;
 
 @JS()
 @staticInterop

--- a/lib/src/dom/css_typed_om.dart
+++ b/lib/src/dom/css_typed_om.dart
@@ -6,14 +6,14 @@ import 'dart:js_interop';
 
 import 'geometry.dart';
 
-typedef CSSUnparsedSegment = JSAny?;
-typedef CSSKeywordish = JSAny?;
-typedef CSSNumberish = JSAny?;
-typedef CSSPerspectiveValue = JSAny?;
-typedef CSSColorRGBComp = JSAny?;
-typedef CSSColorPercent = JSAny?;
-typedef CSSColorNumber = JSAny?;
-typedef CSSColorAngle = JSAny?;
+typedef CSSUnparsedSegment = JSAny;
+typedef CSSKeywordish = JSAny;
+typedef CSSNumberish = JSAny;
+typedef CSSPerspectiveValue = JSAny;
+typedef CSSColorRGBComp = JSAny;
+typedef CSSColorPercent = JSAny;
+typedef CSSColorNumber = JSAny;
+typedef CSSColorAngle = JSAny;
 typedef CSSNumericBaseType = String;
 typedef CSSMathOperator = String;
 
@@ -46,16 +46,16 @@ extension StylePropertyMapReadOnlyExtension on StylePropertyMapReadOnly {
 class StylePropertyMap implements StylePropertyMapReadOnly {}
 
 extension StylePropertyMapExtension on StylePropertyMap {
-  external JSVoid set(
+  external void set(
     String property,
-    JSAny? values,
+    JSAny values,
   );
-  external JSVoid append(
+  external void append(
     String property,
-    JSAny? values,
+    JSAny values,
   );
-  external JSVoid delete(String property);
-  external JSVoid clear();
+  external void delete(String property);
+  external void clear();
 }
 
 @JS('CSSUnparsedValue')
@@ -300,7 +300,7 @@ extension CSSTranslateExtension on CSSTranslate {
 @staticInterop
 class CSSRotate implements CSSTransformComponent {
   external factory CSSRotate(
-    JSAny? angleOrX, [
+    JSAny angleOrX, [
     CSSNumberish y,
     CSSNumberish z,
     CSSNumericValue angle,

--- a/lib/src/dom/css_view_transitions.dart
+++ b/lib/src/dom/css_view_transitions.dart
@@ -11,7 +11,7 @@ typedef UpdateCallback = JSFunction;
 class ViewTransition implements JSObject {}
 
 extension ViewTransitionExtension on ViewTransition {
-  external JSVoid skipTransition();
+  external void skipTransition();
   external JSPromise get updateCallbackDone;
   external JSPromise get ready;
   external JSPromise get finished;

--- a/lib/src/dom/cssom.dart
+++ b/lib/src/dom/cssom.dart
@@ -16,8 +16,8 @@ class MediaList implements JSObject {}
 
 extension MediaListExtension on MediaList {
   external String? item(int index);
-  external JSVoid appendMedium(String medium);
-  external JSVoid deleteMedium(String medium);
+  external void appendMedium(String medium);
+  external void deleteMedium(String medium);
   external set mediaText(String value);
   external String get mediaText;
   external int get length;
@@ -49,15 +49,15 @@ extension CSSStyleSheetExtension on CSSStyleSheet {
     String rule, [
     int index,
   ]);
-  external JSVoid deleteRule(int index);
+  external void deleteRule(int index);
   external JSPromise replace(String text);
-  external JSVoid replaceSync(String text);
+  external void replaceSync(String text);
   external int addRule([
     String selector,
     String style,
     int index,
   ]);
-  external JSVoid removeRule([int index]);
+  external void removeRule([int index]);
   external CSSRule? get ownerRule;
   external CSSRuleList get cssRules;
   external CSSRuleList get rules;
@@ -69,7 +69,7 @@ extension CSSStyleSheetExtension on CSSStyleSheet {
 class CSSStyleSheetInit implements JSObject {
   external factory CSSStyleSheetInit({
     String baseURL,
-    JSAny? media,
+    JSAny media,
     bool disabled,
   });
 }
@@ -77,8 +77,8 @@ class CSSStyleSheetInit implements JSObject {
 extension CSSStyleSheetInitExtension on CSSStyleSheetInit {
   external set baseURL(String value);
   external String get baseURL;
-  external set media(JSAny? value);
-  external JSAny? get media;
+  external set media(JSAny value);
+  external JSAny get media;
   external set disabled(bool value);
   external bool get disabled;
 }
@@ -167,7 +167,7 @@ extension CSSGroupingRuleExtension on CSSGroupingRule {
     String rule, [
     int index,
   ]);
-  external JSVoid deleteRule(int index);
+  external void deleteRule(int index);
   external CSSRuleList get cssRules;
 }
 
@@ -207,7 +207,7 @@ extension CSSStyleDeclarationExtension on CSSStyleDeclaration {
   external String item(int index);
   external String getPropertyValue(String property);
   external String getPropertyPriority(String property);
-  external JSVoid setProperty(
+  external void setProperty(
     String property,
     String value, [
     String priority,
@@ -1521,7 +1521,7 @@ extension $CSSExtension on $CSS {
   external CSSToken parseValue(String css);
   external JSArray parseValueList(String css);
   external JSArray parseCommaValueList(String css);
-  external JSVoid registerProperty(PropertyDefinition definition);
+  external void registerProperty(PropertyDefinition definition);
   external CSSUnitValue number(num value);
   external CSSUnitValue percent(num value);
   external CSSUnitValue cap(num value);

--- a/lib/src/dom/cssom_view.dart
+++ b/lib/src/dom/cssom_view.dart
@@ -48,8 +48,8 @@ extension ScrollToOptionsExtension on ScrollToOptions {
 class MediaQueryList implements EventTarget {}
 
 extension MediaQueryListExtension on MediaQueryList {
-  external JSVoid addListener(EventListener? callback);
-  external JSVoid removeListener(EventListener? callback);
+  external void addListener(EventListener? callback);
+  external void removeListener(EventListener? callback);
   external String get media;
   external bool get matches;
   external set onchange(EventHandler value);

--- a/lib/src/dom/custom_state_pseudo_class.dart
+++ b/lib/src/dom/custom_state_pseudo_class.dart
@@ -9,5 +9,5 @@ import 'dart:js_interop';
 class CustomStateSet implements JSObject {}
 
 extension CustomStateSetExtension on CustomStateSet {
-  external JSVoid add(String value);
+  external void add(String value);
 }

--- a/lib/src/dom/dom.dart
+++ b/lib/src/dom/dom.dart
@@ -49,10 +49,10 @@ class Event implements JSObject {
 
 extension EventExtension on Event {
   external JSArray composedPath();
-  external JSVoid stopPropagation();
-  external JSVoid stopImmediatePropagation();
-  external JSVoid preventDefault();
-  external JSVoid initEvent(
+  external void stopPropagation();
+  external void stopImmediatePropagation();
+  external void preventDefault();
+  external void initEvent(
     String type, [
     bool bubbles,
     bool cancelable,
@@ -104,7 +104,7 @@ class CustomEvent implements Event {
 }
 
 extension CustomEventExtension on CustomEvent {
-  external JSVoid initCustomEvent(
+  external void initCustomEvent(
     String type, [
     bool bubbles,
     bool cancelable,
@@ -132,15 +132,15 @@ class EventTarget implements JSObject {
 }
 
 extension EventTargetExtension on EventTarget {
-  external JSVoid addEventListener(
+  external void addEventListener(
     String type,
     EventListener? callback, [
-    JSAny? options,
+    JSAny options,
   ]);
-  external JSVoid removeEventListener(
+  external void removeEventListener(
     String type,
     EventListener? callback, [
-    JSAny? options,
+    JSAny options,
   ]);
   external bool dispatchEvent(Event event);
 }
@@ -184,7 +184,7 @@ class AbortController implements JSObject {
 }
 
 extension AbortControllerExtension on AbortController {
-  external JSVoid abort([JSAny? reason]);
+  external void abort([JSAny? reason]);
   external AbortSignal get signal;
 }
 
@@ -197,7 +197,7 @@ class AbortSignal implements EventTarget {
 }
 
 extension AbortSignalExtension on AbortSignal {
-  external JSVoid throwIfAborted();
+  external void throwIfAborted();
   external bool get aborted;
   external JSAny? get reason;
   external set onabort(EventHandler value);
@@ -232,9 +232,9 @@ extension DocumentOrShadowRootExtension on DocumentOrShadowRoot {
 class ParentNode implements JSObject {}
 
 extension ParentNodeExtension on ParentNode {
-  external JSVoid prepend(JSAny? nodes);
-  external JSVoid append(JSAny? nodes);
-  external JSVoid replaceChildren(JSAny? nodes);
+  external void prepend(JSAny nodes);
+  external void append(JSAny nodes);
+  external void replaceChildren(JSAny nodes);
   external Element? querySelector(String selectors);
   external NodeList querySelectorAll(String selectors);
   external HTMLCollection get children;
@@ -257,10 +257,10 @@ extension NonDocumentTypeChildNodeExtension on NonDocumentTypeChildNode {
 class ChildNode implements JSObject {}
 
 extension ChildNodeExtension on ChildNode {
-  external JSVoid before(JSAny? nodes);
-  external JSVoid after(JSAny? nodes);
-  external JSVoid replaceWith(JSAny? nodes);
-  external JSVoid remove();
+  external void before(JSAny nodes);
+  external void after(JSAny nodes);
+  external void replaceWith(JSAny nodes);
+  external void remove();
 }
 
 @JS('Slottable')
@@ -297,11 +297,11 @@ class MutationObserver implements JSObject {
 }
 
 extension MutationObserverExtension on MutationObserver {
-  external JSVoid observe(
+  external void observe(
     Node target, [
     MutationObserverInit options,
   ]);
-  external JSVoid disconnect();
+  external void disconnect();
   external JSArray takeRecords();
 }
 
@@ -379,7 +379,7 @@ class Node implements EventTarget {
 extension NodeExtension on Node {
   external Node getRootNode([GetRootNodeOptions options]);
   external bool hasChildNodes();
-  external JSVoid normalize();
+  external void normalize();
   external Node cloneNode([bool deep]);
   external bool isEqualNode(Node? otherNode);
   external bool isSameNode(Node? otherNode);
@@ -468,12 +468,12 @@ extension DocumentExtension on Document {
   external HTMLCollection getElementsByClassName(String classNames);
   external Element createElement(
     String localName, [
-    JSAny? options,
+    JSAny options,
   ]);
   external Element createElementNS(
     String? namespace,
     String qualifiedName, [
-    JSAny? options,
+    JSAny options,
   ]);
   external DocumentFragment createDocumentFragment();
   external Text createTextNode(String data);
@@ -517,9 +517,9 @@ extension DocumentExtension on Document {
     String nameOrUnused2,
     String features,
   ]);
-  external JSVoid close();
-  external JSVoid write(String text);
-  external JSVoid writeln(String text);
+  external void close();
+  external void write(String text);
+  external void writeln(String text);
   external bool hasFocus();
   external bool execCommand(
     String commandId, [
@@ -531,11 +531,11 @@ extension DocumentExtension on Document {
   external bool queryCommandState(String commandId);
   external bool queryCommandSupported(String commandId);
   external String queryCommandValue(String commandId);
-  external JSVoid clear();
-  external JSVoid captureEvents();
-  external JSVoid releaseEvents();
+  external void clear();
+  external void captureEvents();
+  external void releaseEvents();
   external JSPromise exitPictureInPicture();
-  external JSVoid exitPointerLock();
+  external void exitPointerLock();
   external JSPromise requestStorageAccessFor(String requestedOrigin);
   external Selection? getSelection();
   external JSPromise hasStorageAccess();
@@ -705,7 +705,7 @@ class Element
         Animatable {}
 
 extension ElementExtension on Element {
-  external JSVoid insertAdjacentHTML(
+  external void insertAdjacentHTML(
     String position,
     String text,
   );
@@ -720,17 +720,17 @@ extension ElementExtension on Element {
   external DOMRectList getClientRects();
   external DOMRect getBoundingClientRect();
   external bool checkVisibility([CheckVisibilityOptions options]);
-  external JSVoid scrollIntoView([JSAny? arg]);
-  external JSVoid scroll([
-    JSAny? optionsOrX,
+  external void scrollIntoView([JSAny arg]);
+  external void scroll([
+    JSAny optionsOrX,
     num y,
   ]);
-  external JSVoid scrollTo([
-    JSAny? optionsOrX,
+  external void scrollTo([
+    JSAny optionsOrX,
     num y,
   ]);
-  external JSVoid scrollBy([
-    JSAny? optionsOrX,
+  external void scrollBy([
+    JSAny optionsOrX,
     num y,
   ]);
   external bool hasAttributes();
@@ -740,17 +740,17 @@ extension ElementExtension on Element {
     String? namespace,
     String localName,
   );
-  external JSVoid setAttribute(
+  external void setAttribute(
     String qualifiedName,
     String value,
   );
-  external JSVoid setAttributeNS(
+  external void setAttributeNS(
     String? namespace,
     String qualifiedName,
     String value,
   );
-  external JSVoid removeAttribute(String qualifiedName);
-  external JSVoid removeAttributeNS(
+  external void removeAttribute(String qualifiedName);
+  external void removeAttributeNS(
     String? namespace,
     String localName,
   );
@@ -785,16 +785,16 @@ extension ElementExtension on Element {
     String where,
     Element element,
   );
-  external JSVoid insertAdjacentText(
+  external void insertAdjacentText(
     String where,
     String data,
   );
   external JSPromise requestFullscreen([FullscreenOptions options]);
-  external JSVoid setPointerCapture(int pointerId);
-  external JSVoid releasePointerCapture(int pointerId);
+  external void setPointerCapture(int pointerId);
+  external void releasePointerCapture(int pointerId);
   external bool hasPointerCapture(int pointerId);
-  external JSVoid requestPointerLock();
-  external JSVoid setHTML(
+  external void requestPointerLock();
+  external void setHTML(
     String input, [
     SetHTMLOptions options,
   ]);
@@ -897,16 +897,16 @@ extension CharacterDataExtension on CharacterData {
     int offset,
     int count,
   );
-  external JSVoid appendData(String data);
-  external JSVoid insertData(
+  external void appendData(String data);
+  external void insertData(
     int offset,
     String data,
   );
-  external JSVoid deleteData(
+  external void deleteData(
     int offset,
     int count,
   );
-  external JSVoid replaceData(
+  external void replaceData(
     int offset,
     int count,
     String data,
@@ -1001,32 +1001,32 @@ extension RangeExtension on Range {
   external DocumentFragment createContextualFragment(String fragment);
   external DOMRectList getClientRects();
   external DOMRect getBoundingClientRect();
-  external JSVoid setStart(
+  external void setStart(
     Node node,
     int offset,
   );
-  external JSVoid setEnd(
+  external void setEnd(
     Node node,
     int offset,
   );
-  external JSVoid setStartBefore(Node node);
-  external JSVoid setStartAfter(Node node);
-  external JSVoid setEndBefore(Node node);
-  external JSVoid setEndAfter(Node node);
-  external JSVoid collapse([bool toStart]);
-  external JSVoid selectNode(Node node);
-  external JSVoid selectNodeContents(Node node);
+  external void setStartBefore(Node node);
+  external void setStartAfter(Node node);
+  external void setEndBefore(Node node);
+  external void setEndAfter(Node node);
+  external void collapse([bool toStart]);
+  external void selectNode(Node node);
+  external void selectNodeContents(Node node);
   external int compareBoundaryPoints(
     int how,
     Range sourceRange,
   );
-  external JSVoid deleteContents();
+  external void deleteContents();
   external DocumentFragment extractContents();
   external DocumentFragment cloneContents();
-  external JSVoid insertNode(Node node);
-  external JSVoid surroundContents(Node newParent);
+  external void insertNode(Node node);
+  external void surroundContents(Node newParent);
   external Range cloneRange();
-  external JSVoid detach();
+  external void detach();
   external bool isPointInRange(
     Node node,
     int offset,
@@ -1046,7 +1046,7 @@ class NodeIterator implements JSObject {}
 extension NodeIteratorExtension on NodeIterator {
   external Node? nextNode();
   external Node? previousNode();
-  external JSVoid detach();
+  external void detach();
   external Node get root;
   external Node get referenceNode;
   external bool get pointerBeforeReferenceNode;
@@ -1080,8 +1080,8 @@ class DOMTokenList implements JSObject {}
 extension DOMTokenListExtension on DOMTokenList {
   external String? item(int index);
   external bool contains(String token);
-  external JSVoid add(String tokens);
-  external JSVoid remove(String tokens);
+  external void add(String tokens);
+  external void remove(String tokens);
   external bool toggle(
     String token, [
     bool force,
@@ -1167,13 +1167,13 @@ class XSLTProcessor implements JSObject {
 }
 
 extension XSLTProcessorExtension on XSLTProcessor {
-  external JSVoid importStylesheet(Node style);
+  external void importStylesheet(Node style);
   external DocumentFragment transformToFragment(
     Node source,
     Document output,
   );
   external Document transformToDocument(Node source);
-  external JSVoid setParameter(
+  external void setParameter(
     String namespaceURI,
     String localName,
     JSAny? value,
@@ -1182,10 +1182,10 @@ extension XSLTProcessorExtension on XSLTProcessor {
     String namespaceURI,
     String localName,
   );
-  external JSVoid removeParameter(
+  external void removeParameter(
     String namespaceURI,
     String localName,
   );
-  external JSVoid clearParameters();
-  external JSVoid reset();
+  external void clearParameters();
+  external void reset();
 }

--- a/lib/src/dom/edit_context.dart
+++ b/lib/src/dom/edit_context.dart
@@ -38,18 +38,18 @@ class EditContext implements EventTarget {
 }
 
 extension EditContextExtension on EditContext {
-  external JSVoid updateText(
+  external void updateText(
     int rangeStart,
     int rangeEnd,
     String text,
   );
-  external JSVoid updateSelection(
+  external void updateSelection(
     int start,
     int end,
   );
-  external JSVoid updateControlBounds(DOMRect controlBounds);
-  external JSVoid updateSelectionBounds(DOMRect selectionBounds);
-  external JSVoid updateCharacterBounds(
+  external void updateControlBounds(DOMRect controlBounds);
+  external void updateSelectionBounds(DOMRect selectionBounds);
+  external void updateCharacterBounds(
     int rangeStart,
     JSArray characterBounds,
   );

--- a/lib/src/dom/entries_api.dart
+++ b/lib/src/dom/entries_api.dart
@@ -14,7 +14,7 @@ typedef FileCallback = JSFunction;
 class FileSystemEntry implements JSObject {}
 
 extension FileSystemEntryExtension on FileSystemEntry {
-  external JSVoid getParent([
+  external void getParent([
     FileSystemEntryCallback successCallback,
     ErrorCallback errorCallback,
   ]);
@@ -31,13 +31,13 @@ class FileSystemDirectoryEntry implements FileSystemEntry {}
 
 extension FileSystemDirectoryEntryExtension on FileSystemDirectoryEntry {
   external FileSystemDirectoryReader createReader();
-  external JSVoid getFile([
+  external void getFile([
     String? path,
     FileSystemFlags options,
     FileSystemEntryCallback successCallback,
     ErrorCallback errorCallback,
   ]);
-  external JSVoid getDirectory([
+  external void getDirectory([
     String? path,
     FileSystemFlags options,
     FileSystemEntryCallback successCallback,
@@ -67,7 +67,7 @@ extension FileSystemFlagsExtension on FileSystemFlags {
 class FileSystemDirectoryReader implements JSObject {}
 
 extension FileSystemDirectoryReaderExtension on FileSystemDirectoryReader {
-  external JSVoid readEntries(
+  external void readEntries(
     FileSystemEntriesCallback successCallback, [
     ErrorCallback errorCallback,
   ]);
@@ -78,7 +78,7 @@ extension FileSystemDirectoryReaderExtension on FileSystemDirectoryReader {
 class FileSystemFileEntry implements FileSystemEntry {}
 
 extension FileSystemFileEntryExtension on FileSystemFileEntry {
-  external JSVoid file(
+  external void file(
     FileCallback successCallback, [
     ErrorCallback errorCallback,
   ]);

--- a/lib/src/dom/ext_disjoint_timer_query.dart
+++ b/lib/src/dom/ext_disjoint_timer_query.dart
@@ -26,14 +26,14 @@ class EXT_disjoint_timer_query implements JSObject {
 
 extension EXTDisjointTimerQueryExtension on EXT_disjoint_timer_query {
   external WebGLTimerQueryEXT? createQueryEXT();
-  external JSVoid deleteQueryEXT(WebGLTimerQueryEXT? query);
+  external void deleteQueryEXT(WebGLTimerQueryEXT? query);
   external bool isQueryEXT(WebGLTimerQueryEXT? query);
-  external JSVoid beginQueryEXT(
+  external void beginQueryEXT(
     GLenum target,
     WebGLTimerQueryEXT query,
   );
-  external JSVoid endQueryEXT(GLenum target);
-  external JSVoid queryCounterEXT(
+  external void endQueryEXT(GLenum target);
+  external void queryCounterEXT(
     WebGLTimerQueryEXT query,
     GLenum target,
   );

--- a/lib/src/dom/ext_disjoint_timer_query_webgl2.dart
+++ b/lib/src/dom/ext_disjoint_timer_query_webgl2.dart
@@ -18,7 +18,7 @@ class EXT_disjoint_timer_query_webgl2 implements JSObject {
 
 extension EXTDisjointTimerQueryWebgl2Extension
     on EXT_disjoint_timer_query_webgl2 {
-  external JSVoid queryCounterEXT(
+  external void queryCounterEXT(
     WebGLQuery query,
     GLenum target,
   );

--- a/lib/src/dom/fenced_frame.dart
+++ b/lib/src/dom/fenced_frame.dart
@@ -6,10 +6,10 @@ import 'dart:js_interop';
 
 import 'html.dart';
 
-typedef FencedFrameConfigSize = JSAny?;
+typedef FencedFrameConfigSize = JSAny;
 typedef FencedFrameConfigURL = String;
-typedef UrnOrConfig = JSAny?;
-typedef ReportEventType = JSAny?;
+typedef UrnOrConfig = JSAny;
+typedef ReportEventType = JSAny;
 typedef OpaqueProperty = String;
 typedef FenceReportingDestination = String;
 
@@ -35,7 +35,7 @@ extension HTMLFencedFrameElementExtension on HTMLFencedFrameElement {
 class FencedFrameConfig implements JSObject {}
 
 extension FencedFrameConfigExtension on FencedFrameConfig {
-  external JSVoid setSharedStorageContext(String contextString);
+  external void setSharedStorageContext(String contextString);
   external FencedFrameConfigSize? get containerWidth;
   external FencedFrameConfigSize? get containerHeight;
   external FencedFrameConfigSize? get contentWidth;
@@ -73,7 +73,7 @@ extension FenceEventExtension on FenceEvent {
 class Fence implements JSObject {}
 
 extension FenceExtension on Fence {
-  external JSVoid reportEvent([ReportEventType event]);
-  external JSVoid setReportEventDataForAutomaticBeacons([FenceEvent event]);
+  external void reportEvent([ReportEventType event]);
+  external void setReportEventDataForAutomaticBeacons([FenceEvent event]);
   external JSArray getNestedConfigs();
 }

--- a/lib/src/dom/fetch.dart
+++ b/lib/src/dom/fetch.dart
@@ -11,10 +11,10 @@ import 'referrer_policy.dart';
 import 'streams.dart';
 import 'trust_token_api.dart';
 
-typedef HeadersInit = JSAny?;
-typedef XMLHttpRequestBodyInit = JSAny?;
-typedef BodyInit = JSAny?;
-typedef RequestInfo = JSAny?;
+typedef HeadersInit = JSAny;
+typedef XMLHttpRequestBodyInit = JSAny;
+typedef BodyInit = JSAny;
+typedef RequestInfo = JSAny;
 typedef RequestDestination = String;
 typedef RequestMode = String;
 typedef RequestCredentials = String;
@@ -31,15 +31,15 @@ class Headers implements JSObject {
 }
 
 extension HeadersExtension on Headers {
-  external JSVoid append(
+  external void append(
     String name,
     String value,
   );
-  external JSVoid delete(String name);
+  external void delete(String name);
   external String? get(String name);
   external JSArray getSetCookie();
   external bool has(String name);
-  external JSVoid set(
+  external void set(
     String name,
     String value,
   );

--- a/lib/src/dom/file_system_access.dart
+++ b/lib/src/dom/file_system_access.dart
@@ -7,7 +7,7 @@ import 'dart:js_interop';
 import 'fs.dart';
 import 'permissions.dart';
 
-typedef StartInDirectory = JSAny?;
+typedef StartInDirectory = JSAny;
 typedef FileSystemPermissionMode = String;
 typedef WellKnownDirectory = String;
 
@@ -49,15 +49,15 @@ extension FileSystemHandlePermissionDescriptorExtension
 class FilePickerAcceptType implements JSObject {
   external factory FilePickerAcceptType({
     String description,
-    JSAny? accept,
+    JSAny accept,
   });
 }
 
 extension FilePickerAcceptTypeExtension on FilePickerAcceptType {
   external set description(String value);
   external String get description;
-  external set accept(JSAny? value);
-  external JSAny? get accept;
+  external set accept(JSAny value);
+  external JSAny get accept;
 }
 
 @JS()

--- a/lib/src/dom/fileapi.dart
+++ b/lib/src/dom/fileapi.dart
@@ -9,7 +9,7 @@ import 'html.dart';
 import 'streams.dart';
 import 'webidl.dart';
 
-typedef BlobPart = JSAny?;
+typedef BlobPart = JSAny;
 typedef EndingType = String;
 
 @JS('Blob')
@@ -99,14 +99,14 @@ class FileReader implements EventTarget {
 }
 
 extension FileReaderExtension on FileReader {
-  external JSVoid readAsArrayBuffer(Blob blob);
-  external JSVoid readAsBinaryString(Blob blob);
-  external JSVoid readAsText(
+  external void readAsArrayBuffer(Blob blob);
+  external void readAsBinaryString(Blob blob);
+  external void readAsText(
     Blob blob, [
     String encoding,
   ]);
-  external JSVoid readAsDataURL(Blob blob);
-  external JSVoid abort();
+  external void readAsDataURL(Blob blob);
+  external void abort();
   external int get readyState;
   external JSAny? get result;
   external DOMException? get error;

--- a/lib/src/dom/filter_effects.dart
+++ b/lib/src/dom/filter_effects.dart
@@ -246,7 +246,7 @@ class SVGFEDropShadowElement
     implements SVGElement, SVGFilterPrimitiveStandardAttributes {}
 
 extension SVGFEDropShadowElementExtension on SVGFEDropShadowElement {
-  external JSVoid setStdDeviation(
+  external void setStdDeviation(
     num stdDeviationX,
     num stdDeviationY,
   );
@@ -273,7 +273,7 @@ class SVGFEGaussianBlurElement
 }
 
 extension SVGFEGaussianBlurElementExtension on SVGFEGaussianBlurElement {
-  external JSVoid setStdDeviation(
+  external void setStdDeviation(
     num stdDeviationX,
     num stdDeviationY,
   );

--- a/lib/src/dom/fs.dart
+++ b/lib/src/dom/fs.dart
@@ -8,7 +8,7 @@ import 'file_system_access.dart';
 import 'streams.dart';
 import 'webidl.dart';
 
-typedef FileSystemWriteChunkType = JSAny?;
+typedef FileSystemWriteChunkType = JSAny;
 typedef FileSystemHandleKind = String;
 typedef WriteCommandType = String;
 
@@ -165,8 +165,8 @@ extension FileSystemSyncAccessHandleExtension on FileSystemSyncAccessHandle {
     AllowSharedBufferSource buffer, [
     FileSystemReadWriteOptions options,
   ]);
-  external JSVoid truncate(int newSize);
+  external void truncate(int newSize);
   external int getSize();
-  external JSVoid flush();
-  external JSVoid close();
+  external void flush();
+  external void close();
 }

--- a/lib/src/dom/generic_sensor.dart
+++ b/lib/src/dom/generic_sensor.dart
@@ -16,8 +16,8 @@ typedef MockSensorType = String;
 class Sensor implements EventTarget {}
 
 extension SensorExtension on Sensor {
-  external JSVoid start();
-  external JSVoid stop();
+  external void start();
+  external void stop();
   external bool get activated;
   external bool get hasReading;
   external DOMHighResTimeStamp? get timestamp;

--- a/lib/src/dom/geolocation.dart
+++ b/lib/src/dom/geolocation.dart
@@ -14,7 +14,7 @@ typedef PositionErrorCallback = JSFunction;
 class Geolocation implements JSObject {}
 
 extension GeolocationExtension on Geolocation {
-  external JSVoid getCurrentPosition(
+  external void getCurrentPosition(
     PositionCallback successCallback, [
     PositionErrorCallback? errorCallback,
     PositionOptions options,
@@ -24,7 +24,7 @@ extension GeolocationExtension on Geolocation {
     PositionErrorCallback? errorCallback,
     PositionOptions options,
   ]);
-  external JSVoid clearWatch(int watchId);
+  external void clearWatch(int watchId);
 }
 
 @JS()

--- a/lib/src/dom/geometry.dart
+++ b/lib/src/dom/geometry.dart
@@ -203,7 +203,7 @@ extension DOMQuadInitExtension on DOMQuadInit {
 @JS('DOMMatrixReadOnly')
 @staticInterop
 class DOMMatrixReadOnly implements JSObject {
-  external factory DOMMatrixReadOnly([JSAny? init]);
+  external factory DOMMatrixReadOnly([JSAny init]);
 
   external static DOMMatrixReadOnly fromMatrix([DOMMatrixInit other]);
   external static DOMMatrixReadOnly fromFloat32Array(JSFloat32Array array32);
@@ -288,7 +288,7 @@ extension DOMMatrixReadOnlyExtension on DOMMatrixReadOnly {
 @JS('DOMMatrix')
 @staticInterop
 class DOMMatrix implements DOMMatrixReadOnly {
-  external factory DOMMatrix([JSAny? init]);
+  external factory DOMMatrix([JSAny init]);
 
   external static DOMMatrix fromMatrix([DOMMatrixInit other]);
   external static DOMMatrix fromFloat32Array(JSFloat32Array array32);

--- a/lib/src/dom/hr_time.dart
+++ b/lib/src/dom/hr_time.dart
@@ -28,19 +28,19 @@ extension PerformanceExtension on Performance {
     String name, [
     String type,
   ]);
-  external JSVoid clearResourceTimings();
-  external JSVoid setResourceTimingBufferSize(int maxSize);
+  external void clearResourceTimings();
+  external void setResourceTimingBufferSize(int maxSize);
   external PerformanceMark mark(
     String markName, [
     PerformanceMarkOptions markOptions,
   ]);
-  external JSVoid clearMarks([String markName]);
+  external void clearMarks([String markName]);
   external PerformanceMeasure measure(
     String measureName, [
-    JSAny? startOrMeasureOptions,
+    JSAny startOrMeasureOptions,
     String endMark,
   ]);
-  external JSVoid clearMeasures([String measureName]);
+  external void clearMeasures([String measureName]);
   external EventCounts get eventCounts;
   external int get interactionCount;
   external DOMHighResTimeStamp get timeOrigin;

--- a/lib/src/dom/html.dart
+++ b/lib/src/dom/html.dart
@@ -91,7 +91,7 @@ typedef OffscreenRenderingContext = JSObject;
 typedef EventHandler = EventHandlerNonNull?;
 typedef OnErrorEventHandler = OnErrorEventHandlerNonNull?;
 typedef OnBeforeUnloadEventHandler = OnBeforeUnloadEventHandlerNonNull?;
-typedef TimerHandler = JSAny?;
+typedef TimerHandler = JSAny;
 typedef ImageBitmapSource = JSObject;
 typedef MessageEventSource = JSObject;
 typedef BlobCallback = JSFunction;
@@ -165,11 +165,11 @@ extension RadioNodeListExtension on RadioNodeList {
 class HTMLOptionsCollection implements HTMLCollection {}
 
 extension HTMLOptionsCollectionExtension on HTMLOptionsCollection {
-  external JSVoid add(
+  external void add(
     JSObject element, [
     JSAny? before,
   ]);
-  external JSVoid remove(int index);
+  external void remove(int index);
   external set length(int value);
   external int get length;
   external set selectedIndex(int value);
@@ -199,10 +199,10 @@ class HTMLElement
 }
 
 extension HTMLElementExtension on HTMLElement {
-  external JSVoid click();
+  external void click();
   external ElementInternals attachInternals();
-  external JSVoid showPopover();
-  external JSVoid hidePopover();
+  external void showPopover();
+  external void hidePopover();
   external bool togglePopover([bool force]);
   external Element? get offsetParent;
   external int get offsetTop;
@@ -249,8 +249,8 @@ class HTMLUnknownElement implements HTMLElement {}
 class HTMLOrSVGElement implements JSObject {}
 
 extension HTMLOrSVGElementExtension on HTMLOrSVGElement {
-  external JSVoid focus([FocusOptions options]);
-  external JSVoid blur();
+  external void focus([FocusOptions options]);
+  external void blur();
   external DOMStringMap get dataset;
   external set nonce(String value);
   external String get nonce;
@@ -838,7 +838,7 @@ extension HTMLObjectElementExtension on HTMLObjectElement {
   external Document? getSVGDocument();
   external bool checkValidity();
   external bool reportValidity();
-  external JSVoid setCustomValidity(String error);
+  external void setCustomValidity(String error);
   external set data(String value);
   external String get data;
   external set type(String value);
@@ -889,7 +889,7 @@ extension HTMLVideoElementExtension on HTMLVideoElement {
   external VideoPlaybackQuality getVideoPlaybackQuality();
   external JSPromise requestPictureInPicture();
   external int requestVideoFrameCallback(VideoFrameRequestCallback callback);
-  external JSVoid cancelVideoFrameCallback(int handle);
+  external void cancelVideoFrameCallback(int handle);
   external set width(int value);
   external int get width;
   external set height(int value);
@@ -959,12 +959,12 @@ class HTMLMediaElement implements HTMLElement {
 extension HTMLMediaElementExtension on HTMLMediaElement {
   external JSPromise setSinkId(String sinkId);
   external JSPromise setMediaKeys(MediaKeys? mediaKeys);
-  external JSVoid load();
+  external void load();
   external CanPlayTypeResult canPlayType(String type);
-  external JSVoid fastSeek(num time);
+  external void fastSeek(num time);
   external JSObject getStartDate();
   external JSPromise play();
-  external JSVoid pause();
+  external void pause();
   external TextTrack addTextTrack(
     TextTrackKind kind, [
     String label,
@@ -1117,8 +1117,8 @@ extension TextTrackListExtension on TextTrackList {
 class TextTrack implements EventTarget {}
 
 extension TextTrackExtension on TextTrack {
-  external JSVoid addCue(TextTrackCue cue);
-  external JSVoid removeCue(TextTrackCue cue);
+  external void addCue(TextTrackCue cue);
+  external void removeCue(TextTrackCue cue);
   external TextTrackKind get kind;
   external String get label;
   external String get language;
@@ -1245,14 +1245,14 @@ class HTMLTableElement implements HTMLElement {
 
 extension HTMLTableElementExtension on HTMLTableElement {
   external HTMLTableCaptionElement createCaption();
-  external JSVoid deleteCaption();
+  external void deleteCaption();
   external HTMLTableSectionElement createTHead();
-  external JSVoid deleteTHead();
+  external void deleteTHead();
   external HTMLTableSectionElement createTFoot();
-  external JSVoid deleteTFoot();
+  external void deleteTFoot();
   external HTMLTableSectionElement createTBody();
   external HTMLTableRowElement insertRow([int index]);
-  external JSVoid deleteRow(int index);
+  external void deleteRow(int index);
   external set caption(HTMLTableCaptionElement? value);
   external HTMLTableCaptionElement? get caption;
   external set tHead(HTMLTableSectionElement? value);
@@ -1321,7 +1321,7 @@ class HTMLTableSectionElement implements HTMLElement {
 
 extension HTMLTableSectionElementExtension on HTMLTableSectionElement {
   external HTMLTableRowElement insertRow([int index]);
-  external JSVoid deleteRow(int index);
+  external void deleteRow(int index);
   external HTMLCollection get rows;
   external set align(String value);
   external String get align;
@@ -1341,7 +1341,7 @@ class HTMLTableRowElement implements HTMLElement {
 
 extension HTMLTableRowElementExtension on HTMLTableRowElement {
   external HTMLTableCellElement insertCell([int index]);
-  external JSVoid deleteCell(int index);
+  external void deleteCell(int index);
   external int get rowIndex;
   external int get sectionRowIndex;
   external HTMLCollection get cells;
@@ -1402,9 +1402,9 @@ class HTMLFormElement implements HTMLElement {
 }
 
 extension HTMLFormElementExtension on HTMLFormElement {
-  external JSVoid submit();
-  external JSVoid requestSubmit([HTMLElement? submitter]);
-  external JSVoid reset();
+  external void submit();
+  external void requestSubmit([HTMLElement? submitter]);
+  external void reset();
   external bool checkValidity();
   external bool reportValidity();
   external set acceptCharset(String value);
@@ -1452,24 +1452,24 @@ class HTMLInputElement implements HTMLElement, PopoverInvokerElement {
 }
 
 extension HTMLInputElementExtension on HTMLInputElement {
-  external JSVoid stepUp([int n]);
-  external JSVoid stepDown([int n]);
+  external void stepUp([int n]);
+  external void stepDown([int n]);
   external bool checkValidity();
   external bool reportValidity();
-  external JSVoid setCustomValidity(String error);
-  external JSVoid select();
-  external JSVoid setRangeText(
+  external void setCustomValidity(String error);
+  external void select();
+  external void setRangeText(
     String replacement, [
     int start,
     int end,
     SelectionMode selectionMode,
   ]);
-  external JSVoid setSelectionRange(
+  external void setSelectionRange(
     int start,
     int end, [
     String direction,
   ]);
-  external JSVoid showPicker();
+  external void showPicker();
   external set webkitdirectory(bool value);
   external bool get webkitdirectory;
   external JSArray get webkitEntries;
@@ -1570,7 +1570,7 @@ class HTMLButtonElement implements HTMLElement, PopoverInvokerElement {
 extension HTMLButtonElementExtension on HTMLButtonElement {
   external bool checkValidity();
   external bool reportValidity();
-  external JSVoid setCustomValidity(String error);
+  external void setCustomValidity(String error);
   external set disabled(bool value);
   external bool get disabled;
   external HTMLFormElement? get form;
@@ -1605,14 +1605,14 @@ class HTMLSelectElement implements HTMLElement {
 extension HTMLSelectElementExtension on HTMLSelectElement {
   external HTMLOptionElement? item(int index);
   external HTMLOptionElement? namedItem(String name);
-  external JSVoid add(
+  external void add(
     JSObject element, [
     JSAny? before,
   ]);
-  external JSVoid remove([int index]);
+  external void remove([int index]);
   external bool checkValidity();
   external bool reportValidity();
-  external JSVoid setCustomValidity(String error);
+  external void setCustomValidity(String error);
   external set autocomplete(String value);
   external String get autocomplete;
   external set disabled(bool value);
@@ -1696,15 +1696,15 @@ class HTMLTextAreaElement implements HTMLElement {
 extension HTMLTextAreaElementExtension on HTMLTextAreaElement {
   external bool checkValidity();
   external bool reportValidity();
-  external JSVoid setCustomValidity(String error);
-  external JSVoid select();
-  external JSVoid setRangeText(
+  external void setCustomValidity(String error);
+  external void select();
+  external void setRangeText(
     String replacement, [
     int start,
     int end,
     SelectionMode selectionMode,
   ]);
-  external JSVoid setSelectionRange(
+  external void setSelectionRange(
     int start,
     int end, [
     String direction,
@@ -1761,7 +1761,7 @@ class HTMLOutputElement implements HTMLElement {
 extension HTMLOutputElementExtension on HTMLOutputElement {
   external bool checkValidity();
   external bool reportValidity();
-  external JSVoid setCustomValidity(String error);
+  external void setCustomValidity(String error);
   external DOMTokenList get htmlFor;
   external HTMLFormElement? get form;
   external set name(String value);
@@ -1823,7 +1823,7 @@ class HTMLFieldSetElement implements HTMLElement {
 extension HTMLFieldSetElementExtension on HTMLFieldSetElement {
   external bool checkValidity();
   external bool reportValidity();
-  external JSVoid setCustomValidity(String error);
+  external void setCustomValidity(String error);
   external set disabled(bool value);
   external bool get disabled;
   external HTMLFormElement? get form;
@@ -1936,9 +1936,9 @@ class HTMLDialogElement implements HTMLElement {
 }
 
 extension HTMLDialogElementExtension on HTMLDialogElement {
-  external JSVoid show();
-  external JSVoid showModal();
-  external JSVoid close([String returnValue]);
+  external void show();
+  external void showModal();
+  external void close([String returnValue]);
   external set open(bool value);
   external bool get open;
   external set returnValue(String value);
@@ -2002,7 +2002,7 @@ class HTMLSlotElement implements HTMLElement {
 extension HTMLSlotElementExtension on HTMLSlotElement {
   external JSArray assignedNodes([AssignedNodesOptions options]);
   external JSArray assignedElements([AssignedNodesOptions options]);
-  external JSVoid assign(JSObject nodes);
+  external void assign(JSObject nodes);
   external set name(String value);
   external String get name;
 }
@@ -2034,7 +2034,7 @@ extension HTMLCanvasElementExtension on HTMLCanvasElement {
     String type,
     JSAny? quality,
   ]);
-  external JSVoid toBlob(
+  external void toBlob(
     BlobCallback callback, [
     String type,
     JSAny? quality,
@@ -2102,9 +2102,9 @@ extension CanvasRenderingContext2DExtension on CanvasRenderingContext2D {
 class CanvasState implements JSObject {}
 
 extension CanvasStateExtension on CanvasState {
-  external JSVoid save();
-  external JSVoid restore();
-  external JSVoid reset();
+  external void save();
+  external void restore();
+  external void reset();
   external bool isContextLost();
 }
 
@@ -2113,16 +2113,16 @@ extension CanvasStateExtension on CanvasState {
 class CanvasTransform implements JSObject {}
 
 extension CanvasTransformExtension on CanvasTransform {
-  external JSVoid scale(
+  external void scale(
     num x,
     num y,
   );
-  external JSVoid rotate(num angle);
-  external JSVoid translate(
+  external void rotate(num angle);
+  external void translate(
     num x,
     num y,
   );
-  external JSVoid transform(
+  external void transform(
     num a,
     num b,
     num c,
@@ -2131,15 +2131,15 @@ extension CanvasTransformExtension on CanvasTransform {
     num f,
   );
   external DOMMatrix getTransform();
-  external JSVoid setTransform([
-    JSAny? aOrTransform,
+  external void setTransform([
+    JSAny aOrTransform,
     num b,
     num c,
     num d,
     num e,
     num f,
   ]);
-  external JSVoid resetTransform();
+  external void resetTransform();
 }
 
 @JS('CanvasCompositing')
@@ -2192,10 +2192,10 @@ extension CanvasFillStrokeStylesExtension on CanvasFillStrokeStyles {
     CanvasImageSource image,
     String repetition,
   );
-  external set strokeStyle(JSAny? value);
-  external JSAny? get strokeStyle;
-  external set fillStyle(JSAny? value);
-  external JSAny? get fillStyle;
+  external set strokeStyle(JSAny value);
+  external JSAny get strokeStyle;
+  external set fillStyle(JSAny value);
+  external JSAny get fillStyle;
 }
 
 @JS('CanvasShadowStyles')
@@ -2227,19 +2227,19 @@ extension CanvasFiltersExtension on CanvasFilters {
 class CanvasRect implements JSObject {}
 
 extension CanvasRectExtension on CanvasRect {
-  external JSVoid clearRect(
+  external void clearRect(
     num x,
     num y,
     num w,
     num h,
   );
-  external JSVoid fillRect(
+  external void fillRect(
     num x,
     num y,
     num w,
     num h,
   );
-  external JSVoid strokeRect(
+  external void strokeRect(
     num x,
     num y,
     num w,
@@ -2252,24 +2252,24 @@ extension CanvasRectExtension on CanvasRect {
 class CanvasDrawPath implements JSObject {}
 
 extension CanvasDrawPathExtension on CanvasDrawPath {
-  external JSVoid beginPath();
-  external JSVoid fill([
-    JSAny? fillRuleOrPath,
+  external void beginPath();
+  external void fill([
+    JSAny fillRuleOrPath,
     CanvasFillRule fillRule,
   ]);
-  external JSVoid stroke([Path2D path]);
-  external JSVoid clip([
-    JSAny? fillRuleOrPath,
+  external void stroke([Path2D path]);
+  external void clip([
+    JSAny fillRuleOrPath,
     CanvasFillRule fillRule,
   ]);
   external bool isPointInPath(
-    JSAny? pathOrX,
+    JSAny pathOrX,
     num xOrY, [
-    JSAny? fillRuleOrY,
+    JSAny fillRuleOrY,
     CanvasFillRule fillRule,
   ]);
   external bool isPointInStroke(
-    JSAny? pathOrX,
+    JSAny pathOrX,
     num xOrY, [
     num y,
   ]);
@@ -2280,11 +2280,11 @@ extension CanvasDrawPathExtension on CanvasDrawPath {
 class CanvasUserInterface implements JSObject {}
 
 extension CanvasUserInterfaceExtension on CanvasUserInterface {
-  external JSVoid drawFocusIfNeeded(
+  external void drawFocusIfNeeded(
     JSObject elementOrPath, [
     Element element,
   ]);
-  external JSVoid scrollPathIntoView([Path2D path]);
+  external void scrollPathIntoView([Path2D path]);
 }
 
 @JS('CanvasText')
@@ -2292,13 +2292,13 @@ extension CanvasUserInterfaceExtension on CanvasUserInterface {
 class CanvasText implements JSObject {}
 
 extension CanvasTextExtension on CanvasText {
-  external JSVoid fillText(
+  external void fillText(
     String text,
     num x,
     num y, [
     num maxWidth,
   ]);
-  external JSVoid strokeText(
+  external void strokeText(
     String text,
     num x,
     num y, [
@@ -2312,7 +2312,7 @@ extension CanvasTextExtension on CanvasText {
 class CanvasDrawImage implements JSObject {}
 
 extension CanvasDrawImageExtension on CanvasDrawImage {
-  external JSVoid drawImage(
+  external void drawImage(
     CanvasImageSource image,
     num dxOrSx,
     num dyOrSy, [
@@ -2331,7 +2331,7 @@ class CanvasImageData implements JSObject {}
 
 extension CanvasImageDataExtension on CanvasImageData {
   external ImageData createImageData(
-    JSAny? imagedataOrSw, [
+    JSAny imagedataOrSw, [
     int sh,
     ImageDataSettings settings,
   ]);
@@ -2342,7 +2342,7 @@ extension CanvasImageDataExtension on CanvasImageData {
     int sh, [
     ImageDataSettings settings,
   ]);
-  external JSVoid putImageData(
+  external void putImageData(
     ImageData imagedata,
     int dx,
     int dy, [
@@ -2358,7 +2358,7 @@ extension CanvasImageDataExtension on CanvasImageData {
 class CanvasPathDrawingStyles implements JSObject {}
 
 extension CanvasPathDrawingStylesExtension on CanvasPathDrawingStyles {
-  external JSVoid setLineDash(JSArray segments);
+  external void setLineDash(JSArray segments);
   external JSArray getLineDash();
   external set lineWidth(num value);
   external num get lineWidth;
@@ -2404,22 +2404,22 @@ extension CanvasTextDrawingStylesExtension on CanvasTextDrawingStyles {
 class CanvasPath implements JSObject {}
 
 extension CanvasPathExtension on CanvasPath {
-  external JSVoid closePath();
-  external JSVoid moveTo(
+  external void closePath();
+  external void moveTo(
     num x,
     num y,
   );
-  external JSVoid lineTo(
+  external void lineTo(
     num x,
     num y,
   );
-  external JSVoid quadraticCurveTo(
+  external void quadraticCurveTo(
     num cpx,
     num cpy,
     num x,
     num y,
   );
-  external JSVoid bezierCurveTo(
+  external void bezierCurveTo(
     num cp1x,
     num cp1y,
     num cp2x,
@@ -2427,27 +2427,27 @@ extension CanvasPathExtension on CanvasPath {
     num x,
     num y,
   );
-  external JSVoid arcTo(
+  external void arcTo(
     num x1,
     num y1,
     num x2,
     num y2,
     num radius,
   );
-  external JSVoid rect(
+  external void rect(
     num x,
     num y,
     num w,
     num h,
   );
-  external JSVoid roundRect(
+  external void roundRect(
     num x,
     num y,
     num w,
     num h, [
-    JSAny? radii,
+    JSAny radii,
   ]);
-  external JSVoid arc(
+  external void arc(
     num x,
     num y,
     num radius,
@@ -2455,7 +2455,7 @@ extension CanvasPathExtension on CanvasPath {
     num endAngle, [
     bool counterclockwise,
   ]);
-  external JSVoid ellipse(
+  external void ellipse(
     num x,
     num y,
     num radiusX,
@@ -2472,7 +2472,7 @@ extension CanvasPathExtension on CanvasPath {
 class CanvasGradient implements JSObject {}
 
 extension CanvasGradientExtension on CanvasGradient {
-  external JSVoid addColorStop(
+  external void addColorStop(
     num offset,
     String color,
   );
@@ -2483,7 +2483,7 @@ extension CanvasGradientExtension on CanvasGradient {
 class CanvasPattern implements JSObject {}
 
 extension CanvasPatternExtension on CanvasPattern {
-  external JSVoid setTransform([DOMMatrix2DInit transform]);
+  external void setTransform([DOMMatrix2DInit transform]);
 }
 
 @JS('TextMetrics')
@@ -2521,9 +2521,9 @@ extension ImageDataSettingsExtension on ImageDataSettings {
 @staticInterop
 class ImageData implements JSObject {
   external factory ImageData(
-    JSAny? dataOrSw,
+    JSAny dataOrSw,
     int shOrSw, [
-    JSAny? settingsOrSh,
+    JSAny settingsOrSh,
     ImageDataSettings settings,
   ]);
 }
@@ -2538,11 +2538,11 @@ extension ImageDataExtension on ImageData {
 @JS('Path2D')
 @staticInterop
 class Path2D implements CanvasPath {
-  external factory Path2D([JSAny? path]);
+  external factory Path2D([JSAny path]);
 }
 
 extension Path2DExtension on Path2D {
-  external JSVoid addPath(
+  external void addPath(
     Path2D path, [
     DOMMatrix2DInit transform,
   ]);
@@ -2553,7 +2553,7 @@ extension Path2DExtension on Path2D {
 class ImageBitmapRenderingContext implements JSObject {}
 
 extension ImageBitmapRenderingContextExtension on ImageBitmapRenderingContext {
-  external JSVoid transferFromImageBitmap(ImageBitmap? bitmap);
+  external void transferFromImageBitmap(ImageBitmap? bitmap);
   external JSObject get canvas;
 }
 
@@ -2635,7 +2635,7 @@ class OffscreenCanvasRenderingContext2D
 
 extension OffscreenCanvasRenderingContext2DExtension
     on OffscreenCanvasRenderingContext2D {
-  external JSVoid commit();
+  external void commit();
   external OffscreenCanvas get canvas;
 }
 
@@ -2644,7 +2644,7 @@ extension OffscreenCanvasRenderingContext2DExtension
 class CustomElementRegistry implements JSObject {}
 
 extension CustomElementRegistryExtension on CustomElementRegistry {
-  external JSVoid define(
+  external void define(
     String name,
     CustomElementConstructor constructor, [
     ElementDefinitionOptions options,
@@ -2652,7 +2652,7 @@ extension CustomElementRegistryExtension on CustomElementRegistry {
   external CustomElementConstructor? get(String name);
   external String? getName(CustomElementConstructor constructor);
   external JSPromise whenDefined(String name);
-  external JSVoid upgrade(Node root);
+  external void upgrade(Node root);
 }
 
 @JS()
@@ -2674,11 +2674,11 @@ extension ElementDefinitionOptionsExtension on ElementDefinitionOptions {
 class ElementInternals implements ARIAMixin {}
 
 extension ElementInternalsExtension on ElementInternals {
-  external JSVoid setFormValue(
+  external void setFormValue(
     JSAny? value, [
     JSAny? state,
   ]);
-  external JSVoid setValidity([
+  external void setValidity([
     ValidityStateFlags flags,
     String message,
     HTMLElement anchor,
@@ -2826,17 +2826,17 @@ class DataTransfer implements JSObject {
 }
 
 extension DataTransferExtension on DataTransfer {
-  external JSVoid setDragImage(
+  external void setDragImage(
     Element image,
     int x,
     int y,
   );
   external String getData(String format);
-  external JSVoid setData(
+  external void setData(
     String format,
     String data,
   );
-  external JSVoid clearData([String format]);
+  external void clearData([String format]);
   external set dropEffect(String value);
   external String get dropEffect;
   external set effectAllowed(String value);
@@ -2852,11 +2852,11 @@ class DataTransferItemList implements JSObject {}
 
 extension DataTransferItemListExtension on DataTransferItemList {
   external DataTransferItem? add(
-    JSAny? data, [
+    JSAny data, [
     String type,
   ]);
-  external JSVoid remove(int index);
-  external JSVoid clear();
+  external void remove(int index);
+  external void clear();
   external int get length;
 }
 
@@ -2867,7 +2867,7 @@ class DataTransferItem implements JSObject {}
 extension DataTransferItemExtension on DataTransferItem {
   external FileSystemEntry? webkitGetAsEntry();
   external JSPromise getAsFileSystemHandle();
-  external JSVoid getAsString(FunctionStringCallback? callback);
+  external void getAsString(FunctionStringCallback? callback);
   external File? getAsFile();
   external String get kind;
   external String get type;
@@ -2925,34 +2925,34 @@ class Window
         WindowLocalStorage {}
 
 extension WindowExtension on Window {
-  external JSVoid navigate(SpatialNavigationDirection dir);
+  external void navigate(SpatialNavigationDirection dir);
   external MediaQueryList matchMedia(String query);
-  external JSVoid moveTo(
+  external void moveTo(
     int x,
     int y,
   );
-  external JSVoid moveBy(
+  external void moveBy(
     int x,
     int y,
   );
-  external JSVoid resizeTo(
+  external void resizeTo(
     int width,
     int height,
   );
-  external JSVoid resizeBy(
+  external void resizeBy(
     int x,
     int y,
   );
-  external JSVoid scroll([
-    JSAny? optionsOrX,
+  external void scroll([
+    JSAny optionsOrX,
     num y,
   ]);
-  external JSVoid scrollTo([
-    JSAny? optionsOrX,
+  external void scrollTo([
+    JSAny optionsOrX,
     num y,
   ]);
-  external JSVoid scrollBy([
-    JSAny? optionsOrX,
+  external void scrollBy([
+    JSAny optionsOrX,
     num y,
   ]);
   external CSSStyleDeclaration getComputedStyle(
@@ -2963,35 +2963,35 @@ extension WindowExtension on Window {
   external JSPromise showOpenFilePicker([OpenFilePickerOptions options]);
   external JSPromise showSaveFilePicker([SaveFilePickerOptions options]);
   external JSPromise showDirectoryPicker([DirectoryPickerOptions options]);
-  external JSVoid close();
-  external JSVoid stop();
-  external JSVoid focus();
-  external JSVoid blur();
+  external void close();
+  external void stop();
+  external void focus();
+  external void blur();
   external Window? open([
     String url,
     String target,
     String features,
   ]);
-  external JSVoid alert([String message]);
+  external void alert([String message]);
   external bool confirm([String message]);
   external String? prompt([
     String message,
     String default_,
   ]);
-  external JSVoid print();
-  external JSVoid postMessage(
+  external void print();
+  external void postMessage(
     JSAny? message, [
-    JSAny? optionsOrTargetOrigin,
+    JSAny optionsOrTargetOrigin,
     JSArray transfer,
   ]);
-  external JSVoid captureEvents();
-  external JSVoid releaseEvents();
+  external void captureEvents();
+  external void releaseEvents();
   external JSPromise queryLocalFonts([QueryOptions options]);
   external int requestIdleCallback(
     IdleRequestCallback callback, [
     IdleRequestOptions options,
   ]);
-  external JSVoid cancelIdleCallback(int handle);
+  external void cancelIdleCallback(int handle);
   external Selection? getSelection();
   external JSPromise getScreenDetails();
   external int get orientation;
@@ -3086,9 +3086,9 @@ extension BarPropExtension on BarProp {
 class Location implements JSObject {}
 
 extension LocationExtension on Location {
-  external JSVoid assign(String url);
-  external JSVoid replace(String url);
-  external JSVoid reload();
+  external void assign(String url);
+  external void replace(String url);
+  external void reload();
   external set href(String value);
   external String get href;
   external String get origin;
@@ -3114,15 +3114,15 @@ extension LocationExtension on Location {
 class History implements JSObject {}
 
 extension HistoryExtension on History {
-  external JSVoid go([int delta]);
-  external JSVoid back();
-  external JSVoid forward();
-  external JSVoid pushState(
+  external void go([int delta]);
+  external void back();
+  external void forward();
+  external void pushState(
     JSAny? data,
     String unused, [
     String? url,
   ]);
-  external JSVoid replaceState(
+  external void replaceState(
     JSAny? data,
     String unused, [
     String? url,
@@ -3139,8 +3139,7 @@ class Navigation implements EventTarget {}
 
 extension NavigationExtension on Navigation {
   external JSArray entries();
-  external JSVoid updateCurrentEntry(
-      NavigationUpdateCurrentEntryOptions options);
+  external void updateCurrentEntry(NavigationUpdateCurrentEntryOptions options);
   external NavigationResult navigate(
     String url, [
     NavigationNavigateOptions options,
@@ -3272,8 +3271,8 @@ class NavigateEvent implements Event {
 }
 
 extension NavigateEventExtension on NavigateEvent {
-  external JSVoid intercept([NavigationInterceptOptions options]);
-  external JSVoid scroll();
+  external void intercept([NavigationInterceptOptions options]);
+  external void scroll();
   external NavigationType get navigationType;
   external NavigationDestination get destination;
   external bool get canIntercept;
@@ -3826,7 +3825,7 @@ extension WindowOrWorkerGlobalScopeExtension on WindowOrWorkerGlobalScope {
     RequestInfo input, [
     RequestInit init,
   ]);
-  external JSVoid reportError(JSAny? e);
+  external void reportError(JSAny? e);
   external String btoa(String data);
   external String atob(String data);
   external int setTimeout(
@@ -3834,17 +3833,17 @@ extension WindowOrWorkerGlobalScopeExtension on WindowOrWorkerGlobalScope {
     JSAny? arguments, [
     int timeout,
   ]);
-  external JSVoid clearTimeout([int id]);
+  external void clearTimeout([int id]);
   external int setInterval(
     TimerHandler handler,
     JSAny? arguments, [
     int timeout,
   ]);
-  external JSVoid clearInterval([int id]);
-  external JSVoid queueMicrotask(VoidFunction callback);
+  external void clearInterval([int id]);
+  external void queueMicrotask(VoidFunction callback);
   external JSPromise createImageBitmap(
     ImageBitmapSource image, [
-    JSAny? optionsOrSx,
+    JSAny optionsOrSx,
     int sy,
     int sw,
     int sh,
@@ -3901,7 +3900,7 @@ class Navigator
         NavigatorML {}
 
 extension NavigatorExtension on Navigator {
-  external AutoplayPolicy getAutoplayPolicy(JSAny? contextOrElementOrType);
+  external AutoplayPolicy getAutoplayPolicy(JSAny contextOrElementOrType);
   external JSPromise getBattery();
   external bool sendBeacon(
     String url, [
@@ -3913,11 +3912,11 @@ extension NavigatorExtension on Navigator {
   );
   external JSPromise deprecatedReplaceInURN(
     UrnOrConfig urnOrConfig,
-    JSAny? replacements,
+    JSAny replacements,
   );
   external JSArray getGamepads();
   external JSPromise getInstalledRelatedApps();
-  external JSVoid getUserMedia(
+  external void getUserMedia(
     MediaStreamConstraints constraints,
     NavigatorUserMediaSuccessCallback successCallback,
     NavigatorUserMediaErrorCallback errorCallback,
@@ -3925,7 +3924,7 @@ extension NavigatorExtension on Navigator {
   external JSPromise joinAdInterestGroup(AuctionAdInterestGroup group);
   external JSPromise leaveAdInterestGroup([AuctionAdInterestGroupKey group]);
   external JSPromise runAdAuction(AuctionAdConfig config);
-  external JSVoid updateAdInterestGroups();
+  external void updateAdInterestGroups();
   external bool vibrate(VibratePattern pattern);
   external JSPromise share([ShareData data]);
   external bool canShare([ShareData data]);
@@ -3997,11 +3996,11 @@ extension NavigatorOnLineExtension on NavigatorOnLine {
 class NavigatorContentUtils implements JSObject {}
 
 extension NavigatorContentUtilsExtension on NavigatorContentUtils {
-  external JSVoid registerProtocolHandler(
+  external void registerProtocolHandler(
     String scheme,
     String url,
   );
-  external JSVoid unregisterProtocolHandler(
+  external void unregisterProtocolHandler(
     String scheme,
     String url,
   );
@@ -4031,7 +4030,7 @@ extension NavigatorPluginsExtension on NavigatorPlugins {
 class PluginArray implements JSObject {}
 
 extension PluginArrayExtension on PluginArray {
-  external JSVoid refresh();
+  external void refresh();
   external Plugin? item(int index);
   external Plugin? namedItem(String name);
   external int get length;
@@ -4076,7 +4075,7 @@ extension MimeTypeExtension on MimeType {
 class ImageBitmap implements JSObject {}
 
 extension ImageBitmapExtension on ImageBitmap {
-  external JSVoid close();
+  external void close();
   external int get width;
   external int get height;
 }
@@ -4116,7 +4115,7 @@ class AnimationFrameProvider implements JSObject {}
 
 extension AnimationFrameProviderExtension on AnimationFrameProvider {
   external int requestAnimationFrame(FrameRequestCallback callback);
-  external JSVoid cancelAnimationFrame(int handle);
+  external void cancelAnimationFrame(int handle);
 }
 
 @JS('MessageEvent')
@@ -4129,7 +4128,7 @@ class MessageEvent implements Event {
 }
 
 extension MessageEventExtension on MessageEvent {
-  external JSVoid initMessageEvent(
+  external void initMessageEvent(
     String type, [
     bool bubbles,
     bool cancelable,
@@ -4186,7 +4185,7 @@ class EventSource implements EventTarget {
 }
 
 extension EventSourceExtension on EventSource {
-  external JSVoid close();
+  external void close();
   external String get url;
   external bool get withCredentials;
   external int get readyState;
@@ -4226,12 +4225,12 @@ extension MessageChannelExtension on MessageChannel {
 class MessagePort implements EventTarget {}
 
 extension MessagePortExtension on MessagePort {
-  external JSVoid postMessage(
+  external void postMessage(
     JSAny? message, [
     JSObject optionsOrTransfer,
   ]);
-  external JSVoid start();
-  external JSVoid close();
+  external void start();
+  external void close();
   external set onmessage(EventHandler value);
   external EventHandler get onmessage;
   external set onmessageerror(EventHandler value);
@@ -4257,8 +4256,8 @@ class BroadcastChannel implements EventTarget {
 }
 
 extension BroadcastChannelExtension on BroadcastChannel {
-  external JSVoid postMessage(JSAny? message);
-  external JSVoid close();
+  external void postMessage(JSAny? message);
+  external void close();
   external String get name;
   external set onmessage(EventHandler value);
   external EventHandler get onmessage;
@@ -4272,7 +4271,7 @@ class WorkerGlobalScope
     implements EventTarget, FontFaceSource, WindowOrWorkerGlobalScope {}
 
 extension WorkerGlobalScopeExtension on WorkerGlobalScope {
-  external JSVoid importScripts(String urls);
+  external void importScripts(String urls);
   external WorkerGlobalScope get self;
   external WorkerLocation get location;
   external WorkerNavigator get navigator;
@@ -4296,11 +4295,11 @@ class DedicatedWorkerGlobalScope
     implements WorkerGlobalScope, AnimationFrameProvider {}
 
 extension DedicatedWorkerGlobalScopeExtension on DedicatedWorkerGlobalScope {
-  external JSVoid postMessage(
+  external void postMessage(
     JSAny? message, [
     JSObject optionsOrTransfer,
   ]);
-  external JSVoid close();
+  external void close();
   external String get name;
   external set onmessage(EventHandler value);
   external EventHandler get onmessage;
@@ -4315,7 +4314,7 @@ extension DedicatedWorkerGlobalScopeExtension on DedicatedWorkerGlobalScope {
 class SharedWorkerGlobalScope implements WorkerGlobalScope {}
 
 extension SharedWorkerGlobalScopeExtension on SharedWorkerGlobalScope {
-  external JSVoid close();
+  external void close();
   external String get name;
   external set onconnect(EventHandler value);
   external EventHandler get onconnect;
@@ -4340,8 +4339,8 @@ class Worker implements EventTarget, AbstractWorker {
 }
 
 extension WorkerExtension on Worker {
-  external JSVoid terminate();
-  external JSVoid postMessage(
+  external void terminate();
+  external void postMessage(
     JSAny? message, [
     JSObject optionsOrTransfer,
   ]);
@@ -4376,7 +4375,7 @@ extension WorkerOptionsExtension on WorkerOptions {
 class SharedWorker implements EventTarget, AbstractWorker {
   external factory SharedWorker(
     String scriptURL, [
-    JSAny? options,
+    JSAny options,
   ]);
 }
 
@@ -4469,12 +4468,12 @@ class Storage implements JSObject {}
 extension StorageExtension on Storage {
   external String? key(int index);
   external String? getItem(String key);
-  external JSVoid setItem(
+  external void setItem(
     String key,
     String value,
   );
-  external JSVoid removeItem(String key);
-  external JSVoid clear();
+  external void removeItem(String key);
+  external void clear();
   external int get length;
 }
 
@@ -4504,7 +4503,7 @@ class StorageEvent implements Event {
 }
 
 extension StorageEventExtension on StorageEvent {
-  external JSVoid initStorageEvent(
+  external void initStorageEvent(
     String type, [
     bool bubbles,
     bool cancelable,
@@ -4554,8 +4553,8 @@ class HTMLMarqueeElement implements HTMLElement {
 }
 
 extension HTMLMarqueeElementExtension on HTMLMarqueeElement {
-  external JSVoid start();
-  external JSVoid stop();
+  external void start();
+  external void stop();
   external set behavior(String value);
   external String get behavior;
   external set bgColor(String value);
@@ -4668,6 +4667,6 @@ extension HTMLParamElementExtension on HTMLParamElement {
 class External implements JSObject {}
 
 extension ExternalExtension on External {
-  external JSVoid AddSearchProvider();
-  external JSVoid IsSearchProviderInstalled();
+  external void AddSearchProvider();
+  external void IsSearchProviderInstalled();
 }

--- a/lib/src/dom/indexeddb.dart
+++ b/lib/src/dom/indexeddb.dart
@@ -111,16 +111,16 @@ class IDBDatabase implements EventTarget {}
 
 extension IDBDatabaseExtension on IDBDatabase {
   external IDBTransaction transaction(
-    JSAny? storeNames, [
+    JSAny storeNames, [
     IDBTransactionMode mode,
     IDBTransactionOptions options,
   ]);
-  external JSVoid close();
+  external void close();
   external IDBObjectStore createObjectStore(
     String name, [
     IDBObjectStoreParameters options,
   ]);
-  external JSVoid deleteObjectStore(String name);
+  external void deleteObjectStore(String name);
   external String get name;
   external int get version;
   external DOMStringList get objectStoreNames;
@@ -200,10 +200,10 @@ extension IDBObjectStoreExtension on IDBObjectStore {
   external IDBIndex index(String name);
   external IDBIndex createIndex(
     String name,
-    JSAny? keyPath, [
+    JSAny keyPath, [
     IDBIndexParameters options,
   ]);
-  external JSVoid deleteIndex(String name);
+  external void deleteIndex(String name);
   external set name(String value);
   external String get name;
   external JSAny? get keyPath;
@@ -294,10 +294,10 @@ extension IDBKeyRangeExtension on IDBKeyRange {
 class IDBCursor implements JSObject {}
 
 extension IDBCursorExtension on IDBCursor {
-  external JSVoid advance(int count);
+  external void advance(int count);
   @JS('continue')
-  external JSVoid continue_([JSAny? key]);
-  external JSVoid continuePrimaryKey(
+  external void continue_([JSAny? key]);
+  external void continuePrimaryKey(
     JSAny? key,
     JSAny? primaryKey,
   );
@@ -324,8 +324,8 @@ class IDBTransaction implements EventTarget {}
 
 extension IDBTransactionExtension on IDBTransaction {
   external IDBObjectStore objectStore(String name);
-  external JSVoid commit();
-  external JSVoid abort();
+  external void commit();
+  external void abort();
   external DOMStringList get objectStoreNames;
   external IDBTransactionMode get mode;
   external IDBTransactionDurability get durability;

--- a/lib/src/dom/ink_enhancement.dart
+++ b/lib/src/dom/ink_enhancement.dart
@@ -32,7 +32,7 @@ extension InkPresenterParamExtension on InkPresenterParam {
 class InkPresenter implements JSObject {}
 
 extension InkPresenterExtension on InkPresenter {
-  external JSVoid updateInkTrailStartPoint(
+  external void updateInkTrailStartPoint(
     PointerEvent event,
     InkTrailStyle style,
   );

--- a/lib/src/dom/intersection_observer.dart
+++ b/lib/src/dom/intersection_observer.dart
@@ -20,9 +20,9 @@ class IntersectionObserver implements JSObject {
 }
 
 extension IntersectionObserverExtension on IntersectionObserver {
-  external JSVoid observe(Element target);
-  external JSVoid unobserve(Element target);
-  external JSVoid disconnect();
+  external void observe(Element target);
+  external void unobserve(Element target);
+  external void disconnect();
   external JSArray takeRecords();
   external JSObject? get root;
   external String get rootMargin;
@@ -88,7 +88,7 @@ class IntersectionObserverInit implements JSObject {
     JSObject? root,
     String rootMargin,
     String scrollMargin,
-    JSAny? threshold,
+    JSAny threshold,
   });
 }
 
@@ -99,6 +99,6 @@ extension IntersectionObserverInitExtension on IntersectionObserverInit {
   external String get rootMargin;
   external set scrollMargin(String value);
   external String get scrollMargin;
-  external set threshold(JSAny? value);
-  external JSAny? get threshold;
+  external set threshold(JSAny value);
+  external JSAny get threshold;
 }

--- a/lib/src/dom/keyboard_lock.dart
+++ b/lib/src/dom/keyboard_lock.dart
@@ -13,7 +13,7 @@ class Keyboard implements EventTarget {}
 
 extension KeyboardExtension on Keyboard {
   external JSPromise lock([JSArray keyCodes]);
-  external JSVoid unlock();
+  external void unlock();
   external JSPromise getLayoutMap();
   external set onlayoutchange(EventHandler value);
   external EventHandler get onlayoutchange;

--- a/lib/src/dom/media_source.dart
+++ b/lib/src/dom/media_source.dart
@@ -23,13 +23,13 @@ class MediaSource implements EventTarget {
 
 extension MediaSourceExtension on MediaSource {
   external SourceBuffer addSourceBuffer(String type);
-  external JSVoid removeSourceBuffer(SourceBuffer sourceBuffer);
-  external JSVoid endOfStream([EndOfStreamError error]);
-  external JSVoid setLiveSeekableRange(
+  external void removeSourceBuffer(SourceBuffer sourceBuffer);
+  external void endOfStream([EndOfStreamError error]);
+  external void setLiveSeekableRange(
     num start,
     num end,
   );
-  external JSVoid clearLiveSeekableRange();
+  external void clearLiveSeekableRange();
   external MediaSourceHandle get handle;
   external SourceBufferList get sourceBuffers;
   external SourceBufferList get activeSourceBuffers;
@@ -53,10 +53,10 @@ class MediaSourceHandle implements JSObject {}
 class SourceBuffer implements EventTarget {}
 
 extension SourceBufferExtension on SourceBuffer {
-  external JSVoid appendBuffer(BufferSource data);
-  external JSVoid abort();
-  external JSVoid changeType(String type);
-  external JSVoid remove(
+  external void appendBuffer(BufferSource data);
+  external void abort();
+  external void changeType(String type);
+  external void remove(
     num start,
     num end,
   );

--- a/lib/src/dom/mediacapture_fromelement.dart
+++ b/lib/src/dom/mediacapture_fromelement.dart
@@ -13,6 +13,6 @@ class CanvasCaptureMediaStreamTrack implements MediaStreamTrack {}
 
 extension CanvasCaptureMediaStreamTrackExtension
     on CanvasCaptureMediaStreamTrack {
-  external JSVoid requestFrame();
+  external void requestFrame();
   external HTMLCanvasElement get canvas;
 }

--- a/lib/src/dom/mediacapture_streams.dart
+++ b/lib/src/dom/mediacapture_streams.dart
@@ -15,10 +15,10 @@ import 'permissions.dart';
 import 'screen_capture.dart';
 import 'webidl.dart';
 
-typedef ConstrainULong = JSAny?;
-typedef ConstrainDouble = JSAny?;
-typedef ConstrainBoolean = JSAny?;
-typedef ConstrainDOMString = JSAny?;
+typedef ConstrainULong = JSAny;
+typedef ConstrainDouble = JSAny;
+typedef ConstrainBoolean = JSAny;
+typedef ConstrainDOMString = JSAny;
 typedef NavigatorUserMediaSuccessCallback = JSFunction;
 typedef NavigatorUserMediaErrorCallback = JSFunction;
 typedef MediaStreamTrackState = String;
@@ -37,8 +37,8 @@ extension MediaStreamExtension on MediaStream {
   external JSArray getVideoTracks();
   external JSArray getTracks();
   external MediaStreamTrack? getTrackById(String trackId);
-  external JSVoid addTrack(MediaStreamTrack track);
-  external JSVoid removeTrack(MediaStreamTrack track);
+  external void addTrack(MediaStreamTrack track);
+  external void removeTrack(MediaStreamTrack track);
   external MediaStream clone();
   external String get id;
   external bool get active;
@@ -57,7 +57,7 @@ extension MediaStreamTrackExtension on MediaStreamTrack {
   external JSArray getSupportedCaptureActions();
   external JSPromise sendCaptureAction(CaptureAction action);
   external MediaStreamTrack clone();
-  external JSVoid stop();
+  external void stop();
   external MediaTrackCapabilities getCapabilities();
   external MediaTrackConstraints getConstraints();
   external MediaTrackSettings getSettings();
@@ -350,9 +350,9 @@ class MediaTrackConstraintSet implements JSObject {
     ConstrainDouble saturation,
     ConstrainDouble sharpness,
     ConstrainDouble focusDistance,
-    JSAny? pan,
-    JSAny? tilt,
-    JSAny? zoom,
+    JSAny pan,
+    JSAny tilt,
+    JSAny zoom,
     ConstrainBoolean torch,
     ConstrainULong width,
     ConstrainULong height,
@@ -404,12 +404,12 @@ extension MediaTrackConstraintSetExtension on MediaTrackConstraintSet {
   external ConstrainDouble get sharpness;
   external set focusDistance(ConstrainDouble value);
   external ConstrainDouble get focusDistance;
-  external set pan(JSAny? value);
-  external JSAny? get pan;
-  external set tilt(JSAny? value);
-  external JSAny? get tilt;
-  external set zoom(JSAny? value);
-  external JSAny? get zoom;
+  external set pan(JSAny value);
+  external JSAny get pan;
+  external set tilt(JSAny value);
+  external JSAny get tilt;
+  external set zoom(JSAny value);
+  external JSAny get zoom;
   external set torch(ConstrainBoolean value);
   external ConstrainBoolean get torch;
   external set width(ConstrainULong value);
@@ -620,8 +620,8 @@ class MediaDevices implements EventTarget {}
 
 extension MediaDevicesExtension on MediaDevices {
   external JSPromise selectAudioOutput([AudioOutputOptions options]);
-  external JSVoid setCaptureHandleConfig([CaptureHandleConfig config]);
-  external JSVoid setSupportedCaptureActions(JSArray actions);
+  external void setCaptureHandleConfig([CaptureHandleConfig config]);
+  external void setSupportedCaptureActions(JSArray actions);
   external JSPromise enumerateDevices();
   external MediaTrackSupportedConstraints getSupportedConstraints();
   external JSPromise getUserMedia([MediaStreamConstraints constraints]);
@@ -659,18 +659,18 @@ extension InputDeviceInfoExtension on InputDeviceInfo {
 @anonymous
 class MediaStreamConstraints implements JSObject {
   external factory MediaStreamConstraints({
-    JSAny? video,
-    JSAny? audio,
+    JSAny video,
+    JSAny audio,
     bool preferCurrentTab,
     String peerIdentity,
   });
 }
 
 extension MediaStreamConstraintsExtension on MediaStreamConstraints {
-  external set video(JSAny? value);
-  external JSAny? get video;
-  external set audio(JSAny? value);
-  external JSAny? get audio;
+  external set video(JSAny value);
+  external JSAny get video;
+  external set audio(JSAny value);
+  external JSAny get audio;
   external set preferCurrentTab(bool value);
   external bool get preferCurrentTab;
   external set peerIdentity(String value);
@@ -767,17 +767,17 @@ extension ConstrainBooleanParametersExtension on ConstrainBooleanParameters {
 @anonymous
 class ConstrainDOMStringParameters implements JSObject {
   external factory ConstrainDOMStringParameters({
-    JSAny? exact,
-    JSAny? ideal,
+    JSAny exact,
+    JSAny ideal,
   });
 }
 
 extension ConstrainDOMStringParametersExtension
     on ConstrainDOMStringParameters {
-  external set exact(JSAny? value);
-  external JSAny? get exact;
-  external set ideal(JSAny? value);
-  external JSAny? get ideal;
+  external set exact(JSAny value);
+  external JSAny get exact;
+  external set ideal(JSAny value);
+  external JSAny get ideal;
 }
 
 @JS()

--- a/lib/src/dom/mediacapture_viewport.dart
+++ b/lib/src/dom/mediacapture_viewport.dart
@@ -9,15 +9,15 @@ import 'dart:js_interop';
 @anonymous
 class ViewportMediaStreamConstraints implements JSObject {
   external factory ViewportMediaStreamConstraints({
-    JSAny? video,
-    JSAny? audio,
+    JSAny video,
+    JSAny audio,
   });
 }
 
 extension ViewportMediaStreamConstraintsExtension
     on ViewportMediaStreamConstraints {
-  external set video(JSAny? value);
-  external JSAny? get video;
-  external set audio(JSAny? value);
-  external JSAny? get audio;
+  external set video(JSAny value);
+  external JSAny get video;
+  external set audio(JSAny value);
+  external JSAny get audio;
 }

--- a/lib/src/dom/mediasession.dart
+++ b/lib/src/dom/mediasession.dart
@@ -13,13 +13,13 @@ typedef MediaSessionAction = String;
 class MediaSession implements JSObject {}
 
 extension MediaSessionExtension on MediaSession {
-  external JSVoid setActionHandler(
+  external void setActionHandler(
     MediaSessionAction action,
     MediaSessionActionHandler? handler,
   );
-  external JSVoid setPositionState([MediaPositionState state]);
-  external JSVoid setMicrophoneActive(bool active);
-  external JSVoid setCameraActive(bool active);
+  external void setPositionState([MediaPositionState state]);
+  external void setMicrophoneActive(bool active);
+  external void setCameraActive(bool active);
   external set metadata(MediaMetadata? value);
   external MediaMetadata? get metadata;
   external set playbackState(MediaSessionPlaybackState value);

--- a/lib/src/dom/mediastream_recording.dart
+++ b/lib/src/dom/mediastream_recording.dart
@@ -25,11 +25,11 @@ class MediaRecorder implements EventTarget {
 }
 
 extension MediaRecorderExtension on MediaRecorder {
-  external JSVoid start([int timeslice]);
-  external JSVoid stop();
-  external JSVoid pause();
-  external JSVoid resume();
-  external JSVoid requestData();
+  external void start([int timeslice]);
+  external void stop();
+  external void pause();
+  external void resume();
+  external void requestData();
   external MediaStream get stream;
   external String get mimeType;
   external RecordingState get state;

--- a/lib/src/dom/notifications.dart
+++ b/lib/src/dom/notifications.dart
@@ -29,7 +29,7 @@ class Notification implements EventTarget {
 }
 
 extension NotificationExtension on Notification {
-  external JSVoid close();
+  external void close();
   external set onclick(EventHandler value);
   external EventHandler get onclick;
   external set onshow(EventHandler value);

--- a/lib/src/dom/oes_draw_buffers_indexed.dart
+++ b/lib/src/dom/oes_draw_buffers_indexed.dart
@@ -11,36 +11,36 @@ import 'webgl1.dart';
 class OES_draw_buffers_indexed implements JSObject {}
 
 extension OESDrawBuffersIndexedExtension on OES_draw_buffers_indexed {
-  external JSVoid enableiOES(
+  external void enableiOES(
     GLenum target,
     GLuint index,
   );
-  external JSVoid disableiOES(
+  external void disableiOES(
     GLenum target,
     GLuint index,
   );
-  external JSVoid blendEquationiOES(
+  external void blendEquationiOES(
     GLuint buf,
     GLenum mode,
   );
-  external JSVoid blendEquationSeparateiOES(
+  external void blendEquationSeparateiOES(
     GLuint buf,
     GLenum modeRGB,
     GLenum modeAlpha,
   );
-  external JSVoid blendFunciOES(
+  external void blendFunciOES(
     GLuint buf,
     GLenum src,
     GLenum dst,
   );
-  external JSVoid blendFuncSeparateiOES(
+  external void blendFuncSeparateiOES(
     GLuint buf,
     GLenum srcRGB,
     GLenum dstRGB,
     GLenum srcAlpha,
     GLenum dstAlpha,
   );
-  external JSVoid colorMaskiOES(
+  external void colorMaskiOES(
     GLuint buf,
     GLboolean r,
     GLboolean g,

--- a/lib/src/dom/oes_vertex_array_object.dart
+++ b/lib/src/dom/oes_vertex_array_object.dart
@@ -18,7 +18,7 @@ class OES_vertex_array_object implements JSObject {
 
 extension OESVertexArrayObjectExtension on OES_vertex_array_object {
   external WebGLVertexArrayObjectOES? createVertexArrayOES();
-  external JSVoid deleteVertexArrayOES(WebGLVertexArrayObjectOES? arrayObject);
+  external void deleteVertexArrayOES(WebGLVertexArrayObjectOES? arrayObject);
   external GLboolean isVertexArrayOES(WebGLVertexArrayObjectOES? arrayObject);
-  external JSVoid bindVertexArrayOES(WebGLVertexArrayObjectOES? arrayObject);
+  external void bindVertexArrayOES(WebGLVertexArrayObjectOES? arrayObject);
 }

--- a/lib/src/dom/orientation_sensor.dart
+++ b/lib/src/dom/orientation_sensor.dart
@@ -14,7 +14,7 @@ typedef OrientationSensorLocalCoordinateSystem = String;
 class OrientationSensor implements Sensor {}
 
 extension OrientationSensorExtension on OrientationSensor {
-  external JSVoid populateMatrix(RotationMatrixType targetMatrix);
+  external void populateMatrix(RotationMatrixType targetMatrix);
   external JSArray? get quaternion;
 }
 

--- a/lib/src/dom/ovr_multiview2.dart
+++ b/lib/src/dom/ovr_multiview2.dart
@@ -16,7 +16,7 @@ class OVR_multiview2 implements JSObject {
 }
 
 extension OVRMultiview2Extension on OVR_multiview2 {
-  external JSVoid framebufferTextureMultiviewOVR(
+  external void framebufferTextureMultiviewOVR(
     GLenum target,
     GLenum attachment,
     WebGLTexture? texture,

--- a/lib/src/dom/payment_handler.dart
+++ b/lib/src/dom/payment_handler.dart
@@ -27,7 +27,7 @@ class CanMakePaymentEvent implements ExtendableEvent {
 }
 
 extension CanMakePaymentEventExtension on CanMakePaymentEvent {
-  external JSVoid respondWith(JSPromise canMakePaymentResponse);
+  external void respondWith(JSPromise canMakePaymentResponse);
 }
 
 @JS()
@@ -76,7 +76,7 @@ extension PaymentRequestEventExtension on PaymentRequestEvent {
   ]);
   external JSPromise changeShippingAddress([AddressInit shippingAddress]);
   external JSPromise changeShippingOption(String shippingOption);
-  external JSVoid respondWith(JSPromise handlerResponsePromise);
+  external void respondWith(JSPromise handlerResponsePromise);
   external String get topOrigin;
   external String get paymentRequestOrigin;
   external String get paymentRequestId;

--- a/lib/src/dom/payment_request.dart
+++ b/lib/src/dom/payment_request.dart
@@ -244,7 +244,7 @@ class PaymentRequestUpdateEvent implements Event {
 }
 
 extension PaymentRequestUpdateEventExtension on PaymentRequestUpdateEvent {
-  external JSVoid updateWith(JSPromise detailsPromise);
+  external void updateWith(JSPromise detailsPromise);
 }
 
 @JS()

--- a/lib/src/dom/performance_timeline.dart
+++ b/lib/src/dom/performance_timeline.dart
@@ -30,8 +30,8 @@ class PerformanceObserver implements JSObject {
 }
 
 extension PerformanceObserverExtension on PerformanceObserver {
-  external JSVoid observe([PerformanceObserverInit options]);
-  external JSVoid disconnect();
+  external void observe([PerformanceObserverInit options]);
+  external void disconnect();
   external PerformanceEntryList takeRecords();
 }
 

--- a/lib/src/dom/portals.dart
+++ b/lib/src/dom/portals.dart
@@ -15,7 +15,7 @@ class HTMLPortalElement implements HTMLElement {
 
 extension HTMLPortalElementExtension on HTMLPortalElement {
   external JSPromise activate([PortalActivateOptions options]);
-  external JSVoid postMessage(
+  external void postMessage(
     JSAny? message, [
     StructuredSerializeOptions options,
   ]);
@@ -46,7 +46,7 @@ extension PortalActivateOptionsExtension on PortalActivateOptions {
 class PortalHost implements EventTarget {}
 
 extension PortalHostExtension on PortalHost {
-  external JSVoid postMessage(
+  external void postMessage(
     JSAny? message, [
     StructuredSerializeOptions options,
   ]);

--- a/lib/src/dom/presentation_api.dart
+++ b/lib/src/dom/presentation_api.dart
@@ -24,7 +24,7 @@ extension PresentationExtension on Presentation {
 @JS('PresentationRequest')
 @staticInterop
 class PresentationRequest implements EventTarget {
-  external factory PresentationRequest(JSAny? urlOrUrls);
+  external factory PresentationRequest(JSAny urlOrUrls);
 }
 
 extension PresentationRequestExtension on PresentationRequest {
@@ -78,9 +78,9 @@ extension PresentationConnectionAvailableEventInitExtension
 class PresentationConnection implements EventTarget {}
 
 extension PresentationConnectionExtension on PresentationConnection {
-  external JSVoid close();
-  external JSVoid terminate();
-  external JSVoid send(JSAny? dataOrMessage);
+  external void close();
+  external void terminate();
+  external void send(JSAny dataOrMessage);
   external String get id;
   external String get url;
   external PresentationConnectionState get state;

--- a/lib/src/dom/push_api.dart
+++ b/lib/src/dom/push_api.dart
@@ -9,7 +9,7 @@ import 'hr_time.dart';
 import 'permissions.dart';
 import 'service_workers.dart';
 
-typedef PushMessageDataInit = JSAny?;
+typedef PushMessageDataInit = JSAny;
 typedef PushEncryptionKeyName = String;
 
 @JS()
@@ -82,7 +82,7 @@ class PushSubscriptionJSON implements JSObject {
   external factory PushSubscriptionJSON({
     String endpoint,
     EpochTimeStamp? expirationTime,
-    JSAny? keys,
+    JSAny keys,
   });
 }
 
@@ -91,8 +91,8 @@ extension PushSubscriptionJSONExtension on PushSubscriptionJSON {
   external String get endpoint;
   external set expirationTime(EpochTimeStamp? value);
   external EpochTimeStamp? get expirationTime;
-  external set keys(JSAny? value);
-  external JSAny? get keys;
+  external set keys(JSAny value);
+  external JSAny get keys;
 }
 
 @JS('PushMessageData')

--- a/lib/src/dom/reporting.dart
+++ b/lib/src/dom/reporting.dart
@@ -36,8 +36,8 @@ class ReportingObserver implements JSObject {
 }
 
 extension ReportingObserverExtension on ReportingObserver {
-  external JSVoid observe();
-  external JSVoid disconnect();
+  external void observe();
+  external void disconnect();
   external ReportList takeRecords();
 }
 

--- a/lib/src/dom/resize_observer.dart
+++ b/lib/src/dom/resize_observer.dart
@@ -29,12 +29,12 @@ class ResizeObserver implements JSObject {
 }
 
 extension ResizeObserverExtension on ResizeObserver {
-  external JSVoid observe(
+  external void observe(
     Element target, [
     ResizeObserverOptions options,
   ]);
-  external JSVoid unobserve(Element target);
-  external JSVoid disconnect();
+  external void unobserve(Element target);
+  external void disconnect();
 }
 
 @JS('ResizeObserverEntry')

--- a/lib/src/dom/sanitizer_api.dart
+++ b/lib/src/dom/sanitizer_api.dart
@@ -6,7 +6,7 @@ import 'dart:js_interop';
 
 import 'dom.dart';
 
-typedef AttributeMatchList = JSAny?;
+typedef AttributeMatchList = JSAny;
 
 @JS('Sanitizer')
 @staticInterop

--- a/lib/src/dom/scheduling_apis.dart
+++ b/lib/src/dom/scheduling_apis.dart
@@ -86,19 +86,19 @@ class TaskController implements AbortController {
 }
 
 extension TaskControllerExtension on TaskController {
-  external JSVoid setPriority(TaskPriority priority);
+  external void setPriority(TaskPriority priority);
 }
 
 @JS()
 @staticInterop
 @anonymous
 class TaskSignalAnyInit implements JSObject {
-  external factory TaskSignalAnyInit({JSAny? priority});
+  external factory TaskSignalAnyInit({JSAny priority});
 }
 
 extension TaskSignalAnyInitExtension on TaskSignalAnyInit {
-  external set priority(JSAny? value);
-  external JSAny? get priority;
+  external set priority(JSAny value);
+  external JSAny get priority;
 }
 
 @JS('TaskSignal')

--- a/lib/src/dom/screen_capture.dart
+++ b/lib/src/dom/screen_capture.dart
@@ -22,7 +22,7 @@ class CaptureController implements EventTarget {
 }
 
 extension CaptureControllerExtension on CaptureController {
-  external JSVoid setFocusBehavior(CaptureStartFocusBehavior focusBehavior);
+  external void setFocusBehavior(CaptureStartFocusBehavior focusBehavior);
   external set oncapturedmousechange(EventHandler value);
   external EventHandler get oncapturedmousechange;
 }
@@ -32,8 +32,8 @@ extension CaptureControllerExtension on CaptureController {
 @anonymous
 class DisplayMediaStreamOptions implements JSObject {
   external factory DisplayMediaStreamOptions({
-    JSAny? video,
-    JSAny? audio,
+    JSAny video,
+    JSAny audio,
     CaptureController controller,
     SelfCapturePreferenceEnum selfBrowserSurface,
     SystemAudioPreferenceEnum systemAudio,
@@ -43,10 +43,10 @@ class DisplayMediaStreamOptions implements JSObject {
 }
 
 extension DisplayMediaStreamOptionsExtension on DisplayMediaStreamOptions {
-  external set video(JSAny? value);
-  external JSAny? get video;
-  external set audio(JSAny? value);
-  external JSAny? get audio;
+  external set video(JSAny value);
+  external JSAny get video;
+  external set audio(JSAny value);
+  external JSAny get audio;
   external set controller(CaptureController value);
   external CaptureController get controller;
   external set selfBrowserSurface(SelfCapturePreferenceEnum value);

--- a/lib/src/dom/screen_orientation.dart
+++ b/lib/src/dom/screen_orientation.dart
@@ -16,7 +16,7 @@ class ScreenOrientation implements EventTarget {}
 
 extension ScreenOrientationExtension on ScreenOrientation {
   external JSPromise lock(OrientationLockType orientation);
-  external JSVoid unlock();
+  external void unlock();
   external OrientationType get type;
   external int get angle;
   external set onchange(EventHandler value);

--- a/lib/src/dom/scroll_animations.dart
+++ b/lib/src/dom/scroll_animations.dart
@@ -45,7 +45,7 @@ class ViewTimelineOptions implements JSObject {
   external factory ViewTimelineOptions({
     Element subject,
     ScrollAxis axis,
-    JSAny? inset,
+    JSAny inset,
   });
 }
 
@@ -54,8 +54,8 @@ extension ViewTimelineOptionsExtension on ViewTimelineOptions {
   external Element get subject;
   external set axis(ScrollAxis value);
   external ScrollAxis get axis;
-  external set inset(JSAny? value);
-  external JSAny? get inset;
+  external set inset(JSAny value);
+  external JSAny get inset;
 }
 
 @JS('ViewTimeline')

--- a/lib/src/dom/selection_api.dart
+++ b/lib/src/dom/selection_api.dart
@@ -12,38 +12,38 @@ class Selection implements JSObject {}
 
 extension SelectionExtension on Selection {
   external Range getRangeAt(int index);
-  external JSVoid addRange(Range range);
-  external JSVoid removeRange(Range range);
-  external JSVoid removeAllRanges();
-  external JSVoid empty();
+  external void addRange(Range range);
+  external void removeRange(Range range);
+  external void removeAllRanges();
+  external void empty();
   external JSArray getComposedRanges(ShadowRoot shadowRoots);
-  external JSVoid collapse(
+  external void collapse(
     Node? node, [
     int offset,
   ]);
-  external JSVoid setPosition(
+  external void setPosition(
     Node? node, [
     int offset,
   ]);
-  external JSVoid collapseToStart();
-  external JSVoid collapseToEnd();
-  external JSVoid extend(
+  external void collapseToStart();
+  external void collapseToEnd();
+  external void extend(
     Node node, [
     int offset,
   ]);
-  external JSVoid setBaseAndExtent(
+  external void setBaseAndExtent(
     Node anchorNode,
     int anchorOffset,
     Node focusNode,
     int focusOffset,
   );
-  external JSVoid selectAllChildren(Node node);
-  external JSVoid modify([
+  external void selectAllChildren(Node node);
+  external void modify([
     String alter,
     String direction,
     String granularity,
   ]);
-  external JSVoid deleteFromDocument();
+  external void deleteFromDocument();
   external bool containsNode(
     Node node, [
     bool allowPartialContainment,

--- a/lib/src/dom/service_workers.dart
+++ b/lib/src/dom/service_workers.dart
@@ -27,7 +27,7 @@ typedef ClientType = String;
 class ServiceWorker implements EventTarget, AbstractWorker {}
 
 extension ServiceWorkerExtension on ServiceWorker {
-  external JSVoid postMessage(
+  external void postMessage(
     JSAny? message, [
     JSObject optionsOrTransfer,
   ]);
@@ -77,7 +77,7 @@ extension ServiceWorkerContainerExtension on ServiceWorkerContainer {
   ]);
   external JSPromise getRegistration([String clientURL]);
   external JSPromise getRegistrations();
-  external JSVoid startMessages();
+  external void startMessages();
   external ServiceWorker? get controller;
   external JSPromise get ready;
   external set oncontrollerchange(EventHandler value);
@@ -191,7 +191,7 @@ extension ServiceWorkerGlobalScopeExtension on ServiceWorkerGlobalScope {
 class Client implements JSObject {}
 
 extension ClientExtension on Client {
-  external JSVoid postMessage(
+  external void postMessage(
     JSAny? message, [
     JSObject optionsOrTransfer,
   ]);
@@ -252,7 +252,7 @@ class ExtendableEvent implements Event {
 }
 
 extension ExtendableEventExtension on ExtendableEvent {
-  external JSVoid waitUntil(JSPromise f);
+  external void waitUntil(JSPromise f);
 }
 
 @JS()
@@ -272,7 +272,7 @@ class FetchEvent implements ExtendableEvent {
 }
 
 extension FetchEventExtension on FetchEvent {
-  external JSVoid respondWith(JSPromise r);
+  external void respondWith(JSPromise r);
   external Request get request;
   external JSPromise get preloadResponse;
   external String get clientId;

--- a/lib/src/dom/shared_storage.dart
+++ b/lib/src/dom/shared_storage.dart
@@ -6,7 +6,7 @@ import 'dart:js_interop';
 
 import 'html.dart';
 
-typedef SharedStorageResponse = JSAny?;
+typedef SharedStorageResponse = JSAny;
 typedef SharedStorageOperationConstructor = JSFunction;
 
 @JS('SharedStorageWorklet')
@@ -19,7 +19,7 @@ class SharedStorageWorkletGlobalScope implements WorkletGlobalScope {}
 
 extension SharedStorageWorkletGlobalScopeExtension
     on SharedStorageWorkletGlobalScope {
-  external JSVoid register(
+  external void register(
     String name,
     SharedStorageOperationConstructor operationCtor,
   );

--- a/lib/src/dom/speech_api.dart
+++ b/lib/src/dom/speech_api.dart
@@ -17,9 +17,9 @@ class SpeechRecognition implements EventTarget {
 }
 
 extension SpeechRecognitionExtension on SpeechRecognition {
-  external JSVoid start();
-  external JSVoid stop();
-  external JSVoid abort();
+  external void start();
+  external void stop();
+  external void abort();
   external set grammars(SpeechGrammarList value);
   external SpeechGrammarList get grammars;
   external set lang(String value);
@@ -165,11 +165,11 @@ class SpeechGrammarList implements JSObject {
 
 extension SpeechGrammarListExtension on SpeechGrammarList {
   external SpeechGrammar item(int index);
-  external JSVoid addFromURI(
+  external void addFromURI(
     String src, [
     num weight,
   ]);
-  external JSVoid addFromString(
+  external void addFromString(
     String string, [
     num weight,
   ]);
@@ -181,10 +181,10 @@ extension SpeechGrammarListExtension on SpeechGrammarList {
 class SpeechSynthesis implements EventTarget {}
 
 extension SpeechSynthesisExtension on SpeechSynthesis {
-  external JSVoid speak(SpeechSynthesisUtterance utterance);
-  external JSVoid cancel();
-  external JSVoid pause();
-  external JSVoid resume();
+  external void speak(SpeechSynthesisUtterance utterance);
+  external void cancel();
+  external void pause();
+  external void resume();
   external JSArray getVoices();
   external bool get pending;
   external bool get speaking;

--- a/lib/src/dom/streams.dart
+++ b/lib/src/dom/streams.dart
@@ -161,7 +161,7 @@ class ReadableStreamDefaultReader implements ReadableStreamGenericReader {
 
 extension ReadableStreamDefaultReaderExtension on ReadableStreamDefaultReader {
   external JSPromise read();
-  external JSVoid releaseLock();
+  external void releaseLock();
 }
 
 @JS()
@@ -189,7 +189,7 @@ class ReadableStreamBYOBReader implements ReadableStreamGenericReader {
 
 extension ReadableStreamBYOBReaderExtension on ReadableStreamBYOBReader {
   external JSPromise read(ArrayBufferView view);
-  external JSVoid releaseLock();
+  external void releaseLock();
 }
 
 @JS('ReadableStreamDefaultController')
@@ -198,9 +198,9 @@ class ReadableStreamDefaultController implements JSObject {}
 
 extension ReadableStreamDefaultControllerExtension
     on ReadableStreamDefaultController {
-  external JSVoid close();
-  external JSVoid enqueue([JSAny? chunk]);
-  external JSVoid error([JSAny? e]);
+  external void close();
+  external void enqueue([JSAny? chunk]);
+  external void error([JSAny? e]);
   external num? get desiredSize;
 }
 
@@ -210,9 +210,9 @@ class ReadableByteStreamController implements JSObject {}
 
 extension ReadableByteStreamControllerExtension
     on ReadableByteStreamController {
-  external JSVoid close();
-  external JSVoid enqueue(ArrayBufferView chunk);
-  external JSVoid error([JSAny? e]);
+  external void close();
+  external void enqueue(ArrayBufferView chunk);
+  external void error([JSAny? e]);
   external ReadableStreamBYOBRequest? get byobRequest;
   external num? get desiredSize;
 }
@@ -222,8 +222,8 @@ extension ReadableByteStreamControllerExtension
 class ReadableStreamBYOBRequest implements JSObject {}
 
 extension ReadableStreamBYOBRequestExtension on ReadableStreamBYOBRequest {
-  external JSVoid respond(int bytesWritten);
-  external JSVoid respondWithNewView(ArrayBufferView view);
+  external void respond(int bytesWritten);
+  external void respondWithNewView(ArrayBufferView view);
   external ArrayBufferView? get view;
 }
 
@@ -278,7 +278,7 @@ class WritableStreamDefaultWriter implements JSObject {
 extension WritableStreamDefaultWriterExtension on WritableStreamDefaultWriter {
   external JSPromise abort([JSAny? reason]);
   external JSPromise close();
-  external JSVoid releaseLock();
+  external void releaseLock();
   external JSPromise write([JSAny? chunk]);
   external JSPromise get closed;
   external num? get desiredSize;
@@ -291,7 +291,7 @@ class WritableStreamDefaultController implements JSObject {}
 
 extension WritableStreamDefaultControllerExtension
     on WritableStreamDefaultController {
-  external JSVoid error([JSAny? e]);
+  external void error([JSAny? e]);
   external AbortSignal get signal;
 }
 
@@ -345,9 +345,9 @@ class TransformStreamDefaultController implements JSObject {}
 
 extension TransformStreamDefaultControllerExtension
     on TransformStreamDefaultController {
-  external JSVoid enqueue([JSAny? chunk]);
-  external JSVoid error([JSAny? reason]);
-  external JSVoid terminate();
+  external void enqueue([JSAny? chunk]);
+  external void error([JSAny? reason]);
+  external void terminate();
   external num? get desiredSize;
 }
 

--- a/lib/src/dom/svg.dart
+++ b/lib/src/dom/svg.dart
@@ -98,11 +98,11 @@ class SVGLength implements JSObject {
 }
 
 extension SVGLengthExtension on SVGLength {
-  external JSVoid newValueSpecifiedUnits(
+  external void newValueSpecifiedUnits(
     int unitType,
     num valueInSpecifiedUnits,
   );
-  external JSVoid convertToSpecifiedUnits(int unitType);
+  external void convertToSpecifiedUnits(int unitType);
   external int get unitType;
   external set value(num value);
   external num get value;
@@ -123,11 +123,11 @@ class SVGAngle implements JSObject {
 }
 
 extension SVGAngleExtension on SVGAngle {
-  external JSVoid newValueSpecifiedUnits(
+  external void newValueSpecifiedUnits(
     int unitType,
     num valueInSpecifiedUnits,
   );
-  external JSVoid convertToSpecifiedUnits(int unitType);
+  external void convertToSpecifiedUnits(int unitType);
   external int get unitType;
   external set value(num value);
   external num get value;
@@ -142,7 +142,7 @@ extension SVGAngleExtension on SVGAngle {
 class SVGNumberList implements JSObject {}
 
 extension SVGNumberListExtension on SVGNumberList {
-  external JSVoid clear();
+  external void clear();
   external SVGNumber initialize(SVGNumber newItem);
   external SVGNumber getItem(int index);
   external SVGNumber insertItemBefore(
@@ -164,7 +164,7 @@ extension SVGNumberListExtension on SVGNumberList {
 class SVGLengthList implements JSObject {}
 
 extension SVGLengthListExtension on SVGLengthList {
-  external JSVoid clear();
+  external void clear();
   external SVGLength initialize(SVGLength newItem);
   external SVGLength getItem(int index);
   external SVGLength insertItemBefore(
@@ -186,7 +186,7 @@ extension SVGLengthListExtension on SVGLengthList {
 class SVGStringList implements JSObject {}
 
 extension SVGStringListExtension on SVGStringList {
-  external JSVoid clear();
+  external void clear();
   external String initialize(String newItem);
   external String getItem(int index);
   external String insertItemBefore(
@@ -354,7 +354,7 @@ extension SVGSVGElementExtension on SVGSVGElement {
     SVGElement element,
     DOMRectReadOnly rect,
   );
-  external JSVoid deselectAll();
+  external void deselectAll();
   external SVGNumber createSVGNumber();
   external SVGLength createSVGLength();
   external SVGAngle createSVGAngle();
@@ -365,14 +365,14 @@ extension SVGSVGElementExtension on SVGSVGElement {
   external SVGTransform createSVGTransformFromMatrix([DOMMatrix2DInit matrix]);
   external Element getElementById(String elementId);
   external int suspendRedraw(int maxWaitMilliseconds);
-  external JSVoid unsuspendRedraw(int suspendHandleID);
-  external JSVoid unsuspendRedrawAll();
-  external JSVoid forceRedraw();
-  external JSVoid pauseAnimations();
-  external JSVoid unpauseAnimations();
+  external void unsuspendRedraw(int suspendHandleID);
+  external void unsuspendRedrawAll();
+  external void forceRedraw();
+  external void pauseAnimations();
+  external void unpauseAnimations();
   external bool animationsPaused();
   external num getCurrentTime();
-  external JSVoid setCurrentTime(num seconds);
+  external void setCurrentTime(num seconds);
   external SVGAnimatedLength get x;
   external SVGAnimatedLength get y;
   external SVGAnimatedLength get width;
@@ -483,22 +483,22 @@ class SVGTransform implements JSObject {
 }
 
 extension SVGTransformExtension on SVGTransform {
-  external JSVoid setMatrix([DOMMatrix2DInit matrix]);
-  external JSVoid setTranslate(
+  external void setMatrix([DOMMatrix2DInit matrix]);
+  external void setTranslate(
     num tx,
     num ty,
   );
-  external JSVoid setScale(
+  external void setScale(
     num sx,
     num sy,
   );
-  external JSVoid setRotate(
+  external void setRotate(
     num angle,
     num cx,
     num cy,
   );
-  external JSVoid setSkewX(num angle);
-  external JSVoid setSkewY(num angle);
+  external void setSkewX(num angle);
+  external void setSkewY(num angle);
   external int get type;
   external DOMMatrix get matrix;
   external num get angle;
@@ -509,7 +509,7 @@ extension SVGTransformExtension on SVGTransform {
 class SVGTransformList implements JSObject {}
 
 extension SVGTransformListExtension on SVGTransformList {
-  external JSVoid clear();
+  external void clear();
   external SVGTransform initialize(SVGTransform newItem);
   external SVGTransform getItem(int index);
   external SVGTransform insertItemBefore(
@@ -636,7 +636,7 @@ extension SVGAnimatedPointsExtension on SVGAnimatedPoints {
 class SVGPointList implements JSObject {}
 
 extension SVGPointListExtension on SVGPointList {
-  external JSVoid clear();
+  external void clear();
   external DOMPoint initialize(DOMPoint newItem);
   external DOMPoint getItem(int index);
   external DOMPoint insertItemBefore(
@@ -681,7 +681,7 @@ extension SVGTextContentElementExtension on SVGTextContentElement {
   external DOMRect getExtentOfChar(int charnum);
   external num getRotationOfChar(int charnum);
   external int getCharNumAtPosition([DOMPointInit point]);
-  external JSVoid selectSubString(
+  external void selectSubString(
     int charnum,
     int nchars,
   );
@@ -763,8 +763,8 @@ class SVGMarkerElement implements SVGElement, SVGFitToViewBox {
 }
 
 extension SVGMarkerElementExtension on SVGMarkerElement {
-  external JSVoid setOrientToAuto();
-  external JSVoid setOrientToAngle(SVGAngle angle);
+  external void setOrientToAuto();
+  external void setOrientToAngle(SVGAngle angle);
   external SVGAnimatedLength get refX;
   external SVGAnimatedLength get refY;
   external SVGAnimatedEnumeration get markerUnits;

--- a/lib/src/dom/svg_animations.dart
+++ b/lib/src/dom/svg_animations.dart
@@ -13,7 +13,7 @@ import 'svg.dart';
 class TimeEvent implements Event {}
 
 extension TimeEventExtension on TimeEvent {
-  external JSVoid initTimeEvent(
+  external void initTimeEvent(
     String typeArg,
     Window? viewArg,
     int detailArg,
@@ -30,10 +30,10 @@ extension SVGAnimationElementExtension on SVGAnimationElement {
   external num getStartTime();
   external num getCurrentTime();
   external num getSimpleDuration();
-  external JSVoid beginElement();
-  external JSVoid beginElementAt(num offset);
-  external JSVoid endElement();
-  external JSVoid endElementAt(num offset);
+  external void beginElement();
+  external void beginElementAt(num offset);
+  external void endElement();
+  external void endElementAt(num offset);
   external SVGElement? get targetElement;
   external set onbegin(EventHandler value);
   external EventHandler get onbegin;

--- a/lib/src/dom/turtledove.dart
+++ b/lib/src/dom/turtledove.dart
@@ -41,7 +41,7 @@ class GenerateBidInterestGroup implements JSObject {
     required String name,
     required num lifetimeMs,
     bool enableBiddingSignalsPrioritization,
-    JSAny? priorityVector,
+    JSAny priorityVector,
     String executionMode,
     String biddingLogicURL,
     String biddingWasmHelperURL,
@@ -63,8 +63,8 @@ extension GenerateBidInterestGroupExtension on GenerateBidInterestGroup {
   external num get lifetimeMs;
   external set enableBiddingSignalsPrioritization(bool value);
   external bool get enableBiddingSignalsPrioritization;
-  external set priorityVector(JSAny? value);
-  external JSAny? get priorityVector;
+  external set priorityVector(JSAny value);
+  external JSAny get priorityVector;
   external set executionMode(String value);
   external String get executionMode;
   external set biddingLogicURL(String value);
@@ -91,15 +91,15 @@ extension GenerateBidInterestGroupExtension on GenerateBidInterestGroup {
 class AuctionAdInterestGroup implements GenerateBidInterestGroup {
   external factory AuctionAdInterestGroup({
     num priority,
-    JSAny? prioritySignalsOverrides,
+    JSAny prioritySignalsOverrides,
   });
 }
 
 extension AuctionAdInterestGroupExtension on AuctionAdInterestGroup {
   external set priority(num value);
   external num get priority;
-  external set prioritySignalsOverrides(JSAny? value);
-  external JSAny? get prioritySignalsOverrides;
+  external set prioritySignalsOverrides(JSAny value);
+  external JSAny get prioritySignalsOverrides;
 }
 
 @JS()
@@ -136,9 +136,9 @@ class AuctionAdConfig implements JSObject {
     String sellerCurrency,
     JSPromise perBuyerSignals,
     JSPromise perBuyerTimeouts,
-    JSAny? perBuyerGroupLimits,
-    JSAny? perBuyerExperimentGroupIds,
-    JSAny? perBuyerPrioritySignals,
+    JSAny perBuyerGroupLimits,
+    JSAny perBuyerExperimentGroupIds,
+    JSAny perBuyerPrioritySignals,
     JSPromise perBuyerCurrencies,
     JSArray componentAuctions,
     AbortSignal? signal,
@@ -171,12 +171,12 @@ extension AuctionAdConfigExtension on AuctionAdConfig {
   external JSPromise get perBuyerSignals;
   external set perBuyerTimeouts(JSPromise value);
   external JSPromise get perBuyerTimeouts;
-  external set perBuyerGroupLimits(JSAny? value);
-  external JSAny? get perBuyerGroupLimits;
-  external set perBuyerExperimentGroupIds(JSAny? value);
-  external JSAny? get perBuyerExperimentGroupIds;
-  external set perBuyerPrioritySignals(JSAny? value);
-  external JSAny? get perBuyerPrioritySignals;
+  external set perBuyerGroupLimits(JSAny value);
+  external JSAny get perBuyerGroupLimits;
+  external set perBuyerExperimentGroupIds(JSAny value);
+  external JSAny get perBuyerExperimentGroupIds;
+  external set perBuyerPrioritySignals(JSAny value);
+  external JSAny get perBuyerPrioritySignals;
   external set perBuyerCurrencies(JSPromise value);
   external JSPromise get perBuyerCurrencies;
   external set componentAuctions(JSArray value);
@@ -199,8 +199,8 @@ class InterestGroupBiddingScriptRunnerGlobalScope
 extension InterestGroupBiddingScriptRunnerGlobalScopeExtension
     on InterestGroupBiddingScriptRunnerGlobalScope {
   external bool setBid([GenerateBidOutput generateBidOutput]);
-  external JSVoid setPriority(num priority);
-  external JSVoid setPrioritySignalsOverride(
+  external void setPriority(num priority);
+  external void setPrioritySignalsOverride(
     String key, [
     num? priority,
   ]);
@@ -233,7 +233,7 @@ class GenerateBidOutput implements JSObject {
   external factory GenerateBidOutput({
     num bid,
     String bidCurrency,
-    JSAny? render,
+    JSAny render,
     JSAny? ad,
     JSArray adComponents,
     num adCost,
@@ -247,8 +247,8 @@ extension GenerateBidOutputExtension on GenerateBidOutput {
   external num get bid;
   external set bidCurrency(String value);
   external String get bidCurrency;
-  external set render(JSAny? value);
-  external JSAny? get render;
+  external set render(JSAny value);
+  external JSAny get render;
   external set ad(JSAny? value);
   external JSAny? get ad;
   external set adComponents(JSArray value);
@@ -273,9 +273,9 @@ class InterestGroupReportingScriptRunnerGlobalScope
 
 extension InterestGroupReportingScriptRunnerGlobalScopeExtension
     on InterestGroupReportingScriptRunnerGlobalScope {
-  external JSVoid sendReportTo(String url);
-  external JSVoid registerAdBeacon(JSAny? map);
-  external JSVoid registerAdMacro(
+  external void sendReportTo(String url);
+  external void registerAdBeacon(JSAny map);
+  external void registerAdMacro(
     String name,
     String value,
   );

--- a/lib/src/dom/uievents.dart
+++ b/lib/src/dom/uievents.dart
@@ -18,7 +18,7 @@ class UIEvent implements Event {
 }
 
 extension UIEventExtension on UIEvent {
-  external JSVoid initUIEvent(
+  external void initUIEvent(
     String typeArg, [
     bool bubblesArg,
     bool cancelableArg,
@@ -90,7 +90,7 @@ class MouseEvent implements UIEvent {
 
 extension MouseEventExtension on MouseEvent {
   external bool getModifierState(String keyArg);
-  external JSVoid initMouseEvent(
+  external void initMouseEvent(
     String typeArg, [
     bool bubblesArg,
     bool cancelableArg,
@@ -323,7 +323,7 @@ class KeyboardEvent implements UIEvent {
 
 extension KeyboardEventExtension on KeyboardEvent {
   external bool getModifierState(String keyArg);
-  external JSVoid initKeyboardEvent(
+  external void initKeyboardEvent(
     String typeArg, [
     bool bubblesArg,
     bool cancelableArg,
@@ -390,7 +390,7 @@ class CompositionEvent implements UIEvent {
 }
 
 extension CompositionEventExtension on CompositionEvent {
-  external JSVoid initCompositionEvent(
+  external void initCompositionEvent(
     String typeArg, [
     bool bubblesArg,
     bool cancelableArg,
@@ -421,7 +421,7 @@ class MutationEvent implements Event {
 }
 
 extension MutationEventExtension on MutationEvent {
-  external JSVoid initMutationEvent(
+  external void initMutationEvent(
     String typeArg, [
     bool bubblesArg,
     bool cancelableArg,

--- a/lib/src/dom/url.dart
+++ b/lib/src/dom/url.dart
@@ -13,7 +13,7 @@ class URL implements JSObject {
   ]);
 
   external static String createObjectURL(JSObject obj);
-  external static JSVoid revokeObjectURL(String url);
+  external static void revokeObjectURL(String url);
   external static bool canParse(
     String url, [
     String base,
@@ -49,15 +49,15 @@ extension URLExtension on URL {
 @JS('URLSearchParams')
 @staticInterop
 class URLSearchParams implements JSObject {
-  external factory URLSearchParams([JSAny? init]);
+  external factory URLSearchParams([JSAny init]);
 }
 
 extension URLSearchParamsExtension on URLSearchParams {
-  external JSVoid append(
+  external void append(
     String name,
     String value,
   );
-  external JSVoid delete(
+  external void delete(
     String name, [
     String value,
   ]);
@@ -67,10 +67,10 @@ extension URLSearchParamsExtension on URLSearchParams {
     String name, [
     String value,
   ]);
-  external JSVoid set(
+  external void set(
     String name,
     String value,
   );
-  external JSVoid sort();
+  external void sort();
   external int get size;
 }

--- a/lib/src/dom/urlpattern.dart
+++ b/lib/src/dom/urlpattern.dart
@@ -4,14 +4,14 @@
 
 import 'dart:js_interop';
 
-typedef URLPatternInput = JSAny?;
+typedef URLPatternInput = JSAny;
 
 @JS('URLPattern')
 @staticInterop
 class URLPattern implements JSObject {
   external factory URLPattern([
     URLPatternInput input,
-    JSAny? baseURLOrOptions,
+    JSAny baseURLOrOptions,
     URLPatternOptions options,
   ]);
 }
@@ -129,13 +129,13 @@ extension URLPatternResultExtension on URLPatternResult {
 class URLPatternComponentResult implements JSObject {
   external factory URLPatternComponentResult({
     String input,
-    JSAny? groups,
+    JSAny groups,
   });
 }
 
 extension URLPatternComponentResultExtension on URLPatternComponentResult {
   external set input(String value);
   external String get input;
-  external set groups(JSAny? value);
-  external JSAny? get groups;
+  external set groups(JSAny value);
+  external JSAny get groups;
 }

--- a/lib/src/dom/user_timing.dart
+++ b/lib/src/dom/user_timing.dart
@@ -30,21 +30,21 @@ extension PerformanceMarkOptionsExtension on PerformanceMarkOptions {
 class PerformanceMeasureOptions implements JSObject {
   external factory PerformanceMeasureOptions({
     JSAny? detail,
-    JSAny? start,
+    JSAny start,
     DOMHighResTimeStamp duration,
-    JSAny? end,
+    JSAny end,
   });
 }
 
 extension PerformanceMeasureOptionsExtension on PerformanceMeasureOptions {
   external set detail(JSAny? value);
   external JSAny? get detail;
-  external set start(JSAny? value);
-  external JSAny? get start;
+  external set start(JSAny value);
+  external JSAny get start;
   external set duration(DOMHighResTimeStamp value);
   external DOMHighResTimeStamp get duration;
-  external set end(JSAny? value);
-  external JSAny? get end;
+  external set end(JSAny value);
+  external JSAny get end;
 }
 
 @JS('PerformanceMark')

--- a/lib/src/dom/vibration.dart
+++ b/lib/src/dom/vibration.dart
@@ -4,4 +4,4 @@
 
 import 'dart:js_interop';
 
-typedef VibratePattern = JSAny?;
+typedef VibratePattern = JSAny;

--- a/lib/src/dom/virtual_keyboard.dart
+++ b/lib/src/dom/virtual_keyboard.dart
@@ -13,8 +13,8 @@ import 'html.dart';
 class VirtualKeyboard implements EventTarget {}
 
 extension VirtualKeyboardExtension on VirtualKeyboard {
-  external JSVoid show();
-  external JSVoid hide();
+  external void show();
+  external void hide();
   external DOMRect get boundingRect;
   external set overlaysContent(bool value);
   external bool get overlaysContent;

--- a/lib/src/dom/wasm_js_api.dart
+++ b/lib/src/dom/wasm_js_api.dart
@@ -175,7 +175,7 @@ extension TableExtension on Table {
     JSAny? value,
   ]);
   external JSAny? get(int index);
-  external JSVoid set(
+  external void set(
     int index, [
     JSAny? value,
   ]);

--- a/lib/src/dom/web_animations.dart
+++ b/lib/src/dom/web_animations.dart
@@ -55,14 +55,14 @@ class Animation implements EventTarget {
 }
 
 extension AnimationExtension on Animation {
-  external JSVoid cancel();
-  external JSVoid finish();
-  external JSVoid play();
-  external JSVoid pause();
-  external JSVoid updatePlaybackRate(num playbackRate);
-  external JSVoid reverse();
-  external JSVoid persist();
-  external JSVoid commitStyles();
+  external void cancel();
+  external void finish();
+  external void play();
+  external void pause();
+  external void updatePlaybackRate(num playbackRate);
+  external void reverse();
+  external void persist();
+  external void commitStyles();
   external set startTime(CSSNumberish? value);
   external CSSNumberish? get startTime;
   external set currentTime(CSSNumberish? value);
@@ -93,13 +93,13 @@ extension AnimationExtension on Animation {
 class AnimationEffect implements JSObject {}
 
 extension AnimationEffectExtension on AnimationEffect {
-  external JSVoid before(AnimationEffect effects);
-  external JSVoid after(AnimationEffect effects);
-  external JSVoid replace(AnimationEffect effects);
-  external JSVoid remove();
+  external void before(AnimationEffect effects);
+  external void after(AnimationEffect effects);
+  external void replace(AnimationEffect effects);
+  external void remove();
   external EffectTiming getTiming();
   external ComputedEffectTiming getComputedTiming();
-  external JSVoid updateTiming([OptionalEffectTiming timing]);
+  external void updateTiming([OptionalEffectTiming timing]);
   external GroupEffect? get parent;
   external AnimationEffect? get previousSibling;
   external AnimationEffect? get nextSibling;
@@ -113,7 +113,7 @@ class EffectTiming implements JSObject {
     num delay,
     num endDelay,
     num playbackRate,
-    JSAny? duration,
+    JSAny duration,
     FillMode fill,
     num iterationStart,
     num iterations,
@@ -129,8 +129,8 @@ extension EffectTimingExtension on EffectTiming {
   external num get endDelay;
   external set playbackRate(num value);
   external num get playbackRate;
-  external set duration(JSAny? value);
-  external JSAny? get duration;
+  external set duration(JSAny value);
+  external JSAny get duration;
   external set fill(FillMode value);
   external FillMode get fill;
   external set iterationStart(num value);
@@ -154,7 +154,7 @@ class OptionalEffectTiming implements JSObject {
     FillMode fill,
     num iterationStart,
     num iterations,
-    JSAny? duration,
+    JSAny duration,
     PlaybackDirection direction,
     String easing,
   });
@@ -173,8 +173,8 @@ extension OptionalEffectTimingExtension on OptionalEffectTiming {
   external num get iterationStart;
   external set iterations(num value);
   external num get iterations;
-  external set duration(JSAny? value);
-  external JSAny? get duration;
+  external set duration(JSAny value);
+  external JSAny get duration;
   external set direction(PlaybackDirection value);
   external PlaybackDirection get direction;
   external set easing(String value);
@@ -216,13 +216,13 @@ class KeyframeEffect implements AnimationEffect {
   external factory KeyframeEffect(
     JSObject? sourceOrTarget, [
     JSObject? keyframes,
-    JSAny? options,
+    JSAny options,
   ]);
 }
 
 extension KeyframeEffectExtension on KeyframeEffect {
   external JSArray getKeyframes();
-  external JSVoid setKeyframes(JSObject? keyframes);
+  external void setKeyframes(JSObject? keyframes);
   external set iterationComposite(IterationCompositeOperation value);
   external IterationCompositeOperation get iterationComposite;
   external set target(Element? value);
@@ -262,18 +262,18 @@ extension BaseComputedKeyframeExtension on BaseComputedKeyframe {
 class BasePropertyIndexedKeyframe implements JSObject {
   external factory BasePropertyIndexedKeyframe({
     JSAny? offset,
-    JSAny? easing,
-    JSAny? composite,
+    JSAny easing,
+    JSAny composite,
   });
 }
 
 extension BasePropertyIndexedKeyframeExtension on BasePropertyIndexedKeyframe {
   external set offset(JSAny? value);
   external JSAny? get offset;
-  external set easing(JSAny? value);
-  external JSAny? get easing;
-  external set composite(JSAny? value);
-  external JSAny? get composite;
+  external set easing(JSAny value);
+  external JSAny get easing;
+  external set composite(JSAny value);
+  external JSAny get composite;
 }
 
 @JS()
@@ -323,7 +323,7 @@ class Animatable implements JSObject {}
 extension AnimatableExtension on Animatable {
   external Animation animate(
     JSObject? keyframes, [
-    JSAny? options,
+    JSAny options,
   ]);
   external JSArray getAnimations([GetAnimationsOptions options]);
 }
@@ -333,18 +333,18 @@ extension AnimatableExtension on Animatable {
 @anonymous
 class KeyframeAnimationOptions implements KeyframeEffectOptions {
   external factory KeyframeAnimationOptions({
-    JSAny? rangeStart,
-    JSAny? rangeEnd,
+    JSAny rangeStart,
+    JSAny rangeEnd,
     String id,
     AnimationTimeline? timeline,
   });
 }
 
 extension KeyframeAnimationOptionsExtension on KeyframeAnimationOptions {
-  external set rangeStart(JSAny? value);
-  external JSAny? get rangeStart;
-  external set rangeEnd(JSAny? value);
-  external JSAny? get rangeEnd;
+  external set rangeStart(JSAny value);
+  external JSAny get rangeStart;
+  external set rangeEnd(JSAny value);
+  external JSAny get rangeEnd;
   external set id(String value);
   external String get id;
   external set timeline(AnimationTimeline? value);

--- a/lib/src/dom/web_animations_2.dart
+++ b/lib/src/dom/web_animations_2.dart
@@ -16,14 +16,14 @@ typedef IterationCompositeOperation = String;
 class GroupEffect implements JSObject {
   external factory GroupEffect(
     JSArray? children, [
-    JSAny? timing,
+    JSAny timing,
   ]);
 }
 
 extension GroupEffectExtension on GroupEffect {
   external GroupEffect clone();
-  external JSVoid prepend(AnimationEffect effects);
-  external JSVoid append(AnimationEffect effects);
+  external void prepend(AnimationEffect effects);
+  external void append(AnimationEffect effects);
   external AnimationNodeList get children;
   external AnimationEffect? get firstChild;
   external AnimationEffect? get lastChild;
@@ -43,7 +43,7 @@ extension AnimationNodeListExtension on AnimationNodeList {
 class SequenceEffect implements GroupEffect {
   external factory SequenceEffect(
     JSArray? children, [
-    JSAny? timing,
+    JSAny timing,
   ]);
 }
 

--- a/lib/src/dom/web_app_launch.dart
+++ b/lib/src/dom/web_app_launch.dart
@@ -20,5 +20,5 @@ extension LaunchParamsExtension on LaunchParams {
 class LaunchQueue implements JSObject {}
 
 extension LaunchQueueExtension on LaunchQueue {
-  external JSVoid setConsumer(LaunchConsumer consumer);
+  external void setConsumer(LaunchConsumer consumer);
 }

--- a/lib/src/dom/web_bluetooth.dart
+++ b/lib/src/dom/web_bluetooth.dart
@@ -10,9 +10,9 @@ import 'permissions.dart';
 import 'webidl.dart';
 
 typedef UUID = String;
-typedef BluetoothServiceUUID = JSAny?;
-typedef BluetoothCharacteristicUUID = JSAny?;
-typedef BluetoothDescriptorUUID = JSAny?;
+typedef BluetoothServiceUUID = JSAny;
+typedef BluetoothCharacteristicUUID = JSAny;
+typedef BluetoothDescriptorUUID = JSAny;
 
 @JS()
 @staticInterop
@@ -163,7 +163,7 @@ class AllowedBluetoothDevice implements JSObject {
   external factory AllowedBluetoothDevice({
     required String deviceId,
     required bool mayUseGATT,
-    required JSAny? allowedServices,
+    required JSAny allowedServices,
     required JSArray allowedManufacturerData,
   });
 }
@@ -173,8 +173,8 @@ extension AllowedBluetoothDeviceExtension on AllowedBluetoothDevice {
   external String get deviceId;
   external set mayUseGATT(bool value);
   external bool get mayUseGATT;
-  external set allowedServices(JSAny? value);
-  external JSAny? get allowedServices;
+  external set allowedServices(JSAny value);
+  external JSAny get allowedServices;
   external set allowedManufacturerData(JSArray value);
   external JSArray get allowedManufacturerData;
 }
@@ -331,7 +331,7 @@ class BluetoothRemoteGATTServer implements JSObject {}
 
 extension BluetoothRemoteGATTServerExtension on BluetoothRemoteGATTServer {
   external JSPromise connect();
-  external JSVoid disconnect();
+  external void disconnect();
   external JSPromise getPrimaryService(BluetoothServiceUUID service);
   external JSPromise getPrimaryServices([BluetoothServiceUUID service]);
   external BluetoothDevice get device;
@@ -443,8 +443,8 @@ extension ServiceEventHandlersExtension on ServiceEventHandlers {
 @JS('BluetoothUUID')
 @staticInterop
 class BluetoothUUID implements JSObject {
-  external static UUID getService(JSAny? name);
-  external static UUID getCharacteristic(JSAny? name);
-  external static UUID getDescriptor(JSAny? name);
+  external static UUID getService(JSAny name);
+  external static UUID getCharacteristic(JSAny name);
+  external static UUID getDescriptor(JSAny name);
   external static UUID canonicalUUID(int alias);
 }

--- a/lib/src/dom/web_nfc.dart
+++ b/lib/src/dom/web_nfc.dart
@@ -7,7 +7,7 @@ import 'dart:js_interop';
 import 'dom.dart';
 import 'html.dart';
 
-typedef NDEFMessageSource = JSAny?;
+typedef NDEFMessageSource = JSAny;
 
 @JS('NDEFMessage')
 @staticInterop

--- a/lib/src/dom/webaudio.dart
+++ b/lib/src/dom/webaudio.dart
@@ -91,7 +91,7 @@ extension AudioContextExtension on AudioContext {
   external JSPromise resume();
   external JSPromise suspend();
   external JSPromise close();
-  external JSPromise setSinkId(JSAny? sinkId);
+  external JSPromise setSinkId(JSAny sinkId);
   external MediaElementAudioSourceNode createMediaElementSource(
       HTMLMediaElement mediaElement);
   external MediaStreamAudioSourceNode createMediaStreamSource(
@@ -101,7 +101,7 @@ extension AudioContextExtension on AudioContext {
   external MediaStreamAudioDestinationNode createMediaStreamDestination();
   external num get baseLatency;
   external num get outputLatency;
-  external JSAny? get sinkId;
+  external JSAny get sinkId;
   external AudioRenderCapacity get renderCapacity;
   external set onsinkchange(EventHandler value);
   external EventHandler get onsinkchange;
@@ -112,22 +112,22 @@ extension AudioContextExtension on AudioContext {
 @anonymous
 class AudioContextOptions implements JSObject {
   external factory AudioContextOptions({
-    JSAny? latencyHint,
+    JSAny latencyHint,
     num sampleRate,
-    JSAny? sinkId,
-    JSAny? renderSizeHint,
+    JSAny sinkId,
+    JSAny renderSizeHint,
   });
 }
 
 extension AudioContextOptionsExtension on AudioContextOptions {
-  external set latencyHint(JSAny? value);
-  external JSAny? get latencyHint;
+  external set latencyHint(JSAny value);
+  external JSAny get latencyHint;
   external set sampleRate(num value);
   external num get sampleRate;
-  external set sinkId(JSAny? value);
-  external JSAny? get sinkId;
-  external set renderSizeHint(JSAny? value);
-  external JSAny? get renderSizeHint;
+  external set sinkId(JSAny value);
+  external JSAny get sinkId;
+  external set renderSizeHint(JSAny value);
+  external JSAny get renderSizeHint;
 }
 
 @JS()
@@ -172,8 +172,8 @@ extension AudioTimestampExtension on AudioTimestamp {
 class AudioRenderCapacity implements EventTarget {}
 
 extension AudioRenderCapacityExtension on AudioRenderCapacity {
-  external JSVoid start([AudioRenderCapacityOptions options]);
-  external JSVoid stop();
+  external void start([AudioRenderCapacityOptions options]);
+  external void stop();
   external set onupdate(EventHandler value);
   external EventHandler get onupdate;
 }
@@ -234,7 +234,7 @@ extension AudioRenderCapacityEventInitExtension
 @staticInterop
 class OfflineAudioContext implements BaseAudioContext {
   external factory OfflineAudioContext(
-    JSAny? contextOptionsOrNumberOfChannels, [
+    JSAny contextOptionsOrNumberOfChannels, [
     int length,
     num sampleRate,
   ]);
@@ -257,7 +257,7 @@ class OfflineAudioContextOptions implements JSObject {
     int numberOfChannels,
     required int length,
     required num sampleRate,
-    JSAny? renderSizeHint,
+    JSAny renderSizeHint,
   });
 }
 
@@ -268,8 +268,8 @@ extension OfflineAudioContextOptionsExtension on OfflineAudioContextOptions {
   external int get length;
   external set sampleRate(num value);
   external num get sampleRate;
-  external set renderSizeHint(JSAny? value);
-  external JSAny? get renderSizeHint;
+  external set renderSizeHint(JSAny value);
+  external JSAny get renderSizeHint;
 }
 
 @JS('OfflineAudioCompletionEvent')
@@ -307,12 +307,12 @@ class AudioBuffer implements JSObject {
 
 extension AudioBufferExtension on AudioBuffer {
   external JSFloat32Array getChannelData(int channel);
-  external JSVoid copyFromChannel(
+  external void copyFromChannel(
     JSFloat32Array destination,
     int channelNumber, [
     int bufferOffset,
   ]);
-  external JSVoid copyToChannel(
+  external void copyToChannel(
     JSFloat32Array source,
     int channelNumber, [
     int bufferOffset,
@@ -353,8 +353,8 @@ extension AudioNodeExtension on AudioNode {
     int output,
     int input,
   ]);
-  external JSVoid disconnect([
-    JSAny? destinationNodeOrDestinationParamOrOutput,
+  external void disconnect([
+    JSAny destinationNodeOrDestinationParamOrOutput,
     int output,
     int input,
   ]);
@@ -432,8 +432,8 @@ extension AudioParamExtension on AudioParam {
 class AudioScheduledSourceNode implements AudioNode {}
 
 extension AudioScheduledSourceNodeExtension on AudioScheduledSourceNode {
-  external JSVoid start([num when]);
-  external JSVoid stop([num when]);
+  external void start([num when]);
+  external void stop([num when]);
   external set onended(EventHandler value);
   external EventHandler get onended;
 }
@@ -448,10 +448,10 @@ class AnalyserNode implements AudioNode {
 }
 
 extension AnalyserNodeExtension on AnalyserNode {
-  external JSVoid getFloatFrequencyData(JSFloat32Array array);
-  external JSVoid getByteFrequencyData(JSUint8Array array);
-  external JSVoid getFloatTimeDomainData(JSFloat32Array array);
-  external JSVoid getByteTimeDomainData(JSUint8Array array);
+  external void getFloatFrequencyData(JSFloat32Array array);
+  external void getByteFrequencyData(JSUint8Array array);
+  external void getFloatTimeDomainData(JSFloat32Array array);
+  external void getByteTimeDomainData(JSUint8Array array);
   external set fftSize(int value);
   external int get fftSize;
   external int get frequencyBinCount;
@@ -496,7 +496,7 @@ class AudioBufferSourceNode implements AudioScheduledSourceNode {
 }
 
 extension AudioBufferSourceNodeExtension on AudioBufferSourceNode {
-  external JSVoid start([
+  external void start([
     num when,
     num offset,
     num duration,
@@ -555,12 +555,12 @@ extension AudioDestinationNodeExtension on AudioDestinationNode {
 class AudioListener implements JSObject {}
 
 extension AudioListenerExtension on AudioListener {
-  external JSVoid setPosition(
+  external void setPosition(
     num x,
     num y,
     num z,
   );
-  external JSVoid setOrientation(
+  external void setOrientation(
     num x,
     num y,
     num z,
@@ -624,7 +624,7 @@ class BiquadFilterNode implements AudioNode {
 }
 
 extension BiquadFilterNodeExtension on BiquadFilterNode {
-  external JSVoid getFrequencyResponse(
+  external void getFrequencyResponse(
     JSFloat32Array frequencyHz,
     JSFloat32Array magResponse,
     JSFloat32Array phaseResponse,
@@ -872,7 +872,7 @@ class IIRFilterNode implements AudioNode {
 }
 
 extension IIRFilterNodeExtension on IIRFilterNode {
-  external JSVoid getFrequencyResponse(
+  external void getFrequencyResponse(
     JSFloat32Array frequencyHz,
     JSFloat32Array magResponse,
     JSFloat32Array phaseResponse,
@@ -997,7 +997,7 @@ class OscillatorNode implements AudioScheduledSourceNode {
 }
 
 extension OscillatorNodeExtension on OscillatorNode {
-  external JSVoid setPeriodicWave(PeriodicWave periodicWave);
+  external void setPeriodicWave(PeriodicWave periodicWave);
   external set type(OscillatorType value);
   external OscillatorType get type;
   external AudioParam get frequency;
@@ -1037,12 +1037,12 @@ class PannerNode implements AudioNode {
 }
 
 extension PannerNodeExtension on PannerNode {
-  external JSVoid setPosition(
+  external void setPosition(
     num x,
     num y,
     num z,
   );
-  external JSVoid setOrientation(
+  external void setOrientation(
     num x,
     num y,
     num z,
@@ -1243,7 +1243,7 @@ extension AudioWorkletExtension on AudioWorklet {
 class AudioWorkletGlobalScope implements WorkletGlobalScope {}
 
 extension AudioWorkletGlobalScopeExtension on AudioWorkletGlobalScope {
-  external JSVoid registerProcessor(
+  external void registerProcessor(
     String name,
     AudioWorkletProcessorConstructor processorCtor,
   );
@@ -1285,7 +1285,7 @@ class AudioWorkletNodeOptions implements AudioNodeOptions {
     int numberOfInputs,
     int numberOfOutputs,
     JSArray outputChannelCount,
-    JSAny? parameterData,
+    JSAny parameterData,
     JSObject processorOptions,
   });
 }
@@ -1297,8 +1297,8 @@ extension AudioWorkletNodeOptionsExtension on AudioWorkletNodeOptions {
   external int get numberOfOutputs;
   external set outputChannelCount(JSArray value);
   external JSArray get outputChannelCount;
-  external set parameterData(JSAny? value);
-  external JSAny? get parameterData;
+  external set parameterData(JSAny value);
+  external JSAny get parameterData;
   external set processorOptions(JSObject value);
   external JSObject get processorOptions;
 }

--- a/lib/src/dom/webauthn.dart
+++ b/lib/src/dom/webauthn.dart
@@ -701,7 +701,7 @@ extension AuthenticationExtensionsPRFValuesExtension
 class AuthenticationExtensionsPRFInputs implements JSObject {
   external factory AuthenticationExtensionsPRFInputs({
     AuthenticationExtensionsPRFValues eval,
-    JSAny? evalByCredential,
+    JSAny evalByCredential,
   });
 }
 
@@ -709,8 +709,8 @@ extension AuthenticationExtensionsPRFInputsExtension
     on AuthenticationExtensionsPRFInputs {
   external set eval(AuthenticationExtensionsPRFValues value);
   external AuthenticationExtensionsPRFValues get eval;
-  external set evalByCredential(JSAny? value);
-  external JSAny? get evalByCredential;
+  external set evalByCredential(JSAny value);
+  external JSAny get evalByCredential;
 }
 
 @JS()

--- a/lib/src/dom/webcodecs.dart
+++ b/lib/src/dom/webcodecs.dart
@@ -45,11 +45,11 @@ class AudioDecoder implements EventTarget {
 }
 
 extension AudioDecoderExtension on AudioDecoder {
-  external JSVoid configure(AudioDecoderConfig config);
-  external JSVoid decode(EncodedAudioChunk chunk);
+  external void configure(AudioDecoderConfig config);
+  external void decode(EncodedAudioChunk chunk);
   external JSPromise flush();
-  external JSVoid reset();
-  external JSVoid close();
+  external void reset();
+  external void close();
   external CodecState get state;
   external int get decodeQueueSize;
   external set ondequeue(EventHandler value);
@@ -82,11 +82,11 @@ class VideoDecoder implements EventTarget {
 }
 
 extension VideoDecoderExtension on VideoDecoder {
-  external JSVoid configure(VideoDecoderConfig config);
-  external JSVoid decode(EncodedVideoChunk chunk);
+  external void configure(VideoDecoderConfig config);
+  external void decode(EncodedVideoChunk chunk);
   external JSPromise flush();
-  external JSVoid reset();
-  external JSVoid close();
+  external void reset();
+  external void close();
   external CodecState get state;
   external int get decodeQueueSize;
   external set ondequeue(EventHandler value);
@@ -119,11 +119,11 @@ class AudioEncoder implements EventTarget {
 }
 
 extension AudioEncoderExtension on AudioEncoder {
-  external JSVoid configure(AudioEncoderConfig config);
-  external JSVoid encode(AudioData data);
+  external void configure(AudioEncoderConfig config);
+  external void encode(AudioData data);
   external JSPromise flush();
-  external JSVoid reset();
-  external JSVoid close();
+  external void reset();
+  external void close();
   external CodecState get state;
   external int get encodeQueueSize;
   external set ondequeue(EventHandler value);
@@ -169,14 +169,14 @@ class VideoEncoder implements EventTarget {
 }
 
 extension VideoEncoderExtension on VideoEncoder {
-  external JSVoid configure(VideoEncoderConfig config);
-  external JSVoid encode(
+  external void configure(VideoEncoderConfig config);
+  external void encode(
     VideoFrame frame, [
     VideoEncoderEncodeOptions options,
   ]);
   external JSPromise flush();
-  external JSVoid reset();
-  external JSVoid close();
+  external void reset();
+  external void close();
   external CodecState get state;
   external int get encodeQueueSize;
   external set ondequeue(EventHandler value);
@@ -485,7 +485,7 @@ class EncodedAudioChunk implements JSObject {
 }
 
 extension EncodedAudioChunkExtension on EncodedAudioChunk {
-  external JSVoid copyTo(AllowSharedBufferSource destination);
+  external void copyTo(AllowSharedBufferSource destination);
   external EncodedAudioChunkType get type;
   external int get timestamp;
   external int? get duration;
@@ -522,7 +522,7 @@ class EncodedVideoChunk implements JSObject {
 }
 
 extension EncodedVideoChunkExtension on EncodedVideoChunk {
-  external JSVoid copyTo(AllowSharedBufferSource destination);
+  external void copyTo(AllowSharedBufferSource destination);
   external EncodedVideoChunkType get type;
   external int get timestamp;
   external int? get duration;
@@ -560,12 +560,12 @@ class AudioData implements JSObject {
 
 extension AudioDataExtension on AudioData {
   external int allocationSize(AudioDataCopyToOptions options);
-  external JSVoid copyTo(
+  external void copyTo(
     AllowSharedBufferSource destination,
     AudioDataCopyToOptions options,
   );
   external AudioData clone();
-  external JSVoid close();
+  external void close();
   external AudioSampleFormat? get format;
   external num get sampleRate;
   external int get numberOfFrames;
@@ -646,7 +646,7 @@ extension VideoFrameExtension on VideoFrame {
     VideoFrameCopyToOptions options,
   ]);
   external VideoFrame clone();
-  external JSVoid close();
+  external void close();
   external VideoPixelFormat? get format;
   external int get codedWidth;
   external int get codedHeight;
@@ -823,8 +823,8 @@ class ImageDecoder implements JSObject {
 
 extension ImageDecoderExtension on ImageDecoder {
   external JSPromise decode([ImageDecodeOptions options]);
-  external JSVoid reset();
-  external JSVoid close();
+  external void reset();
+  external void close();
   external String get type;
   external bool get complete;
   external JSPromise get completed;

--- a/lib/src/dom/webcryptoapi.dart
+++ b/lib/src/dom/webcryptoapi.dart
@@ -6,7 +6,7 @@ import 'dart:js_interop';
 
 import 'webidl.dart';
 
-typedef AlgorithmIdentifier = JSAny?;
+typedef AlgorithmIdentifier = JSAny;
 typedef HashAlgorithmIdentifier = AlgorithmIdentifier;
 typedef BigInteger = JSUint8Array;
 typedef NamedCurve = String;

--- a/lib/src/dom/webgl1.dart
+++ b/lib/src/dom/webgl1.dart
@@ -426,71 +426,71 @@ extension WebGLRenderingContextBaseExtension on WebGLRenderingContextBase {
   external bool isContextLost();
   external JSArray? getSupportedExtensions();
   external JSObject? getExtension(String name);
-  external JSVoid activeTexture(GLenum texture);
-  external JSVoid attachShader(
+  external void activeTexture(GLenum texture);
+  external void attachShader(
     WebGLProgram program,
     WebGLShader shader,
   );
-  external JSVoid bindAttribLocation(
+  external void bindAttribLocation(
     WebGLProgram program,
     GLuint index,
     String name,
   );
-  external JSVoid bindBuffer(
+  external void bindBuffer(
     GLenum target,
     WebGLBuffer? buffer,
   );
-  external JSVoid bindFramebuffer(
+  external void bindFramebuffer(
     GLenum target,
     WebGLFramebuffer? framebuffer,
   );
-  external JSVoid bindRenderbuffer(
+  external void bindRenderbuffer(
     GLenum target,
     WebGLRenderbuffer? renderbuffer,
   );
-  external JSVoid bindTexture(
+  external void bindTexture(
     GLenum target,
     WebGLTexture? texture,
   );
-  external JSVoid blendColor(
+  external void blendColor(
     GLclampf red,
     GLclampf green,
     GLclampf blue,
     GLclampf alpha,
   );
-  external JSVoid blendEquation(GLenum mode);
-  external JSVoid blendEquationSeparate(
+  external void blendEquation(GLenum mode);
+  external void blendEquationSeparate(
     GLenum modeRGB,
     GLenum modeAlpha,
   );
-  external JSVoid blendFunc(
+  external void blendFunc(
     GLenum sfactor,
     GLenum dfactor,
   );
-  external JSVoid blendFuncSeparate(
+  external void blendFuncSeparate(
     GLenum srcRGB,
     GLenum dstRGB,
     GLenum srcAlpha,
     GLenum dstAlpha,
   );
   external GLenum checkFramebufferStatus(GLenum target);
-  external JSVoid clear(GLbitfield mask);
-  external JSVoid clearColor(
+  external void clear(GLbitfield mask);
+  external void clearColor(
     GLclampf red,
     GLclampf green,
     GLclampf blue,
     GLclampf alpha,
   );
-  external JSVoid clearDepth(GLclampf depth);
-  external JSVoid clearStencil(GLint s);
-  external JSVoid colorMask(
+  external void clearDepth(GLclampf depth);
+  external void clearStencil(GLint s);
+  external void colorMask(
     GLboolean red,
     GLboolean green,
     GLboolean blue,
     GLboolean alpha,
   );
-  external JSVoid compileShader(WebGLShader shader);
-  external JSVoid copyTexImage2D(
+  external void compileShader(WebGLShader shader);
+  external void copyTexImage2D(
     GLenum target,
     GLint level,
     GLenum internalformat,
@@ -500,7 +500,7 @@ extension WebGLRenderingContextBaseExtension on WebGLRenderingContextBase {
     GLsizei height,
     GLint border,
   );
-  external JSVoid copyTexSubImage2D(
+  external void copyTexSubImage2D(
     GLenum target,
     GLint level,
     GLint xoffset,
@@ -516,55 +516,55 @@ extension WebGLRenderingContextBaseExtension on WebGLRenderingContextBase {
   external WebGLRenderbuffer? createRenderbuffer();
   external WebGLShader? createShader(GLenum type);
   external WebGLTexture? createTexture();
-  external JSVoid cullFace(GLenum mode);
-  external JSVoid deleteBuffer(WebGLBuffer? buffer);
-  external JSVoid deleteFramebuffer(WebGLFramebuffer? framebuffer);
-  external JSVoid deleteProgram(WebGLProgram? program);
-  external JSVoid deleteRenderbuffer(WebGLRenderbuffer? renderbuffer);
-  external JSVoid deleteShader(WebGLShader? shader);
-  external JSVoid deleteTexture(WebGLTexture? texture);
-  external JSVoid depthFunc(GLenum func);
-  external JSVoid depthMask(GLboolean flag);
-  external JSVoid depthRange(
+  external void cullFace(GLenum mode);
+  external void deleteBuffer(WebGLBuffer? buffer);
+  external void deleteFramebuffer(WebGLFramebuffer? framebuffer);
+  external void deleteProgram(WebGLProgram? program);
+  external void deleteRenderbuffer(WebGLRenderbuffer? renderbuffer);
+  external void deleteShader(WebGLShader? shader);
+  external void deleteTexture(WebGLTexture? texture);
+  external void depthFunc(GLenum func);
+  external void depthMask(GLboolean flag);
+  external void depthRange(
     GLclampf zNear,
     GLclampf zFar,
   );
-  external JSVoid detachShader(
+  external void detachShader(
     WebGLProgram program,
     WebGLShader shader,
   );
-  external JSVoid disable(GLenum cap);
-  external JSVoid disableVertexAttribArray(GLuint index);
-  external JSVoid drawArrays(
+  external void disable(GLenum cap);
+  external void disableVertexAttribArray(GLuint index);
+  external void drawArrays(
     GLenum mode,
     GLint first,
     GLsizei count,
   );
-  external JSVoid drawElements(
+  external void drawElements(
     GLenum mode,
     GLsizei count,
     GLenum type,
     GLintptr offset,
   );
-  external JSVoid enable(GLenum cap);
-  external JSVoid enableVertexAttribArray(GLuint index);
-  external JSVoid finish();
-  external JSVoid flush();
-  external JSVoid framebufferRenderbuffer(
+  external void enable(GLenum cap);
+  external void enableVertexAttribArray(GLuint index);
+  external void finish();
+  external void flush();
+  external void framebufferRenderbuffer(
     GLenum target,
     GLenum attachment,
     GLenum renderbuffertarget,
     WebGLRenderbuffer? renderbuffer,
   );
-  external JSVoid framebufferTexture2D(
+  external void framebufferTexture2D(
     GLenum target,
     GLenum attachment,
     GLenum textarget,
     WebGLTexture? texture,
     GLint level,
   );
-  external JSVoid frontFace(GLenum mode);
-  external JSVoid generateMipmap(GLenum target);
+  external void frontFace(GLenum mode);
+  external void generateMipmap(GLenum target);
   external WebGLActiveInfo? getActiveAttrib(
     WebGLProgram program,
     GLuint index,
@@ -628,7 +628,7 @@ extension WebGLRenderingContextBaseExtension on WebGLRenderingContextBase {
     GLuint index,
     GLenum pname,
   );
-  external JSVoid hint(
+  external void hint(
     GLenum target,
     GLenum mode,
   );
@@ -639,158 +639,158 @@ extension WebGLRenderingContextBaseExtension on WebGLRenderingContextBase {
   external GLboolean isRenderbuffer(WebGLRenderbuffer? renderbuffer);
   external GLboolean isShader(WebGLShader? shader);
   external GLboolean isTexture(WebGLTexture? texture);
-  external JSVoid lineWidth(GLfloat width);
-  external JSVoid linkProgram(WebGLProgram program);
-  external JSVoid pixelStorei(
+  external void lineWidth(GLfloat width);
+  external void linkProgram(WebGLProgram program);
+  external void pixelStorei(
     GLenum pname,
     GLint param,
   );
-  external JSVoid polygonOffset(
+  external void polygonOffset(
     GLfloat factor,
     GLfloat units,
   );
-  external JSVoid renderbufferStorage(
+  external void renderbufferStorage(
     GLenum target,
     GLenum internalformat,
     GLsizei width,
     GLsizei height,
   );
-  external JSVoid sampleCoverage(
+  external void sampleCoverage(
     GLclampf value,
     GLboolean invert,
   );
-  external JSVoid scissor(
+  external void scissor(
     GLint x,
     GLint y,
     GLsizei width,
     GLsizei height,
   );
-  external JSVoid shaderSource(
+  external void shaderSource(
     WebGLShader shader,
     String source,
   );
-  external JSVoid stencilFunc(
+  external void stencilFunc(
     GLenum func,
     GLint ref,
     GLuint mask,
   );
-  external JSVoid stencilFuncSeparate(
+  external void stencilFuncSeparate(
     GLenum face,
     GLenum func,
     GLint ref,
     GLuint mask,
   );
-  external JSVoid stencilMask(GLuint mask);
-  external JSVoid stencilMaskSeparate(
+  external void stencilMask(GLuint mask);
+  external void stencilMaskSeparate(
     GLenum face,
     GLuint mask,
   );
-  external JSVoid stencilOp(
+  external void stencilOp(
     GLenum fail,
     GLenum zfail,
     GLenum zpass,
   );
-  external JSVoid stencilOpSeparate(
+  external void stencilOpSeparate(
     GLenum face,
     GLenum fail,
     GLenum zfail,
     GLenum zpass,
   );
-  external JSVoid texParameterf(
+  external void texParameterf(
     GLenum target,
     GLenum pname,
     GLfloat param,
   );
-  external JSVoid texParameteri(
+  external void texParameteri(
     GLenum target,
     GLenum pname,
     GLint param,
   );
-  external JSVoid uniform1f(
+  external void uniform1f(
     WebGLUniformLocation? location,
     GLfloat x,
   );
-  external JSVoid uniform2f(
+  external void uniform2f(
     WebGLUniformLocation? location,
     GLfloat x,
     GLfloat y,
   );
-  external JSVoid uniform3f(
+  external void uniform3f(
     WebGLUniformLocation? location,
     GLfloat x,
     GLfloat y,
     GLfloat z,
   );
-  external JSVoid uniform4f(
+  external void uniform4f(
     WebGLUniformLocation? location,
     GLfloat x,
     GLfloat y,
     GLfloat z,
     GLfloat w,
   );
-  external JSVoid uniform1i(
+  external void uniform1i(
     WebGLUniformLocation? location,
     GLint x,
   );
-  external JSVoid uniform2i(
+  external void uniform2i(
     WebGLUniformLocation? location,
     GLint x,
     GLint y,
   );
-  external JSVoid uniform3i(
+  external void uniform3i(
     WebGLUniformLocation? location,
     GLint x,
     GLint y,
     GLint z,
   );
-  external JSVoid uniform4i(
+  external void uniform4i(
     WebGLUniformLocation? location,
     GLint x,
     GLint y,
     GLint z,
     GLint w,
   );
-  external JSVoid useProgram(WebGLProgram? program);
-  external JSVoid validateProgram(WebGLProgram program);
-  external JSVoid vertexAttrib1f(
+  external void useProgram(WebGLProgram? program);
+  external void validateProgram(WebGLProgram program);
+  external void vertexAttrib1f(
     GLuint index,
     GLfloat x,
   );
-  external JSVoid vertexAttrib2f(
+  external void vertexAttrib2f(
     GLuint index,
     GLfloat x,
     GLfloat y,
   );
-  external JSVoid vertexAttrib3f(
+  external void vertexAttrib3f(
     GLuint index,
     GLfloat x,
     GLfloat y,
     GLfloat z,
   );
-  external JSVoid vertexAttrib4f(
+  external void vertexAttrib4f(
     GLuint index,
     GLfloat x,
     GLfloat y,
     GLfloat z,
     GLfloat w,
   );
-  external JSVoid vertexAttrib1fv(
+  external void vertexAttrib1fv(
     GLuint index,
     Float32List values,
   );
-  external JSVoid vertexAttrib2fv(
+  external void vertexAttrib2fv(
     GLuint index,
     Float32List values,
   );
-  external JSVoid vertexAttrib3fv(
+  external void vertexAttrib3fv(
     GLuint index,
     Float32List values,
   );
-  external JSVoid vertexAttrib4fv(
+  external void vertexAttrib4fv(
     GLuint index,
     Float32List values,
   );
-  external JSVoid vertexAttribPointer(
+  external void vertexAttribPointer(
     GLuint index,
     GLint size,
     GLenum type,
@@ -798,7 +798,7 @@ extension WebGLRenderingContextBaseExtension on WebGLRenderingContextBase {
     GLsizei stride,
     GLintptr offset,
   );
-  external JSVoid viewport(
+  external void viewport(
     GLint x,
     GLint y,
     GLsizei width,
@@ -820,17 +820,17 @@ class WebGLRenderingContextOverloads implements JSObject {}
 
 extension WebGLRenderingContextOverloadsExtension
     on WebGLRenderingContextOverloads {
-  external JSVoid bufferData(
+  external void bufferData(
     GLenum target,
-    JSAny? dataOrSize,
+    JSAny dataOrSize,
     GLenum usage,
   );
-  external JSVoid bufferSubData(
+  external void bufferSubData(
     GLenum target,
     GLintptr offset,
     AllowSharedBufferSource data,
   );
-  external JSVoid compressedTexImage2D(
+  external void compressedTexImage2D(
     GLenum target,
     GLint level,
     GLenum internalformat,
@@ -839,7 +839,7 @@ extension WebGLRenderingContextOverloadsExtension
     GLint border,
     ArrayBufferView data,
   );
-  external JSVoid compressedTexSubImage2D(
+  external void compressedTexSubImage2D(
     GLenum target,
     GLint level,
     GLint xoffset,
@@ -849,7 +849,7 @@ extension WebGLRenderingContextOverloadsExtension
     GLenum format,
     ArrayBufferView data,
   );
-  external JSVoid readPixels(
+  external void readPixels(
     GLint x,
     GLint y,
     GLsizei width,
@@ -858,71 +858,71 @@ extension WebGLRenderingContextOverloadsExtension
     GLenum type,
     ArrayBufferView? pixels,
   );
-  external JSVoid texImage2D(
+  external void texImage2D(
     GLenum target,
     GLint level,
     GLint internalformat,
-    JSAny? formatOrWidth,
-    JSAny? heightOrType,
-    JSAny? borderOrSource, [
+    JSAny formatOrWidth,
+    JSAny heightOrType,
+    JSAny borderOrSource, [
     GLenum format,
     GLenum type,
     ArrayBufferView? pixels,
   ]);
-  external JSVoid texSubImage2D(
+  external void texSubImage2D(
     GLenum target,
     GLint level,
     GLint xoffset,
     GLint yoffset,
-    JSAny? formatOrWidth,
-    JSAny? heightOrType,
-    JSAny? formatOrSource, [
+    JSAny formatOrWidth,
+    JSAny heightOrType,
+    JSAny formatOrSource, [
     GLenum type,
     ArrayBufferView? pixels,
   ]);
-  external JSVoid uniform1fv(
+  external void uniform1fv(
     WebGLUniformLocation? location,
     Float32List v,
   );
-  external JSVoid uniform2fv(
+  external void uniform2fv(
     WebGLUniformLocation? location,
     Float32List v,
   );
-  external JSVoid uniform3fv(
+  external void uniform3fv(
     WebGLUniformLocation? location,
     Float32List v,
   );
-  external JSVoid uniform4fv(
+  external void uniform4fv(
     WebGLUniformLocation? location,
     Float32List v,
   );
-  external JSVoid uniform1iv(
+  external void uniform1iv(
     WebGLUniformLocation? location,
     Int32List v,
   );
-  external JSVoid uniform2iv(
+  external void uniform2iv(
     WebGLUniformLocation? location,
     Int32List v,
   );
-  external JSVoid uniform3iv(
+  external void uniform3iv(
     WebGLUniformLocation? location,
     Int32List v,
   );
-  external JSVoid uniform4iv(
+  external void uniform4iv(
     WebGLUniformLocation? location,
     Int32List v,
   );
-  external JSVoid uniformMatrix2fv(
+  external void uniformMatrix2fv(
     WebGLUniformLocation? location,
     GLboolean transpose,
     Float32List value,
   );
-  external JSVoid uniformMatrix3fv(
+  external void uniformMatrix3fv(
     WebGLUniformLocation? location,
     GLboolean transpose,
     Float32List value,
   );
-  external JSVoid uniformMatrix4fv(
+  external void uniformMatrix4fv(
     WebGLUniformLocation? location,
     GLboolean transpose,
     Float32List value,

--- a/lib/src/dom/webgl2.dart
+++ b/lib/src/dom/webgl2.dart
@@ -300,21 +300,21 @@ class WebGL2RenderingContextBase implements JSObject {
 }
 
 extension WebGL2RenderingContextBaseExtension on WebGL2RenderingContextBase {
-  external JSVoid copyBufferSubData(
+  external void copyBufferSubData(
     GLenum readTarget,
     GLenum writeTarget,
     GLintptr readOffset,
     GLintptr writeOffset,
     GLsizeiptr size,
   );
-  external JSVoid getBufferSubData(
+  external void getBufferSubData(
     GLenum target,
     GLintptr srcByteOffset,
     ArrayBufferView dstBuffer, [
     int dstOffset,
     GLuint length,
   ]);
-  external JSVoid blitFramebuffer(
+  external void blitFramebuffer(
     GLint srcX0,
     GLint srcY0,
     GLint srcX1,
@@ -326,18 +326,18 @@ extension WebGL2RenderingContextBaseExtension on WebGL2RenderingContextBase {
     GLbitfield mask,
     GLenum filter,
   );
-  external JSVoid framebufferTextureLayer(
+  external void framebufferTextureLayer(
     GLenum target,
     GLenum attachment,
     WebGLTexture? texture,
     GLint level,
     GLint layer,
   );
-  external JSVoid invalidateFramebuffer(
+  external void invalidateFramebuffer(
     GLenum target,
     JSArray attachments,
   );
-  external JSVoid invalidateSubFramebuffer(
+  external void invalidateSubFramebuffer(
     GLenum target,
     JSArray attachments,
     GLint x,
@@ -345,27 +345,27 @@ extension WebGL2RenderingContextBaseExtension on WebGL2RenderingContextBase {
     GLsizei width,
     GLsizei height,
   );
-  external JSVoid readBuffer(GLenum src);
+  external void readBuffer(GLenum src);
   external JSAny? getInternalformatParameter(
     GLenum target,
     GLenum internalformat,
     GLenum pname,
   );
-  external JSVoid renderbufferStorageMultisample(
+  external void renderbufferStorageMultisample(
     GLenum target,
     GLsizei samples,
     GLenum internalformat,
     GLsizei width,
     GLsizei height,
   );
-  external JSVoid texStorage2D(
+  external void texStorage2D(
     GLenum target,
     GLsizei levels,
     GLenum internalformat,
     GLsizei width,
     GLsizei height,
   );
-  external JSVoid texStorage3D(
+  external void texStorage3D(
     GLenum target,
     GLsizei levels,
     GLenum internalformat,
@@ -373,7 +373,7 @@ extension WebGL2RenderingContextBaseExtension on WebGL2RenderingContextBase {
     GLsizei height,
     GLsizei depth,
   );
-  external JSVoid texImage3D(
+  external void texImage3D(
     GLenum target,
     GLint level,
     GLint internalformat,
@@ -383,10 +383,10 @@ extension WebGL2RenderingContextBaseExtension on WebGL2RenderingContextBase {
     GLint border,
     GLenum format,
     GLenum type,
-    JSAny? pboOffsetOrSourceOrSrcData, [
+    JSAny pboOffsetOrSourceOrSrcData, [
     int srcOffset,
   ]);
-  external JSVoid texSubImage3D(
+  external void texSubImage3D(
     GLenum target,
     GLint level,
     GLint xoffset,
@@ -397,10 +397,10 @@ extension WebGL2RenderingContextBaseExtension on WebGL2RenderingContextBase {
     GLsizei depth,
     GLenum format,
     GLenum type,
-    JSAny? pboOffsetOrSourceOrSrcData, [
+    JSAny pboOffsetOrSourceOrSrcData, [
     int srcOffset,
   ]);
-  external JSVoid copyTexSubImage3D(
+  external void copyTexSubImage3D(
     GLenum target,
     GLint level,
     GLint xoffset,
@@ -411,7 +411,7 @@ extension WebGL2RenderingContextBaseExtension on WebGL2RenderingContextBase {
     GLsizei width,
     GLsizei height,
   );
-  external JSVoid compressedTexImage3D(
+  external void compressedTexImage3D(
     GLenum target,
     GLint level,
     GLenum internalformat,
@@ -419,11 +419,11 @@ extension WebGL2RenderingContextBaseExtension on WebGL2RenderingContextBase {
     GLsizei height,
     GLsizei depth,
     GLint border,
-    JSAny? imageSizeOrSrcData, [
-    JSAny? offsetOrSrcOffset,
+    JSAny imageSizeOrSrcData, [
+    JSAny offsetOrSrcOffset,
     GLuint srcLengthOverride,
   ]);
-  external JSVoid compressedTexSubImage3D(
+  external void compressedTexSubImage3D(
     GLenum target,
     GLint level,
     GLint xoffset,
@@ -433,149 +433,149 @@ extension WebGL2RenderingContextBaseExtension on WebGL2RenderingContextBase {
     GLsizei height,
     GLsizei depth,
     GLenum format,
-    JSAny? imageSizeOrSrcData, [
-    JSAny? offsetOrSrcOffset,
+    JSAny imageSizeOrSrcData, [
+    JSAny offsetOrSrcOffset,
     GLuint srcLengthOverride,
   ]);
   external GLint getFragDataLocation(
     WebGLProgram program,
     String name,
   );
-  external JSVoid uniform1ui(
+  external void uniform1ui(
     WebGLUniformLocation? location,
     GLuint v0,
   );
-  external JSVoid uniform2ui(
+  external void uniform2ui(
     WebGLUniformLocation? location,
     GLuint v0,
     GLuint v1,
   );
-  external JSVoid uniform3ui(
+  external void uniform3ui(
     WebGLUniformLocation? location,
     GLuint v0,
     GLuint v1,
     GLuint v2,
   );
-  external JSVoid uniform4ui(
+  external void uniform4ui(
     WebGLUniformLocation? location,
     GLuint v0,
     GLuint v1,
     GLuint v2,
     GLuint v3,
   );
-  external JSVoid uniform1uiv(
+  external void uniform1uiv(
     WebGLUniformLocation? location,
     Uint32List data, [
     int srcOffset,
     GLuint srcLength,
   ]);
-  external JSVoid uniform2uiv(
+  external void uniform2uiv(
     WebGLUniformLocation? location,
     Uint32List data, [
     int srcOffset,
     GLuint srcLength,
   ]);
-  external JSVoid uniform3uiv(
+  external void uniform3uiv(
     WebGLUniformLocation? location,
     Uint32List data, [
     int srcOffset,
     GLuint srcLength,
   ]);
-  external JSVoid uniform4uiv(
+  external void uniform4uiv(
     WebGLUniformLocation? location,
     Uint32List data, [
     int srcOffset,
     GLuint srcLength,
   ]);
-  external JSVoid uniformMatrix3x2fv(
+  external void uniformMatrix3x2fv(
     WebGLUniformLocation? location,
     GLboolean transpose,
     Float32List data, [
     int srcOffset,
     GLuint srcLength,
   ]);
-  external JSVoid uniformMatrix4x2fv(
+  external void uniformMatrix4x2fv(
     WebGLUniformLocation? location,
     GLboolean transpose,
     Float32List data, [
     int srcOffset,
     GLuint srcLength,
   ]);
-  external JSVoid uniformMatrix2x3fv(
+  external void uniformMatrix2x3fv(
     WebGLUniformLocation? location,
     GLboolean transpose,
     Float32List data, [
     int srcOffset,
     GLuint srcLength,
   ]);
-  external JSVoid uniformMatrix4x3fv(
+  external void uniformMatrix4x3fv(
     WebGLUniformLocation? location,
     GLboolean transpose,
     Float32List data, [
     int srcOffset,
     GLuint srcLength,
   ]);
-  external JSVoid uniformMatrix2x4fv(
+  external void uniformMatrix2x4fv(
     WebGLUniformLocation? location,
     GLboolean transpose,
     Float32List data, [
     int srcOffset,
     GLuint srcLength,
   ]);
-  external JSVoid uniformMatrix3x4fv(
+  external void uniformMatrix3x4fv(
     WebGLUniformLocation? location,
     GLboolean transpose,
     Float32List data, [
     int srcOffset,
     GLuint srcLength,
   ]);
-  external JSVoid vertexAttribI4i(
+  external void vertexAttribI4i(
     GLuint index,
     GLint x,
     GLint y,
     GLint z,
     GLint w,
   );
-  external JSVoid vertexAttribI4iv(
+  external void vertexAttribI4iv(
     GLuint index,
     Int32List values,
   );
-  external JSVoid vertexAttribI4ui(
+  external void vertexAttribI4ui(
     GLuint index,
     GLuint x,
     GLuint y,
     GLuint z,
     GLuint w,
   );
-  external JSVoid vertexAttribI4uiv(
+  external void vertexAttribI4uiv(
     GLuint index,
     Uint32List values,
   );
-  external JSVoid vertexAttribIPointer(
+  external void vertexAttribIPointer(
     GLuint index,
     GLint size,
     GLenum type,
     GLsizei stride,
     GLintptr offset,
   );
-  external JSVoid vertexAttribDivisor(
+  external void vertexAttribDivisor(
     GLuint index,
     GLuint divisor,
   );
-  external JSVoid drawArraysInstanced(
+  external void drawArraysInstanced(
     GLenum mode,
     GLint first,
     GLsizei count,
     GLsizei instanceCount,
   );
-  external JSVoid drawElementsInstanced(
+  external void drawElementsInstanced(
     GLenum mode,
     GLsizei count,
     GLenum type,
     GLintptr offset,
     GLsizei instanceCount,
   );
-  external JSVoid drawRangeElements(
+  external void drawRangeElements(
     GLenum mode,
     GLuint start,
     GLuint end,
@@ -583,39 +583,39 @@ extension WebGL2RenderingContextBaseExtension on WebGL2RenderingContextBase {
     GLenum type,
     GLintptr offset,
   );
-  external JSVoid drawBuffers(JSArray buffers);
-  external JSVoid clearBufferfv(
+  external void drawBuffers(JSArray buffers);
+  external void clearBufferfv(
     GLenum buffer,
     GLint drawbuffer,
     Float32List values, [
     int srcOffset,
   ]);
-  external JSVoid clearBufferiv(
+  external void clearBufferiv(
     GLenum buffer,
     GLint drawbuffer,
     Int32List values, [
     int srcOffset,
   ]);
-  external JSVoid clearBufferuiv(
+  external void clearBufferuiv(
     GLenum buffer,
     GLint drawbuffer,
     Uint32List values, [
     int srcOffset,
   ]);
-  external JSVoid clearBufferfi(
+  external void clearBufferfi(
     GLenum buffer,
     GLint drawbuffer,
     GLfloat depth,
     GLint stencil,
   );
   external WebGLQuery? createQuery();
-  external JSVoid deleteQuery(WebGLQuery? query);
+  external void deleteQuery(WebGLQuery? query);
   external GLboolean isQuery(WebGLQuery? query);
-  external JSVoid beginQuery(
+  external void beginQuery(
     GLenum target,
     WebGLQuery query,
   );
-  external JSVoid endQuery(GLenum target);
+  external void endQuery(GLenum target);
   external WebGLQuery? getQuery(
     GLenum target,
     GLenum pname,
@@ -625,18 +625,18 @@ extension WebGL2RenderingContextBaseExtension on WebGL2RenderingContextBase {
     GLenum pname,
   );
   external WebGLSampler? createSampler();
-  external JSVoid deleteSampler(WebGLSampler? sampler);
+  external void deleteSampler(WebGLSampler? sampler);
   external GLboolean isSampler(WebGLSampler? sampler);
-  external JSVoid bindSampler(
+  external void bindSampler(
     GLuint unit,
     WebGLSampler? sampler,
   );
-  external JSVoid samplerParameteri(
+  external void samplerParameteri(
     WebGLSampler sampler,
     GLenum pname,
     GLint param,
   );
-  external JSVoid samplerParameterf(
+  external void samplerParameterf(
     WebGLSampler sampler,
     GLenum pname,
     GLfloat param,
@@ -650,13 +650,13 @@ extension WebGL2RenderingContextBaseExtension on WebGL2RenderingContextBase {
     GLbitfield flags,
   );
   external GLboolean isSync(WebGLSync? sync);
-  external JSVoid deleteSync(WebGLSync? sync);
+  external void deleteSync(WebGLSync? sync);
   external GLenum clientWaitSync(
     WebGLSync sync,
     GLbitfield flags,
     GLuint64 timeout,
   );
-  external JSVoid waitSync(
+  external void waitSync(
     WebGLSync sync,
     GLbitfield flags,
     GLint64 timeout,
@@ -666,15 +666,15 @@ extension WebGL2RenderingContextBaseExtension on WebGL2RenderingContextBase {
     GLenum pname,
   );
   external WebGLTransformFeedback? createTransformFeedback();
-  external JSVoid deleteTransformFeedback(WebGLTransformFeedback? tf);
+  external void deleteTransformFeedback(WebGLTransformFeedback? tf);
   external GLboolean isTransformFeedback(WebGLTransformFeedback? tf);
-  external JSVoid bindTransformFeedback(
+  external void bindTransformFeedback(
     GLenum target,
     WebGLTransformFeedback? tf,
   );
-  external JSVoid beginTransformFeedback(GLenum primitiveMode);
-  external JSVoid endTransformFeedback();
-  external JSVoid transformFeedbackVaryings(
+  external void beginTransformFeedback(GLenum primitiveMode);
+  external void endTransformFeedback();
+  external void transformFeedbackVaryings(
     WebGLProgram program,
     JSArray varyings,
     GLenum bufferMode,
@@ -683,14 +683,14 @@ extension WebGL2RenderingContextBaseExtension on WebGL2RenderingContextBase {
     WebGLProgram program,
     GLuint index,
   );
-  external JSVoid pauseTransformFeedback();
-  external JSVoid resumeTransformFeedback();
-  external JSVoid bindBufferBase(
+  external void pauseTransformFeedback();
+  external void resumeTransformFeedback();
+  external void bindBufferBase(
     GLenum target,
     GLuint index,
     WebGLBuffer? buffer,
   );
-  external JSVoid bindBufferRange(
+  external void bindBufferRange(
     GLenum target,
     GLuint index,
     WebGLBuffer? buffer,
@@ -723,15 +723,15 @@ extension WebGL2RenderingContextBaseExtension on WebGL2RenderingContextBase {
     WebGLProgram program,
     GLuint uniformBlockIndex,
   );
-  external JSVoid uniformBlockBinding(
+  external void uniformBlockBinding(
     WebGLProgram program,
     GLuint uniformBlockIndex,
     GLuint uniformBlockBinding,
   );
   external WebGLVertexArrayObject? createVertexArray();
-  external JSVoid deleteVertexArray(WebGLVertexArrayObject? vertexArray);
+  external void deleteVertexArray(WebGLVertexArrayObject? vertexArray);
   external GLboolean isVertexArray(WebGLVertexArrayObject? vertexArray);
-  external JSVoid bindVertexArray(WebGLVertexArrayObject? array);
+  external void bindVertexArray(WebGLVertexArrayObject? array);
 }
 
 @JS('WebGL2RenderingContextOverloads')
@@ -740,56 +740,56 @@ class WebGL2RenderingContextOverloads implements JSObject {}
 
 extension WebGL2RenderingContextOverloadsExtension
     on WebGL2RenderingContextOverloads {
-  external JSVoid bufferData(
+  external void bufferData(
     GLenum target,
-    JSAny? sizeOrSrcData,
+    JSAny sizeOrSrcData,
     GLenum usage, [
     int srcOffset,
     GLuint length,
   ]);
-  external JSVoid bufferSubData(
+  external void bufferSubData(
     GLenum target,
     GLintptr dstByteOffset,
     JSObject srcData, [
     int srcOffset,
     GLuint length,
   ]);
-  external JSVoid texImage2D(
+  external void texImage2D(
     GLenum target,
     GLint level,
     GLint internalformat,
-    JSAny? formatOrWidth,
-    JSAny? heightOrType,
-    JSAny? borderOrSource, [
+    JSAny formatOrWidth,
+    JSAny heightOrType,
+    JSAny borderOrSource, [
     GLenum format,
     GLenum type,
-    JSAny? pboOffsetOrPixelsOrSourceOrSrcData,
+    JSAny pboOffsetOrPixelsOrSourceOrSrcData,
     int srcOffset,
   ]);
-  external JSVoid texSubImage2D(
+  external void texSubImage2D(
     GLenum target,
     GLint level,
     GLint xoffset,
     GLint yoffset,
-    JSAny? formatOrWidth,
-    JSAny? heightOrType,
-    JSAny? formatOrSource, [
+    JSAny formatOrWidth,
+    JSAny heightOrType,
+    JSAny formatOrSource, [
     GLenum type,
-    JSAny? pboOffsetOrPixelsOrSourceOrSrcData,
+    JSAny pboOffsetOrPixelsOrSourceOrSrcData,
     int srcOffset,
   ]);
-  external JSVoid compressedTexImage2D(
+  external void compressedTexImage2D(
     GLenum target,
     GLint level,
     GLenum internalformat,
     GLsizei width,
     GLsizei height,
     GLint border,
-    JSAny? imageSizeOrSrcData, [
-    JSAny? offsetOrSrcOffset,
+    JSAny imageSizeOrSrcData, [
+    JSAny offsetOrSrcOffset,
     GLuint srcLengthOverride,
   ]);
-  external JSVoid compressedTexSubImage2D(
+  external void compressedTexSubImage2D(
     GLenum target,
     GLint level,
     GLint xoffset,
@@ -797,87 +797,87 @@ extension WebGL2RenderingContextOverloadsExtension
     GLsizei width,
     GLsizei height,
     GLenum format,
-    JSAny? imageSizeOrSrcData, [
-    JSAny? offsetOrSrcOffset,
+    JSAny imageSizeOrSrcData, [
+    JSAny offsetOrSrcOffset,
     GLuint srcLengthOverride,
   ]);
-  external JSVoid uniform1fv(
+  external void uniform1fv(
     WebGLUniformLocation? location,
     Float32List data, [
     int srcOffset,
     GLuint srcLength,
   ]);
-  external JSVoid uniform2fv(
+  external void uniform2fv(
     WebGLUniformLocation? location,
     Float32List data, [
     int srcOffset,
     GLuint srcLength,
   ]);
-  external JSVoid uniform3fv(
+  external void uniform3fv(
     WebGLUniformLocation? location,
     Float32List data, [
     int srcOffset,
     GLuint srcLength,
   ]);
-  external JSVoid uniform4fv(
+  external void uniform4fv(
     WebGLUniformLocation? location,
     Float32List data, [
     int srcOffset,
     GLuint srcLength,
   ]);
-  external JSVoid uniform1iv(
+  external void uniform1iv(
     WebGLUniformLocation? location,
     Int32List data, [
     int srcOffset,
     GLuint srcLength,
   ]);
-  external JSVoid uniform2iv(
+  external void uniform2iv(
     WebGLUniformLocation? location,
     Int32List data, [
     int srcOffset,
     GLuint srcLength,
   ]);
-  external JSVoid uniform3iv(
+  external void uniform3iv(
     WebGLUniformLocation? location,
     Int32List data, [
     int srcOffset,
     GLuint srcLength,
   ]);
-  external JSVoid uniform4iv(
+  external void uniform4iv(
     WebGLUniformLocation? location,
     Int32List data, [
     int srcOffset,
     GLuint srcLength,
   ]);
-  external JSVoid uniformMatrix2fv(
+  external void uniformMatrix2fv(
     WebGLUniformLocation? location,
     GLboolean transpose,
     Float32List data, [
     int srcOffset,
     GLuint srcLength,
   ]);
-  external JSVoid uniformMatrix3fv(
+  external void uniformMatrix3fv(
     WebGLUniformLocation? location,
     GLboolean transpose,
     Float32List data, [
     int srcOffset,
     GLuint srcLength,
   ]);
-  external JSVoid uniformMatrix4fv(
+  external void uniformMatrix4fv(
     WebGLUniformLocation? location,
     GLboolean transpose,
     Float32List data, [
     int srcOffset,
     GLuint srcLength,
   ]);
-  external JSVoid readPixels(
+  external void readPixels(
     GLint x,
     GLint y,
     GLsizei width,
     GLsizei height,
     GLenum format,
     GLenum type,
-    JSAny? dstDataOrOffset, [
+    JSAny dstDataOrOffset, [
     int dstOffset,
   ]);
 }

--- a/lib/src/dom/webgl_draw_buffers.dart
+++ b/lib/src/dom/webgl_draw_buffers.dart
@@ -46,5 +46,5 @@ class WEBGL_draw_buffers implements JSObject {
 }
 
 extension WEBGLDrawBuffersExtension on WEBGL_draw_buffers {
-  external JSVoid drawBuffersWEBGL(JSArray buffers);
+  external void drawBuffersWEBGL(JSArray buffers);
 }

--- a/lib/src/dom/webgl_draw_instanced_base_vertex_base_instance.dart
+++ b/lib/src/dom/webgl_draw_instanced_base_vertex_base_instance.dart
@@ -12,14 +12,14 @@ class WEBGL_draw_instanced_base_vertex_base_instance implements JSObject {}
 
 extension WEBGLDrawInstancedBaseVertexBaseInstanceExtension
     on WEBGL_draw_instanced_base_vertex_base_instance {
-  external JSVoid drawArraysInstancedBaseInstanceWEBGL(
+  external void drawArraysInstancedBaseInstanceWEBGL(
     GLenum mode,
     GLint first,
     GLsizei count,
     GLsizei instanceCount,
     GLuint baseInstance,
   );
-  external JSVoid drawElementsInstancedBaseVertexBaseInstanceWEBGL(
+  external void drawElementsInstancedBaseVertexBaseInstanceWEBGL(
     GLenum mode,
     GLsizei count,
     GLenum type,

--- a/lib/src/dom/webgl_lose_context.dart
+++ b/lib/src/dom/webgl_lose_context.dart
@@ -9,6 +9,6 @@ import 'dart:js_interop';
 class WEBGL_lose_context implements JSObject {}
 
 extension WEBGLLoseContextExtension on WEBGL_lose_context {
-  external JSVoid loseContext();
-  external JSVoid restoreContext();
+  external void loseContext();
+  external void restoreContext();
 }

--- a/lib/src/dom/webgl_multi_draw.dart
+++ b/lib/src/dom/webgl_multi_draw.dart
@@ -11,7 +11,7 @@ import 'webgl1.dart';
 class WEBGL_multi_draw implements JSObject {}
 
 extension WEBGLMultiDrawExtension on WEBGL_multi_draw {
-  external JSVoid multiDrawArraysWEBGL(
+  external void multiDrawArraysWEBGL(
     GLenum mode,
     JSObject firstsList,
     int firstsOffset,
@@ -19,7 +19,7 @@ extension WEBGLMultiDrawExtension on WEBGL_multi_draw {
     int countsOffset,
     GLsizei drawcount,
   );
-  external JSVoid multiDrawElementsWEBGL(
+  external void multiDrawElementsWEBGL(
     GLenum mode,
     JSObject countsList,
     int countsOffset,
@@ -28,7 +28,7 @@ extension WEBGLMultiDrawExtension on WEBGL_multi_draw {
     int offsetsOffset,
     GLsizei drawcount,
   );
-  external JSVoid multiDrawArraysInstancedWEBGL(
+  external void multiDrawArraysInstancedWEBGL(
     GLenum mode,
     JSObject firstsList,
     int firstsOffset,
@@ -38,7 +38,7 @@ extension WEBGLMultiDrawExtension on WEBGL_multi_draw {
     int instanceCountsOffset,
     GLsizei drawcount,
   );
-  external JSVoid multiDrawElementsInstancedWEBGL(
+  external void multiDrawElementsInstancedWEBGL(
     GLenum mode,
     JSObject countsList,
     int countsOffset,

--- a/lib/src/dom/webgl_multi_draw_instanced_base_vertex_base_instance.dart
+++ b/lib/src/dom/webgl_multi_draw_instanced_base_vertex_base_instance.dart
@@ -13,7 +13,7 @@ class WEBGL_multi_draw_instanced_base_vertex_base_instance
 
 extension WEBGLMultiDrawInstancedBaseVertexBaseInstanceExtension
     on WEBGL_multi_draw_instanced_base_vertex_base_instance {
-  external JSVoid multiDrawArraysInstancedBaseInstanceWEBGL(
+  external void multiDrawArraysInstancedBaseInstanceWEBGL(
     GLenum mode,
     JSObject firstsList,
     int firstsOffset,
@@ -25,7 +25,7 @@ extension WEBGLMultiDrawInstancedBaseVertexBaseInstanceExtension
     int baseInstancesOffset,
     GLsizei drawcount,
   );
-  external JSVoid multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(
+  external void multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(
     GLenum mode,
     JSObject countsList,
     int countsOffset,

--- a/lib/src/dom/webgl_provoking_vertex.dart
+++ b/lib/src/dom/webgl_provoking_vertex.dart
@@ -15,5 +15,5 @@ class WEBGL_provoking_vertex implements JSObject {
 }
 
 extension WEBGLProvokingVertexExtension on WEBGL_provoking_vertex {
-  external JSVoid provokingVertexWEBGL(GLenum provokeMode);
+  external void provokingVertexWEBGL(GLenum provokeMode);
 }

--- a/lib/src/dom/webgpu.dart
+++ b/lib/src/dom/webgpu.dart
@@ -203,7 +203,7 @@ extension GPUAdapterExtension on GPUAdapter {
 class GPUDeviceDescriptor implements GPUObjectDescriptorBase {
   external factory GPUDeviceDescriptor({
     JSArray requiredFeatures,
-    JSAny? requiredLimits,
+    JSAny requiredLimits,
     GPUQueueDescriptor defaultQueue,
   });
 }
@@ -211,8 +211,8 @@ class GPUDeviceDescriptor implements GPUObjectDescriptorBase {
 extension GPUDeviceDescriptorExtension on GPUDeviceDescriptor {
   external set requiredFeatures(JSArray value);
   external JSArray get requiredFeatures;
-  external set requiredLimits(JSAny? value);
-  external JSAny? get requiredLimits;
+  external set requiredLimits(JSAny value);
+  external JSAny get requiredLimits;
   external set defaultQueue(GPUQueueDescriptor value);
   external GPUQueueDescriptor get defaultQueue;
 }
@@ -222,7 +222,7 @@ extension GPUDeviceDescriptorExtension on GPUDeviceDescriptor {
 class GPUDevice implements EventTarget, GPUObjectBase {}
 
 extension GPUDeviceExtension on GPUDevice {
-  external JSVoid destroy();
+  external void destroy();
   external GPUBuffer createBuffer(GPUBufferDescriptor descriptor);
   external GPUTexture createTexture(GPUTextureDescriptor descriptor);
   external GPUSampler createSampler([GPUSamplerDescriptor descriptor]);
@@ -248,7 +248,7 @@ extension GPUDeviceExtension on GPUDevice {
   external GPURenderBundleEncoder createRenderBundleEncoder(
       GPURenderBundleEncoderDescriptor descriptor);
   external GPUQuerySet createQuerySet(GPUQuerySetDescriptor descriptor);
-  external JSVoid pushErrorScope(GPUErrorFilter filter);
+  external void pushErrorScope(GPUErrorFilter filter);
   external JSPromise popErrorScope();
   external GPUSupportedFeatures get features;
   external GPUSupportedLimits get limits;
@@ -272,8 +272,8 @@ extension GPUBufferExtension on GPUBuffer {
     GPUSize64 offset,
     GPUSize64 size,
   ]);
-  external JSVoid unmap();
-  external JSVoid destroy();
+  external void unmap();
+  external void destroy();
   external GPUSize64Out get size;
   external GPUFlagsConstant get usage;
   external GPUBufferMapState get mapState;
@@ -333,7 +333,7 @@ class GPUTexture implements GPUObjectBase {}
 
 extension GPUTextureExtension on GPUTexture {
   external GPUTextureView createView([GPUTextureViewDescriptor descriptor]);
-  external JSVoid destroy();
+  external void destroy();
   external GPUIntegerCoordinateOut get width;
   external GPUIntegerCoordinateOut get height;
   external GPUIntegerCoordinateOut get depthOrArrayLayers;
@@ -722,7 +722,7 @@ class GPUShaderModuleDescriptor implements GPUObjectDescriptorBase {
   external factory GPUShaderModuleDescriptor({
     required String code,
     JSObject sourceMap,
-    JSAny? hints,
+    JSAny hints,
   });
 }
 
@@ -731,21 +731,21 @@ extension GPUShaderModuleDescriptorExtension on GPUShaderModuleDescriptor {
   external String get code;
   external set sourceMap(JSObject value);
   external JSObject get sourceMap;
-  external set hints(JSAny? value);
-  external JSAny? get hints;
+  external set hints(JSAny value);
+  external JSAny get hints;
 }
 
 @JS()
 @staticInterop
 @anonymous
 class GPUShaderModuleCompilationHint implements JSObject {
-  external factory GPUShaderModuleCompilationHint({JSAny? layout});
+  external factory GPUShaderModuleCompilationHint({JSAny layout});
 }
 
 extension GPUShaderModuleCompilationHintExtension
     on GPUShaderModuleCompilationHint {
-  external set layout(JSAny? value);
-  external JSAny? get layout;
+  external set layout(JSAny value);
+  external JSAny get layout;
 }
 
 @JS('GPUCompilationMessage')
@@ -799,12 +799,12 @@ extension GPUPipelineErrorInitExtension on GPUPipelineErrorInit {
 @staticInterop
 @anonymous
 class GPUPipelineDescriptorBase implements GPUObjectDescriptorBase {
-  external factory GPUPipelineDescriptorBase({required JSAny? layout});
+  external factory GPUPipelineDescriptorBase({required JSAny layout});
 }
 
 extension GPUPipelineDescriptorBaseExtension on GPUPipelineDescriptorBase {
-  external set layout(JSAny? value);
-  external JSAny? get layout;
+  external set layout(JSAny value);
+  external JSAny get layout;
 }
 
 @JS('GPUPipelineBase')
@@ -822,7 +822,7 @@ class GPUProgrammableStage implements JSObject {
   external factory GPUProgrammableStage({
     required GPUShaderModule module,
     required String entryPoint,
-    JSAny? constants,
+    JSAny constants,
   });
 }
 
@@ -831,8 +831,8 @@ extension GPUProgrammableStageExtension on GPUProgrammableStage {
   external GPUShaderModule get module;
   external set entryPoint(String value);
   external String get entryPoint;
-  external set constants(JSAny? value);
-  external JSAny? get constants;
+  external set constants(JSAny value);
+  external JSAny get constants;
 }
 
 @JS('GPUComputePipeline')
@@ -1244,38 +1244,38 @@ extension GPUCommandEncoderExtension on GPUCommandEncoder {
       GPURenderPassDescriptor descriptor);
   external GPUComputePassEncoder beginComputePass(
       [GPUComputePassDescriptor descriptor]);
-  external JSVoid copyBufferToBuffer(
+  external void copyBufferToBuffer(
     GPUBuffer source,
     GPUSize64 sourceOffset,
     GPUBuffer destination,
     GPUSize64 destinationOffset,
     GPUSize64 size,
   );
-  external JSVoid copyBufferToTexture(
+  external void copyBufferToTexture(
     GPUImageCopyBuffer source,
     GPUImageCopyTexture destination,
     GPUExtent3D copySize,
   );
-  external JSVoid copyTextureToBuffer(
+  external void copyTextureToBuffer(
     GPUImageCopyTexture source,
     GPUImageCopyBuffer destination,
     GPUExtent3D copySize,
   );
-  external JSVoid copyTextureToTexture(
+  external void copyTextureToTexture(
     GPUImageCopyTexture source,
     GPUImageCopyTexture destination,
     GPUExtent3D copySize,
   );
-  external JSVoid clearBuffer(
+  external void clearBuffer(
     GPUBuffer buffer, [
     GPUSize64 offset,
     GPUSize64 size,
   ]);
-  external JSVoid writeTimestamp(
+  external void writeTimestamp(
     GPUQuerySet querySet,
     GPUSize32 queryIndex,
   );
-  external JSVoid resolveQuerySet(
+  external void resolveQuerySet(
     GPUQuerySet querySet,
     GPUSize32 firstQuery,
     GPUSize32 queryCount,
@@ -1297,7 +1297,7 @@ class GPUCommandEncoderDescriptor implements GPUObjectDescriptorBase {
 class GPUBindingCommandsMixin implements JSObject {}
 
 extension GPUBindingCommandsMixinExtension on GPUBindingCommandsMixin {
-  external JSVoid setBindGroup(
+  external void setBindGroup(
     GPUIndex32 index,
     GPUBindGroup? bindGroup, [
     JSObject dynamicOffsetsOrDynamicOffsetsData,
@@ -1311,9 +1311,9 @@ extension GPUBindingCommandsMixinExtension on GPUBindingCommandsMixin {
 class GPUDebugCommandsMixin implements JSObject {}
 
 extension GPUDebugCommandsMixinExtension on GPUDebugCommandsMixin {
-  external JSVoid pushDebugGroup(String groupLabel);
-  external JSVoid popDebugGroup();
-  external JSVoid insertDebugMarker(String markerLabel);
+  external void pushDebugGroup(String groupLabel);
+  external void popDebugGroup();
+  external void insertDebugMarker(String markerLabel);
 }
 
 @JS('GPUComputePassEncoder')
@@ -1326,17 +1326,17 @@ class GPUComputePassEncoder
         GPUBindingCommandsMixin {}
 
 extension GPUComputePassEncoderExtension on GPUComputePassEncoder {
-  external JSVoid setPipeline(GPUComputePipeline pipeline);
-  external JSVoid dispatchWorkgroups(
+  external void setPipeline(GPUComputePipeline pipeline);
+  external void dispatchWorkgroups(
     GPUSize32 workgroupCountX, [
     GPUSize32 workgroupCountY,
     GPUSize32 workgroupCountZ,
   ]);
-  external JSVoid dispatchWorkgroupsIndirect(
+  external void dispatchWorkgroupsIndirect(
     GPUBuffer indirectBuffer,
     GPUSize64 indirectOffset,
   );
-  external JSVoid end();
+  external void end();
 }
 
 @JS()
@@ -1384,7 +1384,7 @@ class GPURenderPassEncoder
         GPURenderCommandsMixin {}
 
 extension GPURenderPassEncoderExtension on GPURenderPassEncoder {
-  external JSVoid setViewport(
+  external void setViewport(
     num x,
     num y,
     num width,
@@ -1392,18 +1392,18 @@ extension GPURenderPassEncoderExtension on GPURenderPassEncoder {
     num minDepth,
     num maxDepth,
   );
-  external JSVoid setScissorRect(
+  external void setScissorRect(
     GPUIntegerCoordinate x,
     GPUIntegerCoordinate y,
     GPUIntegerCoordinate width,
     GPUIntegerCoordinate height,
   );
-  external JSVoid setBlendConstant(GPUColor color);
-  external JSVoid setStencilReference(GPUStencilValue reference);
-  external JSVoid beginOcclusionQuery(GPUSize32 queryIndex);
-  external JSVoid endOcclusionQuery();
-  external JSVoid executeBundles(JSArray bundles);
-  external JSVoid end();
+  external void setBlendConstant(GPUColor color);
+  external void setStencilReference(GPUStencilValue reference);
+  external void beginOcclusionQuery(GPUSize32 queryIndex);
+  external void endOcclusionQuery();
+  external void executeBundles(JSArray bundles);
+  external void end();
 }
 
 @JS()
@@ -1545,37 +1545,37 @@ extension GPURenderPassLayoutExtension on GPURenderPassLayout {
 class GPURenderCommandsMixin implements JSObject {}
 
 extension GPURenderCommandsMixinExtension on GPURenderCommandsMixin {
-  external JSVoid setPipeline(GPURenderPipeline pipeline);
-  external JSVoid setIndexBuffer(
+  external void setPipeline(GPURenderPipeline pipeline);
+  external void setIndexBuffer(
     GPUBuffer buffer,
     GPUIndexFormat indexFormat, [
     GPUSize64 offset,
     GPUSize64 size,
   ]);
-  external JSVoid setVertexBuffer(
+  external void setVertexBuffer(
     GPUIndex32 slot,
     GPUBuffer? buffer, [
     GPUSize64 offset,
     GPUSize64 size,
   ]);
-  external JSVoid draw(
+  external void draw(
     GPUSize32 vertexCount, [
     GPUSize32 instanceCount,
     GPUSize32 firstVertex,
     GPUSize32 firstInstance,
   ]);
-  external JSVoid drawIndexed(
+  external void drawIndexed(
     GPUSize32 indexCount, [
     GPUSize32 instanceCount,
     GPUSize32 firstIndex,
     GPUSignedOffset32 baseVertex,
     GPUSize32 firstInstance,
   ]);
-  external JSVoid drawIndirect(
+  external void drawIndirect(
     GPUBuffer indirectBuffer,
     GPUSize64 indirectOffset,
   );
-  external JSVoid drawIndexedIndirect(
+  external void drawIndexedIndirect(
     GPUBuffer indirectBuffer,
     GPUSize64 indirectOffset,
   );
@@ -1636,22 +1636,22 @@ class GPUQueueDescriptor implements GPUObjectDescriptorBase {
 class GPUQueue implements GPUObjectBase {}
 
 extension GPUQueueExtension on GPUQueue {
-  external JSVoid submit(JSArray commandBuffers);
+  external void submit(JSArray commandBuffers);
   external JSPromise onSubmittedWorkDone();
-  external JSVoid writeBuffer(
+  external void writeBuffer(
     GPUBuffer buffer,
     GPUSize64 bufferOffset,
     AllowSharedBufferSource data, [
     GPUSize64 dataOffset,
     GPUSize64 size,
   ]);
-  external JSVoid writeTexture(
+  external void writeTexture(
     GPUImageCopyTexture destination,
     AllowSharedBufferSource data,
     GPUImageDataLayout dataLayout,
     GPUExtent3D size,
   );
-  external JSVoid copyExternalImageToTexture(
+  external void copyExternalImageToTexture(
     GPUImageCopyExternalImage source,
     GPUImageCopyTextureTagged destination,
     GPUExtent3D copySize,
@@ -1663,7 +1663,7 @@ extension GPUQueueExtension on GPUQueue {
 class GPUQuerySet implements GPUObjectBase {}
 
 extension GPUQuerySetExtension on GPUQuerySet {
-  external JSVoid destroy();
+  external void destroy();
   external GPUQueryType get type;
   external GPUSize32Out get count;
 }
@@ -1690,8 +1690,8 @@ extension GPUQuerySetDescriptorExtension on GPUQuerySetDescriptor {
 class GPUCanvasContext implements JSObject {}
 
 extension GPUCanvasContextExtension on GPUCanvasContext {
-  external JSVoid configure(GPUCanvasConfiguration configuration);
-  external JSVoid unconfigure();
+  external void configure(GPUCanvasConfiguration configuration);
+  external void unconfigure();
   external GPUTexture getCurrentTexture();
   external JSObject get canvas;
 }

--- a/lib/src/dom/webmidi.dart
+++ b/lib/src/dom/webmidi.dart
@@ -98,11 +98,11 @@ extension MIDIInputExtension on MIDIInput {
 class MIDIOutput implements MIDIPort {}
 
 extension MIDIOutputExtension on MIDIOutput {
-  external JSVoid send(
+  external void send(
     JSArray data, [
     DOMHighResTimeStamp timestamp,
   ]);
-  external JSVoid clear();
+  external void clear();
 }
 
 @JS('MIDIMessageEvent')

--- a/lib/src/dom/webnn.dart
+++ b/lib/src/dom/webnn.dart
@@ -6,10 +6,10 @@ import 'dart:js_interop';
 
 import 'webgpu.dart';
 
-typedef MLNamedArrayBufferViews = JSAny?;
+typedef MLNamedArrayBufferViews = JSAny;
 typedef MLGPUResource = JSObject;
-typedef MLNamedGPUResources = JSAny?;
-typedef MLNamedOperands = JSAny?;
+typedef MLNamedGPUResources = JSAny;
+typedef MLNamedOperands = JSAny;
 typedef MLBufferView = JSObject;
 typedef MLDeviceType = String;
 typedef MLPowerPreference = String;
@@ -93,7 +93,7 @@ class MLActivation implements JSObject {}
 class MLContext implements JSObject {}
 
 extension MLContextExtension on MLContext {
-  external JSVoid computeSync(
+  external void computeSync(
     MLGraph graph,
     MLNamedArrayBufferViews inputs,
     MLNamedArrayBufferViews outputs,
@@ -128,8 +128,8 @@ extension MLComputeResultExtension on MLComputeResult {
 class MLCommandEncoder implements JSObject {}
 
 extension MLCommandEncoderExtension on MLCommandEncoder {
-  external JSVoid initializeGraph(MLGraph graph);
-  external JSVoid dispatch(
+  external void initializeGraph(MLGraph graph);
+  external void dispatch(
     MLGraph graph,
     MLNamedGPUResources inputs,
     MLNamedGPUResources outputs,
@@ -169,8 +169,8 @@ extension MLGraphBuilderExtension on MLGraphBuilder {
     MLOperandDescriptor descriptor,
   );
   external MLOperand constant(
-    JSAny? descriptorOrValue, [
-    JSAny? bufferViewOrType,
+    JSAny descriptorOrValue, [
+    JSAny bufferViewOrType,
   ]);
   external JSPromise build(MLNamedOperands outputs);
   external MLGraph buildSync(MLNamedOperands outputs);
@@ -383,7 +383,7 @@ extension MLGraphBuilderExtension on MLGraphBuilder {
   external JSObject softsign([MLOperand input]);
   external JSArray split(
     MLOperand input,
-    JSAny? splits, [
+    JSAny splits, [
     MLSplitOptions options,
   ]);
   external MLOperand squeeze(

--- a/lib/src/dom/webrtc.dart
+++ b/lib/src/dom/webrtc.dart
@@ -79,15 +79,15 @@ extension RTCConfigurationExtension on RTCConfiguration {
 @anonymous
 class RTCIceServer implements JSObject {
   external factory RTCIceServer({
-    required JSAny? urls,
+    required JSAny urls,
     String username,
     String credential,
   });
 }
 
 extension RTCIceServerExtension on RTCIceServer {
-  external set urls(JSAny? value);
-  external JSAny? get urls;
+  external set urls(JSAny value);
+  external JSAny get urls;
   external set username(String value);
   external String get username;
   external set credential(String value);
@@ -138,7 +138,7 @@ class RTCPeerConnection implements EventTarget {
 }
 
 extension RTCPeerConnectionExtension on RTCPeerConnection {
-  external JSVoid setIdentityProvider(
+  external void setIdentityProvider(
     String provider, [
     RTCIdentityProviderOptions options,
   ]);
@@ -167,10 +167,10 @@ extension RTCPeerConnectionExtension on RTCPeerConnection {
     VoidFunction successCallback,
     RTCPeerConnectionErrorCallback failureCallback,
   ]);
-  external JSVoid restartIce();
+  external void restartIce();
   external RTCConfiguration getConfiguration();
-  external JSVoid setConfiguration([RTCConfiguration configuration]);
-  external JSVoid close();
+  external void setConfiguration([RTCConfiguration configuration]);
+  external void close();
   external JSArray getSenders();
   external JSArray getReceivers();
   external JSArray getTransceivers();
@@ -178,9 +178,9 @@ extension RTCPeerConnectionExtension on RTCPeerConnection {
     MediaStreamTrack track,
     MediaStream streams,
   );
-  external JSVoid removeTrack(RTCRtpSender sender);
+  external void removeTrack(RTCRtpSender sender);
   external RTCRtpTransceiver addTransceiver(
-    JSAny? trackOrKind, [
+    JSAny trackOrKind, [
     RTCRtpTransceiverInit init,
   ]);
   external RTCDataChannel createDataChannel(
@@ -452,7 +452,7 @@ extension RTCRtpSenderExtension on RTCRtpSender {
   ]);
   external RTCRtpSendParameters getParameters();
   external JSPromise replaceTrack(MediaStreamTrack? withTrack);
-  external JSVoid setStreams(MediaStream streams);
+  external void setStreams(MediaStream streams);
   external JSPromise getStats();
   external set transform(RTCRtpTransform? value);
   external RTCRtpTransform? get transform;
@@ -721,8 +721,8 @@ class RTCRtpSynchronizationSource implements RTCRtpContributingSource {
 class RTCRtpTransceiver implements JSObject {}
 
 extension RTCRtpTransceiverExtension on RTCRtpTransceiver {
-  external JSVoid stop();
-  external JSVoid setCodecPreferences(JSArray codecs);
+  external void stop();
+  external void setCodecPreferences(JSArray codecs);
   external String? get mid;
   external RTCRtpSender get sender;
   external RTCRtpReceiver get receiver;
@@ -769,13 +769,13 @@ class RTCIceTransport implements EventTarget {
 }
 
 extension RTCIceTransportExtension on RTCIceTransport {
-  external JSVoid gather([RTCIceGatherOptions options]);
-  external JSVoid start([
+  external void gather([RTCIceGatherOptions options]);
+  external void start([
     RTCIceParameters remoteParameters,
     RTCIceRole role,
   ]);
-  external JSVoid stop();
-  external JSVoid addRemoteCandidate([RTCIceCandidateInit remoteCandidate]);
+  external void stop();
+  external void addRemoteCandidate([RTCIceCandidateInit remoteCandidate]);
   external JSArray getLocalCandidates();
   external JSArray getRemoteCandidates();
   external RTCIceCandidatePair? getSelectedCandidatePair();
@@ -891,8 +891,8 @@ extension RTCSctpTransportExtension on RTCSctpTransport {
 class RTCDataChannel implements EventTarget {}
 
 extension RTCDataChannelExtension on RTCDataChannel {
-  external JSVoid close();
-  external JSVoid send(JSAny? data);
+  external void close();
+  external void send(JSAny data);
   external RTCPriorityType get priority;
   external String get label;
   external bool get ordered;
@@ -983,7 +983,7 @@ extension RTCDataChannelEventInitExtension on RTCDataChannelEventInit {
 class RTCDTMFSender implements EventTarget {}
 
 extension RTCDTMFSenderExtension on RTCDTMFSender {
-  external JSVoid insertDTMF(
+  external void insertDTMF(
     String tones, [
     int duration,
     int interToneGap,

--- a/lib/src/dom/webrtc_encoded_transform.dart
+++ b/lib/src/dom/webrtc_encoded_transform.dart
@@ -11,7 +11,7 @@ import 'webcryptoapi.dart';
 
 typedef RTCRtpTransform = JSObject;
 typedef SmallCryptoKeyID = int;
-typedef CryptoKeyID = JSAny?;
+typedef CryptoKeyID = JSAny;
 typedef SFrameTransformRole = String;
 typedef SFrameTransformErrorEventType = String;
 typedef RTCEncodedVideoFrameType = String;

--- a/lib/src/dom/webrtc_identity.dart
+++ b/lib/src/dom/webrtc_identity.dart
@@ -25,7 +25,7 @@ class RTCIdentityProviderRegistrar implements JSObject {}
 
 extension RTCIdentityProviderRegistrarExtension
     on RTCIdentityProviderRegistrar {
-  external JSVoid register(RTCIdentityProvider idp);
+  external void register(RTCIdentityProvider idp);
 }
 
 @JS()

--- a/lib/src/dom/webrtc_stats.dart
+++ b/lib/src/dom/webrtc_stats.dart
@@ -324,7 +324,7 @@ class RTCOutboundRtpStreamStats implements RTCSentRtpStreamStats {
     num totalEncodeTime,
     num totalPacketSendDelay,
     RTCQualityLimitationReason qualityLimitationReason,
-    JSAny? qualityLimitationDurations,
+    JSAny qualityLimitationDurations,
     int qualityLimitationResolutionChanges,
     int nackCount,
     int firCount,
@@ -379,8 +379,8 @@ extension RTCOutboundRtpStreamStatsExtension on RTCOutboundRtpStreamStats {
   external num get totalPacketSendDelay;
   external set qualityLimitationReason(RTCQualityLimitationReason value);
   external RTCQualityLimitationReason get qualityLimitationReason;
-  external set qualityLimitationDurations(JSAny? value);
-  external JSAny? get qualityLimitationDurations;
+  external set qualityLimitationDurations(JSAny value);
+  external JSAny get qualityLimitationDurations;
   external set qualityLimitationResolutionChanges(int value);
   external int get qualityLimitationResolutionChanges;
   external set nackCount(int value);

--- a/lib/src/dom/websockets.dart
+++ b/lib/src/dom/websockets.dart
@@ -14,7 +14,7 @@ typedef BinaryType = String;
 class WebSocket implements EventTarget {
   external factory WebSocket(
     String url, [
-    JSAny? protocols,
+    JSAny protocols,
   ]);
 
   external static int get CONNECTING;
@@ -24,11 +24,11 @@ class WebSocket implements EventTarget {
 }
 
 extension WebSocketExtension on WebSocket {
-  external JSVoid close([
+  external void close([
     int code,
     String reason,
   ]);
-  external JSVoid send(JSAny? data);
+  external void send(JSAny data);
   external String get url;
   external int get readyState;
   external int get bufferedAmount;

--- a/lib/src/dom/webtransport.dart
+++ b/lib/src/dom/webtransport.dart
@@ -42,7 +42,7 @@ class WebTransport implements JSObject {
 
 extension WebTransportExtension on WebTransport {
   external JSPromise getStats();
-  external JSVoid close([WebTransportCloseInfo closeInfo]);
+  external void close([WebTransportCloseInfo closeInfo]);
   external JSPromise createBidirectionalStream(
       [WebTransportSendStreamOptions options]);
   external JSPromise createUnidirectionalStream(

--- a/lib/src/dom/webvtt.dart
+++ b/lib/src/dom/webvtt.dart
@@ -7,7 +7,7 @@ import 'dart:js_interop';
 import 'dom.dart';
 import 'html.dart';
 
-typedef LineAndPositionSetting = JSAny?;
+typedef LineAndPositionSetting = JSAny;
 typedef AutoKeyword = String;
 typedef DirectionSetting = String;
 typedef LineAlignSetting = String;

--- a/lib/src/dom/webxr.dart
+++ b/lib/src/dom/webxr.dart
@@ -78,11 +78,11 @@ extension XRSessionExtension on XRSession {
   external JSPromise requestHitTestSourceForTransientInput(
       XRTransientInputHitTestOptionsInit options);
   external JSPromise requestLightProbe([XRLightProbeInit options]);
-  external JSVoid updateRenderState([XRRenderStateInit state]);
+  external void updateRenderState([XRRenderStateInit state]);
   external JSPromise updateTargetFrameRate(num rate);
   external JSPromise requestReferenceSpace(XRReferenceSpaceType type);
   external int requestAnimationFrame(XRFrameRequestCallback callback);
-  external JSVoid cancelAnimationFrame(int handle);
+  external void cancelAnimationFrame(int handle);
   external JSPromise end();
   external JSArray get persistentAnchors;
   external XREnvironmentBlendMode get environmentBlendMode;
@@ -224,7 +224,7 @@ extension XRBoundedReferenceSpaceExtension on XRBoundedReferenceSpace {
 class XRView implements JSObject {}
 
 extension XRViewExtension on XRView {
-  external JSVoid requestViewportScale(num? scale);
+  external void requestViewportScale(num? scale);
   external XRCamera? get camera;
   external bool get isFirstPersonObserver;
   external XREye get eye;

--- a/lib/src/dom/webxr_hit_test.dart
+++ b/lib/src/dom/webxr_hit_test.dart
@@ -55,7 +55,7 @@ extension XRTransientInputHitTestOptionsInitExtension
 class XRHitTestSource implements JSObject {}
 
 extension XRHitTestSourceExtension on XRHitTestSource {
-  external JSVoid cancel();
+  external void cancel();
 }
 
 @JS('XRTransientInputHitTestSource')
@@ -64,7 +64,7 @@ class XRTransientInputHitTestSource implements JSObject {}
 
 extension XRTransientInputHitTestSourceExtension
     on XRTransientInputHitTestSource {
-  external JSVoid cancel();
+  external void cancel();
 }
 
 @JS('XRHitTestResult')

--- a/lib/src/dom/webxrlayers.dart
+++ b/lib/src/dom/webxrlayers.dart
@@ -22,7 +22,7 @@ typedef XRTextureType = String;
 class XRCompositionLayer implements XRLayer {}
 
 extension XRCompositionLayerExtension on XRCompositionLayer {
-  external JSVoid destroy();
+  external void destroy();
   external XRLayerLayout get layout;
   external set blendTextureSourceAlpha(bool value);
   external bool get blendTextureSourceAlpha;

--- a/lib/src/dom/xhr.dart
+++ b/lib/src/dom/xhr.dart
@@ -9,7 +9,7 @@ import 'dom.dart';
 import 'html.dart';
 import 'trust_token_api.dart';
 
-typedef FormDataEntryValue = JSAny?;
+typedef FormDataEntryValue = JSAny;
 typedef XMLHttpRequestResponseType = String;
 
 @JS('XMLHttpRequestEventTarget')
@@ -50,25 +50,25 @@ class XMLHttpRequest implements XMLHttpRequestEventTarget {
 }
 
 extension XMLHttpRequestExtension on XMLHttpRequest {
-  external JSVoid setAttributionReporting(
+  external void setAttributionReporting(
       AttributionReportingRequestOptions options);
-  external JSVoid setPrivateToken(PrivateToken privateToken);
-  external JSVoid open(
+  external void setPrivateToken(PrivateToken privateToken);
+  external void open(
     String method,
     String url, [
     bool async,
     String? username,
     String? password,
   ]);
-  external JSVoid setRequestHeader(
+  external void setRequestHeader(
     String name,
     String value,
   );
-  external JSVoid send([JSAny? body]);
-  external JSVoid abort();
+  external void send([JSAny? body]);
+  external void abort();
   external String? getResponseHeader(String name);
   external String getAllResponseHeaders();
-  external JSVoid overrideMimeType(String mime);
+  external void overrideMimeType(String mime);
   external set onreadystatechange(EventHandler value);
   external EventHandler get onreadystatechange;
   external int get readyState;
@@ -97,18 +97,18 @@ class FormData implements JSObject {
 }
 
 extension FormDataExtension on FormData {
-  external JSVoid append(
+  external void append(
     String name,
-    JSAny? blobValueOrValue, [
+    JSAny blobValueOrValue, [
     String filename,
   ]);
-  external JSVoid delete(String name);
+  external void delete(String name);
   external FormDataEntryValue? get(String name);
   external JSArray getAll(String name);
   external bool has(String name);
-  external JSVoid set(
+  external void set(
     String name,
-    JSAny? blobValueOrValue, [
+    JSAny blobValueOrValue, [
     String filename,
   ]);
 }

--- a/tool/bindings_generator/type_aliases.dart
+++ b/tool/bindings_generator/type_aliases.dart
@@ -2,16 +2,17 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-const typeAliases = <String, String>{
+const idlOrBuiltinToJsTypeAliases = <String, String>{
   'any': 'JSAny',
   'bigint': 'JSBigInt',
   'record': 'JSAny',
   'object': 'JSObject',
   'Promise': 'JSPromise',
-  'boolean': 'bool',
+  'boolean': 'JSBoolean',
+  // Note that this is a special sentinel that doesn't actually exist in the set
+  // of JS types today (although this might in the future).
   'undefined': 'JSUndefined',
   'Function': 'JSFunction',
-  'WindowProxy': 'Window',
   'SharedArrayBuffer': 'JSObject',
 
   'ArrayBuffer': 'JSArrayBuffer',
@@ -34,26 +35,25 @@ const typeAliases = <String, String>{
   'FrozenArray': 'JSArray',
   'ObservableArray': 'JSArray',
 
-  // TODO(srujzs): We should ideally use JS types everywhere, and only change
-  // to Dart types when we are translating. However, we need to figure out what
-  // to do for `int` vs `num` as they both map to `JSNumber`.
-  // Number aliases.
-  'byte': 'int',
-  'octet': 'int',
-  'short': 'int',
-  'long': 'int',
-  'long long': 'int',
-  'unsigned short': 'int',
-  'unsigned long': 'int',
-  'unsigned long long': 'int',
-  'float': 'num',
-  'double': 'num',
-  'unrestricted double': 'num',
-  'unrestricted float': 'num',
+  // Number aliases. Like `JSUndefined`, `JSInteger` and `JSDouble` are special
+  // sentinels so that we can differentiate between `int` and `double` values
+  // when we emit Dart types.
+  'byte': 'JSInteger',
+  'octet': 'JSInteger',
+  'short': 'JSInteger',
+  'long': 'JSInteger',
+  'long long': 'JSInteger',
+  'unsigned short': 'JSInteger',
+  'unsigned long': 'JSInteger',
+  'unsigned long long': 'JSInteger',
+  'float': 'JSDouble',
+  'double': 'JSDouble',
+  'unrestricted double': 'JSDouble',
+  'unrestricted float': 'JSDouble',
 
   // String aliases.
-  'DOMString': 'String',
-  'USVString': 'String',
-  'ByteString': 'String',
-  'CSSOMString': 'String',
+  'DOMString': 'JSString',
+  'USVString': 'JSString',
+  'ByteString': 'JSString',
+  'CSSOMString': 'JSString',
 };


### PR DESCRIPTION
Major changes:
1. Fixes an issue where we assume that all JSAnys should be nullable, whereas all anys should be nullable instead.
2. Changes typing model to go from IDLType to "raw" type, which is either an IDL declaration type or a dart:js_interop type, to a Dart type reference. This makes it easier to add generic types later as well.

Minor changes:
1. Reuses _Type and renames it to _RawType instead of using a record.
2. Removes unnecessary "isReturn" parameters as undefined can only appear in a return type per the web IDL spec.
3. JSVoid -> void as it's more readable.