### PR TITLE
fixes to the return types of several Node helper extension methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Add an example.
 - `src/helpers.dart`:
   - Added event extensions for `WebSocket`
+  - Fixes to the return types of the `append()` and `clone()` extension methods
+    on `Node`.
 
 ## 0.4.0
 

--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -9,6 +9,7 @@
 /// to have from `dart:html`.
 ///
 /// This helper layer serves two purposes:
+///
 ///   * provide useful functionality in environments where `dart:html` is not
 ///     available (like on Wasm).
 ///   * help bridge the gap in functionality from the past, which may reduce

--- a/lib/src/helpers/extensions.dart
+++ b/lib/src/helpers/extensions.dart
@@ -7,6 +7,7 @@
 ///
 /// The extensions here are added by hand over time, depending on needs and use
 /// cases. They currently consist of:
+///
 ///  * renames: methods that provide the same functionality, but use a more
 ///    idiomatic Dart name. Typically these renames match the names used in
 ///    `dart:html` in the past.
@@ -66,8 +67,8 @@ extension CanvasRenderingContext2DGlue on CanvasRenderingContext2D {
 
 extension NodeGlue on Node {
   set text(String s) => textContent = s;
-  void append(Node other) => appendChild(other);
-  void clone(bool deep) => cloneNode(deep);
+  Node append(Node other) => appendChild(other);
+  Node clone(bool? deep) => deep == null ? cloneNode() : cloneNode(deep);
 }
 
 extension EventGlue on MouseEvent {


### PR DESCRIPTION
- fixes to the return types of several Node helper extension methods

When trying to port DartPad to package:web, I noticed that the `Node.clone()` extension method had a return type of `void`, which made it hard to use. This PR updates `clone` and `append` to have the same signatures as they have in `dart:html`.

As an aside, when using code completion for a Node element, I see completions for both `append` and `appendChild`, and `clone` and `cloneNode`. Two are from extension methods and two are generated. It's not clear to me as a user which methods I should be using, what the differences are, or why there are multiple options. Perhaps we should plan to deprecate the extension methods which are just there to ease porting from dart:html? Where there are trivially the same generated methods available, and the extension methods don't add any usability improvements?

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
