### PR TITLE
Redeprecate deprecated APIs in 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 0.5.0-wip
+
+- Redeprecate APIs that were deprecated in `0.4.1` but undeprecated in `0.4.2`.
+
 ## 0.4.2
 
-- Undeprecate some APIs and helpers library that were deprecated in 0.4.1.
+- Undeprecate some APIs and helpers library that were deprecated in `0.4.1`.
   Because deprecations are breaking in Flutter, they should be done in a
   breaking change.
 

--- a/lib/helpers.dart
+++ b/lib/helpers.dart
@@ -2,9 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// TODO(srujzs): Deprecate in 0.5.0 instead. This results in failures in Flutter
-// CI.
-// @Deprecated('See instead package:web/web.dart.')
-// library;
+@Deprecated('See instead package:web/web.dart.')
+library;
 
 export 'web.dart';

--- a/lib/src/helpers/extensions.dart
+++ b/lib/src/helpers/extensions.dart
@@ -67,13 +67,9 @@ extension CanvasRenderingContext2DGlue on CanvasRenderingContext2D {
 
 extension NodeGlue on Node {
   set text(String s) => textContent = s;
-  // TODO(srujzs): Deprecate in 0.5.0 instead. Deprecations are breaking for
-  // Flutter CI.
-  // @Deprecated('See Node.appendChild()')
+  @Deprecated('See Node.appendChild()')
   Node append(Node other) => appendChild(other);
-  // TODO(srujzs): Deprecate in 0.5.0 instead. Deprecations are breaking for
-  // Flutter CI.
-  // @Deprecated('See Node.cloneNode()')
+  @Deprecated('See Node.cloneNode()')
   Node clone(bool? deep) => cloneNode(deep ?? false);
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: web
-version: 0.4.2
+version: 0.5.0-wip
 description: Lightweight browser API bindings built around JS static interop.
 repository: https://github.com/dart-lang/web
 


### PR DESCRIPTION
Moves us to `0.5.0-wip` as well.