### PR TITLE
Prepare for 0.3.1 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.1-dev
+## 0.3.1
 - Add `onMessage` getter to `WindowEventGetters` extension methods.
 - `helpers.dart`: expose the `EventStreamProviders` class.
 - Add `createIFrameElement` method to `helpers.dart`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: web
 description: >-
   Lightweight DOM and JS bindings built around JS static interop.
-version: 0.3.1-dev
+version: 0.3.1
 
 repository: https://github.com/dart-lang/web
 


### PR DESCRIPTION
Publishing 0.3.1 will unblock https://github.com/flutter/devtools/pull/6626. 
@srujzs @kevmoo 