### PR TITLE
Add `createIFrameElement` helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.3.1-dev
-
+- Add `createIFrameElement` method to `helpers.dart`.
 - Updated types to account for union types.
 - Fixed issue where all `JSAny`s were treated as nullable.
 - Changed `JSVoid` to `void`.

--- a/lib/helpers.dart
+++ b/lib/helpers.dart
@@ -46,6 +46,9 @@ HTMLCanvasElement createCanvasElement({int? width, int? height}) {
   return result;
 }
 
+HTMLIFrameElement createIFrameElement() =>
+    document.createElement('iframe') as HTMLIFrameElement;
+
 @JS('Audio')
 external JSFunction get _audioConstructor;
 HTMLAudioElement createAudioElement() => _audioConstructor.callAsConstructor();


### PR DESCRIPTION
In trying to migrate from `dart:html` to `package:web`, it was not obvious to me how to create an iFrame element. Not sure if you think this is special enough to special case with its own helper, but thought I'd push up a PR to propose.

@srujzs 