### PR TITLE
rename helpers.dart to web_helpers.dart and no longer export web.dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
-## 0.4.1-wip
+## 0.5.0-wip
 
-- Add an example.
-- `helpers.dart`:
+- Rename the `helpers.dart` library to `web_helpers.dart`.
+- No longer export `web.dart` from `web_helpers.dart`.
+- `web_helpers.dart`:
   - Added event extensions for `WebSocket`
+- Add an example.
 
 ## 0.4.0
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -2,9 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 void main() {
   final div = document.querySelector('div') as HTMLDivElement;
-  div.text = 'Text set at ${DateTime.now()}';
+  div.textContent = 'Text set at ${DateTime.now()}';
 }

--- a/lib/src/helpers/events/streams.dart
+++ b/lib/src/helpers/events/streams.dart
@@ -5,8 +5,8 @@
 import 'dart:async';
 import 'dart:js_interop';
 
-import '../../../helpers.dart' show Device;
 import '../../../web.dart' as html;
+import '../../../web_helpers.dart' show Device;
 
 /// Helper class used to create streams abstracting DOM events. This is a
 /// piece of the helper layer directly derived from a similar feature in

--- a/lib/web_helpers.dart
+++ b/lib/web_helpers.dart
@@ -35,7 +35,6 @@ export 'src/helpers/extensions.dart';
 export 'src/helpers/http.dart';
 export 'src/helpers/lists.dart';
 export 'src/helpers/renames.dart';
-export 'web.dart';
 
 HTMLElement createElementTag(String s) =>
     document.createElement(s) as HTMLElement;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: web
 description: Lightweight browser API bindings built around JS static interop.
-version: 0.4.1-wip
+version: 0.5.0-wip
 
 repository: https://github.com/dart-lang/web
 

--- a/test/helpers_test.dart
+++ b/test/helpers_test.dart
@@ -8,7 +8,7 @@ library;
 import 'dart:js_interop';
 
 import 'package:test/test.dart';
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 void main() {
   test('instanceOfString works with package:web types', () {


### PR DESCRIPTION
- rename `helpers.dart` to `web_helpers.dart`
- no longer export `web.dart` from `web_helpers.dart`
- fix https://github.com/dart-lang/web/issues/98

@srujzs, @kevmoo - thoughts?

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
