### PR TITLE
rev to 0.4.1 in preparation for publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.1-wip
+## 0.4.1
 
 - Exported the helper libraries from `web.dart`.
 - Deprecated the `helpers.dart` library in favor of `web.dart`.
@@ -9,7 +9,7 @@
   `Node`.
 - Deprecated `NodeGlue.append` in favor of `Node.appendChild`.
 - Deprecated `NodeGlue.clone` in favor of `Node.cloneNode`.
-- Updated to `@webref/css` `6.10.0`.
+- Updated `@webref/css` to `6.10.0`.
 
 ## 0.4.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,6 @@
 name: web
+version: 0.4.1
 description: Lightweight browser API bindings built around JS static interop.
-version: 0.4.1-wip
-
 repository: https://github.com/dart-lang/web
 
 environment:


### PR DESCRIPTION
- rev to 0.4.1 in preparation for publishing

From the changelog, the only deprecation that users are likely to see is "Deprecated the `helpers.dart` library in favor of `web.dart`". If we wanted to reduce the impact of this version on people's CIs, we could un-deprecate `helpers.dart`, continue to prefer importing `web.dart` in docs and such - and wait until a future 0.5.0 release to deprecate the helpers.dart import.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
