### PR TITLE
Undeprecate some APIs and prepare for publish of 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.2
+
+- Undeprecate some APIs and helpers library that were deprecated in 0.4.1.
+  Because deprecations are breaking in Flutter, they should be done in a
+  breaking change.
+
 ## 0.4.1
 
 - Exported the helper libraries from `web.dart`.

--- a/lib/helpers.dart
+++ b/lib/helpers.dart
@@ -2,7 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@Deprecated('See instead package:web/web.dart.')
-library;
+// TODO(srujzs): Deprecate in 0.5.0 instead. This results in failures in Flutter
+// CI.
+// @Deprecated('See instead package:web/web.dart.')
+// library;
 
 export 'web.dart';

--- a/lib/src/helpers/extensions.dart
+++ b/lib/src/helpers/extensions.dart
@@ -67,9 +67,13 @@ extension CanvasRenderingContext2DGlue on CanvasRenderingContext2D {
 
 extension NodeGlue on Node {
   set text(String s) => textContent = s;
-  @Deprecated('See Node.appendChild()')
+  // TODO(srujzs): Deprecate in 0.5.0 instead. Deprecations are breaking for
+  // Flutter CI.
+  // @Deprecated('See Node.appendChild()')
   Node append(Node other) => appendChild(other);
-  @Deprecated('See Node.cloneNode()')
+  // TODO(srujzs): Deprecate in 0.5.0 instead. Deprecations are breaking for
+  // Flutter CI.
+  // @Deprecated('See Node.cloneNode()')
   Node clone(bool? deep) => cloneNode(deep ?? false);
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: web
-version: 0.4.1
+version: 0.4.2
 description: Lightweight browser API bindings built around JS static interop.
 repository: https://github.com/dart-lang/web
 


### PR DESCRIPTION
These deprecations are breaking for Flutter CI. Let's do them in a breaking change version instead.