### PR TITLE
Add event extensions for `WebSocket`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.4.1-wip
 
 - Add an example.
+- `helpers.dart`:
+  - Added event extensions for `WebSocket`
 
 ## 0.4.0
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -18,8 +18,6 @@ linter:
   - avoid_bool_literals_in_conditional_expressions
   - avoid_private_typedef_functions
   - avoid_redundant_argument_values
-  - avoid_returning_null
-  - avoid_returning_null_for_future
   - avoid_returning_this
   - avoid_unused_constructor_parameters
   - cancel_subscriptions

--- a/lib/src/helpers/events/events.dart
+++ b/lib/src/helpers/events/events.dart
@@ -289,3 +289,13 @@ extension WindowCustomEvents on Window {
   Stream<TransitionEvent> get onTransitionEnd =>
       CustomEventProviders.transitionEndEvent.forTarget(this);
 }
+
+extension WebSocketEvents on WebSocket {
+  Stream<Event> get onOpen => EventStreamProviders.openEvent.forTarget(this);
+  Stream<MessageEvent> get onMessage =>
+      EventStreamProviders.messageEvent.forTarget(this);
+  Stream<CloseEvent> get onClose =>
+      EventStreamProviders.closeEvent.forTarget(this);
+  Stream<Event> get onError =>
+      EventStreamProviders.errorEventSourceEvent.forTarget(this);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.4.1-wip
 repository: https://github.com/dart-lang/web
 
 environment:
-  sdk: ">=3.2.0-194.0.dev <4.0.0"
+  sdk: ^3.2.0
 
 dev_dependencies:
   analyzer: ^6.2.0


### PR DESCRIPTION
Cleanup SDK constraint now that Dart 3.2 is stable
