### PR TITLE
Add generics to JSArrays and JSPromises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Contribute a markdown file for the renamed classes from `dart:html` to
   `package:web` (see [renames.md](tool/renames.md)).
 - Migrate classes to use interop extension types that implement `JSObject`.
+- Add generics to APIs that use `JSArray` and `JSPromise`. Typedefs of a Dart
+  primitive type are instead replaced with their JS type equivalent if they
+  appear as a type parameter in order to conform with the type bounds of
+  `JSArray` and `JSPromise`.
 
 ## 0.4.2
 

--- a/lib/src/dom/anchors.dart
+++ b/lib/src/dom/anchors.dart
@@ -9,7 +9,7 @@ import 'dart:js_interop';
 import 'webxr.dart';
 
 extension type XRAnchor._(JSObject _) implements JSObject {
-  external JSPromise requestPersistentHandle();
+  external JSPromise<JSString> requestPersistentHandle();
   external void delete();
   external XRSpace get anchorSpace;
 }

--- a/lib/src/dom/background_fetch.dart
+++ b/lib/src/dom/background_fetch.dart
@@ -9,27 +9,28 @@ import 'dart:js_interop';
 import 'dom.dart';
 import 'fetch.dart';
 import 'html.dart';
+import 'image_resource.dart';
 import 'service_workers.dart';
 
 typedef BackgroundFetchResult = String;
 typedef BackgroundFetchFailureReason = String;
 extension type BackgroundFetchManager._(JSObject _) implements JSObject {
-  external JSPromise fetch(
+  external JSPromise<BackgroundFetchRegistration> fetch(
     String id,
     JSAny requests, [
     BackgroundFetchOptions options,
   ]);
-  external JSPromise get(String id);
-  external JSPromise getIds();
+  external JSPromise<BackgroundFetchRegistration?> get(String id);
+  external JSPromise<JSArray<JSString>> getIds();
 }
 extension type BackgroundFetchUIOptions._(JSObject _) implements JSObject {
   external factory BackgroundFetchUIOptions({
-    JSArray icons,
+    JSArray<ImageResource> icons,
     String title,
   });
 
-  external set icons(JSArray value);
-  external JSArray get icons;
+  external set icons(JSArray<ImageResource> value);
+  external JSArray<ImageResource> get icons;
   external set title(String value);
   external String get title;
 }
@@ -42,12 +43,12 @@ extension type BackgroundFetchOptions._(JSObject _)
 }
 extension type BackgroundFetchRegistration._(JSObject _)
     implements EventTarget, JSObject {
-  external JSPromise abort();
-  external JSPromise match(
+  external JSPromise<JSBoolean> abort();
+  external JSPromise<BackgroundFetchRecord> match(
     RequestInfo request, [
     CacheQueryOptions options,
   ]);
-  external JSPromise matchAll([
+  external JSPromise<JSArray<BackgroundFetchRecord>> matchAll([
     RequestInfo request,
     CacheQueryOptions options,
   ]);
@@ -64,7 +65,7 @@ extension type BackgroundFetchRegistration._(JSObject _)
 }
 extension type BackgroundFetchRecord._(JSObject _) implements JSObject {
   external Request get request;
-  external JSPromise get responseReady;
+  external JSPromise<Response> get responseReady;
 }
 extension type BackgroundFetchEvent._(JSObject _)
     implements ExtendableEvent, JSObject {
@@ -90,5 +91,5 @@ extension type BackgroundFetchUpdateUIEvent._(JSObject _)
     BackgroundFetchEventInit init,
   );
 
-  external JSPromise updateUI([BackgroundFetchUIOptions options]);
+  external JSPromise<JSAny?> updateUI([BackgroundFetchUIOptions options]);
 }

--- a/lib/src/dom/background_sync.dart
+++ b/lib/src/dom/background_sync.dart
@@ -9,8 +9,8 @@ import 'dart:js_interop';
 import 'service_workers.dart';
 
 extension type SyncManager._(JSObject _) implements JSObject {
-  external JSPromise register(String tag);
-  external JSPromise getTags();
+  external JSPromise<JSAny?> register(String tag);
+  external JSPromise<JSArray<JSString>> getTags();
 }
 extension type SyncEvent._(JSObject _) implements ExtendableEvent, JSObject {
   external factory SyncEvent(

--- a/lib/src/dom/capture_handle_identity.dart
+++ b/lib/src/dom/capture_handle_identity.dart
@@ -10,15 +10,15 @@ extension type CaptureHandleConfig._(JSObject _) implements JSObject {
   external factory CaptureHandleConfig({
     bool exposeOrigin,
     String handle,
-    JSArray permittedOrigins,
+    JSArray<JSString> permittedOrigins,
   });
 
   external set exposeOrigin(bool value);
   external bool get exposeOrigin;
   external set handle(String value);
   external String get handle;
-  external set permittedOrigins(JSArray value);
-  external JSArray get permittedOrigins;
+  external set permittedOrigins(JSArray<JSString> value);
+  external JSArray<JSString> get permittedOrigins;
 }
 extension type CaptureHandle._(JSObject _) implements JSObject {
   external factory CaptureHandle({

--- a/lib/src/dom/clipboard_apis.dart
+++ b/lib/src/dom/clipboard_apis.dart
@@ -7,11 +7,12 @@
 import 'dart:js_interop';
 
 import 'dom.dart';
+import 'fileapi.dart';
 import 'html.dart';
 import 'permissions.dart';
 
-typedef ClipboardItemData = JSPromise;
-typedef ClipboardItems = JSArray;
+typedef ClipboardItemData = JSPromise<JSAny>;
+typedef ClipboardItems = JSArray<ClipboardItem>;
 typedef PresentationStyle = String;
 extension type ClipboardEventInit._(JSObject _) implements EventInit, JSObject {
   external factory ClipboardEventInit({DataTransfer? clipboardData});
@@ -34,9 +35,9 @@ extension type ClipboardItem._(JSObject _) implements JSObject {
   ]);
 
   external static bool supports(String type);
-  external JSPromise getType(String type);
+  external JSPromise<Blob> getType(String type);
   external PresentationStyle get presentationStyle;
-  external JSArray get types;
+  external JSArray<JSString> get types;
 }
 extension type ClipboardItemOptions._(JSObject _) implements JSObject {
   external factory ClipboardItemOptions({PresentationStyle presentationStyle});
@@ -45,10 +46,10 @@ extension type ClipboardItemOptions._(JSObject _) implements JSObject {
   external PresentationStyle get presentationStyle;
 }
 extension type Clipboard._(JSObject _) implements EventTarget, JSObject {
-  external JSPromise read();
-  external JSPromise readText();
-  external JSPromise write(ClipboardItems data);
-  external JSPromise writeText(String data);
+  external JSPromise<ClipboardItems> read();
+  external JSPromise<JSString> readText();
+  external JSPromise<JSAny?> write(ClipboardItems data);
+  external JSPromise<JSAny?> writeText(String data);
 }
 extension type ClipboardPermissionDescriptor._(JSObject _)
     implements PermissionDescriptor, JSObject {

--- a/lib/src/dom/compute_pressure.dart
+++ b/lib/src/dom/compute_pressure.dart
@@ -17,11 +17,11 @@ extension type PressureObserver._(JSObject _) implements JSObject {
     PressureObserverOptions options,
   ]);
 
-  external static JSArray get supportedSources;
-  external JSPromise observe(PressureSource source);
+  external static JSArray<JSString> get supportedSources;
+  external JSPromise<JSAny?> observe(PressureSource source);
   external void unobserve(PressureSource source);
   external void disconnect();
-  external JSArray takeRecords();
+  external JSArray<PressureRecord> takeRecords();
 }
 extension type PressureRecord._(JSObject _) implements JSObject {
   external JSObject toJSON();

--- a/lib/src/dom/console.dart
+++ b/lib/src/dom/console.dart
@@ -22,7 +22,7 @@ extension type $Console._(JSObject _) implements JSObject {
   external void log(JSAny? data);
   external void table([
     JSAny? tabularData,
-    JSArray properties,
+    JSArray<JSString> properties,
   ]);
   external void trace(JSAny? data);
   external void warn(JSAny? data);

--- a/lib/src/dom/contact_picker.dart
+++ b/lib/src/dom/contact_picker.dart
@@ -6,6 +6,8 @@
 
 import 'dart:js_interop';
 
+import 'fileapi.dart';
+
 typedef ContactProperty = String;
 extension type ContactAddress._(JSObject _) implements JSObject {
   external JSObject toJSON();
@@ -18,27 +20,27 @@ extension type ContactAddress._(JSObject _) implements JSObject {
   external String get recipient;
   external String get region;
   external String get sortingCode;
-  external JSArray get addressLine;
+  external JSArray<JSString> get addressLine;
 }
 extension type ContactInfo._(JSObject _) implements JSObject {
   external factory ContactInfo({
-    JSArray address,
-    JSArray email,
-    JSArray icon,
-    JSArray name,
-    JSArray tel,
+    JSArray<ContactAddress> address,
+    JSArray<JSString> email,
+    JSArray<Blob> icon,
+    JSArray<JSString> name,
+    JSArray<JSString> tel,
   });
 
-  external set address(JSArray value);
-  external JSArray get address;
-  external set email(JSArray value);
-  external JSArray get email;
-  external set icon(JSArray value);
-  external JSArray get icon;
-  external set name(JSArray value);
-  external JSArray get name;
-  external set tel(JSArray value);
-  external JSArray get tel;
+  external set address(JSArray<ContactAddress> value);
+  external JSArray<ContactAddress> get address;
+  external set email(JSArray<JSString> value);
+  external JSArray<JSString> get email;
+  external set icon(JSArray<Blob> value);
+  external JSArray<Blob> get icon;
+  external set name(JSArray<JSString> value);
+  external JSArray<JSString> get name;
+  external set tel(JSArray<JSString> value);
+  external JSArray<JSString> get tel;
 }
 extension type ContactsSelectOptions._(JSObject _) implements JSObject {
   external factory ContactsSelectOptions({bool multiple});
@@ -47,9 +49,9 @@ extension type ContactsSelectOptions._(JSObject _) implements JSObject {
   external bool get multiple;
 }
 extension type ContactsManager._(JSObject _) implements JSObject {
-  external JSPromise getProperties();
-  external JSPromise select(
-    JSArray properties, [
+  external JSPromise<JSArray<JSString>> getProperties();
+  external JSPromise<JSArray<ContactInfo>> select(
+    JSArray<JSString> properties, [
     ContactsSelectOptions options,
   ]);
 }

--- a/lib/src/dom/content_index.dart
+++ b/lib/src/dom/content_index.dart
@@ -6,6 +6,7 @@
 
 import 'dart:js_interop';
 
+import 'image_resource.dart';
 import 'service_workers.dart';
 
 typedef ContentCategory = String;
@@ -15,7 +16,7 @@ extension type ContentDescription._(JSObject _) implements JSObject {
     required String title,
     required String description,
     ContentCategory category,
-    JSArray icons,
+    JSArray<ImageResource> icons,
     required String url,
   });
 
@@ -27,15 +28,15 @@ extension type ContentDescription._(JSObject _) implements JSObject {
   external String get description;
   external set category(ContentCategory value);
   external ContentCategory get category;
-  external set icons(JSArray value);
-  external JSArray get icons;
+  external set icons(JSArray<ImageResource> value);
+  external JSArray<ImageResource> get icons;
   external set url(String value);
   external String get url;
 }
 extension type ContentIndex._(JSObject _) implements JSObject {
-  external JSPromise add(ContentDescription description);
-  external JSPromise delete(String id);
-  external JSPromise getAll();
+  external JSPromise<JSAny?> add(ContentDescription description);
+  external JSPromise<JSAny?> delete(String id);
+  external JSPromise<JSArray<ContentDescription>> getAll();
 }
 extension type ContentIndexEventInit._(JSObject _)
     implements ExtendableEventInit, JSObject {

--- a/lib/src/dom/cookie_store.dart
+++ b/lib/src/dom/cookie_store.dart
@@ -11,16 +11,16 @@ import 'hr_time.dart';
 import 'html.dart';
 import 'service_workers.dart';
 
-typedef CookieList = JSArray;
+typedef CookieList = JSArray<CookieListItem>;
 typedef CookieSameSite = String;
 extension type CookieStore._(JSObject _) implements EventTarget, JSObject {
-  external JSPromise get([JSAny nameOrOptions]);
-  external JSPromise getAll([JSAny nameOrOptions]);
-  external JSPromise set(
+  external JSPromise<CookieListItem?> get([JSAny nameOrOptions]);
+  external JSPromise<CookieList> getAll([JSAny nameOrOptions]);
+  external JSPromise<JSAny?> set(
     JSAny nameOrOptions, [
     String value,
   ]);
-  external JSPromise delete(JSAny nameOrOptions);
+  external JSPromise<JSAny?> delete(JSAny nameOrOptions);
   external set onchange(EventHandler value);
   external EventHandler get onchange;
 }
@@ -108,9 +108,11 @@ extension type CookieListItem._(JSObject _) implements JSObject {
   external bool get partitioned;
 }
 extension type CookieStoreManager._(JSObject _) implements JSObject {
-  external JSPromise subscribe(JSArray subscriptions);
-  external JSPromise getSubscriptions();
-  external JSPromise unsubscribe(JSArray subscriptions);
+  external JSPromise<JSAny?> subscribe(
+      JSArray<CookieStoreGetOptions> subscriptions);
+  external JSPromise<JSArray<CookieStoreGetOptions>> getSubscriptions();
+  external JSPromise<JSAny?> unsubscribe(
+      JSArray<CookieStoreGetOptions> subscriptions);
 }
 extension type CookieChangeEvent._(JSObject _) implements Event, JSObject {
   external factory CookieChangeEvent(
@@ -118,8 +120,8 @@ extension type CookieChangeEvent._(JSObject _) implements Event, JSObject {
     CookieChangeEventInit eventInitDict,
   ]);
 
-  external JSArray get changed;
-  external JSArray get deleted;
+  external JSArray<CookieListItem> get changed;
+  external JSArray<CookieListItem> get deleted;
 }
 extension type CookieChangeEventInit._(JSObject _)
     implements EventInit, JSObject {
@@ -140,8 +142,8 @@ extension type ExtendableCookieChangeEvent._(JSObject _)
     ExtendableCookieChangeEventInit eventInitDict,
   ]);
 
-  external JSArray get changed;
-  external JSArray get deleted;
+  external JSArray<CookieListItem> get changed;
+  external JSArray<CookieListItem> get deleted;
 }
 extension type ExtendableCookieChangeEventInit._(JSObject _)
     implements ExtendableEventInit, JSObject {

--- a/lib/src/dom/credential_management.dart
+++ b/lib/src/dom/credential_management.dart
@@ -14,15 +14,15 @@ import 'webauthn.dart';
 typedef PasswordCredentialInit = JSObject;
 typedef CredentialMediationRequirement = String;
 extension type Credential._(JSObject _) implements JSObject {
-  external static JSPromise isConditionalMediationAvailable();
+  external static JSPromise<JSBoolean> isConditionalMediationAvailable();
   external String get id;
   external String get type;
 }
 extension type CredentialsContainer._(JSObject _) implements JSObject {
-  external JSPromise get([CredentialRequestOptions options]);
-  external JSPromise store(Credential credential);
-  external JSPromise create([CredentialCreationOptions options]);
-  external JSPromise preventSilentAccess();
+  external JSPromise<Credential?> get([CredentialRequestOptions options]);
+  external JSPromise<JSAny?> store(Credential credential);
+  external JSPromise<Credential?> create([CredentialCreationOptions options]);
+  external JSPromise<JSAny?> preventSilentAccess();
 }
 extension type CredentialData._(JSObject _) implements JSObject {
   external factory CredentialData({required String id});
@@ -111,14 +111,14 @@ extension type FederatedCredential._(JSObject _)
 extension type FederatedCredentialRequestOptions._(JSObject _)
     implements JSObject {
   external factory FederatedCredentialRequestOptions({
-    JSArray providers,
-    JSArray protocols,
+    JSArray<JSString> providers,
+    JSArray<JSString> protocols,
   });
 
-  external set providers(JSArray value);
-  external JSArray get providers;
-  external set protocols(JSArray value);
-  external JSArray get protocols;
+  external set providers(JSArray<JSString> value);
+  external JSArray<JSString> get providers;
+  external set protocols(JSArray<JSString> value);
+  external JSArray<JSString> get protocols;
 }
 extension type FederatedCredentialInit._(JSObject _)
     implements CredentialData, JSObject {

--- a/lib/src/dom/css_animation_worklet.dart
+++ b/lib/src/dom/css_animation_worklet.dart
@@ -34,5 +34,5 @@ extension type WorkletAnimation._(JSObject _) implements Animation, JSObject {
   external String get animatorName;
 }
 extension type WorkletGroupEffect._(JSObject _) implements JSObject {
-  external JSArray getChildren();
+  external JSArray<WorkletAnimationEffect> getChildren();
 }

--- a/lib/src/dom/css_cascade.dart
+++ b/lib/src/dom/css_cascade.dart
@@ -14,5 +14,5 @@ extension type CSSLayerBlockRule._(JSObject _)
 }
 extension type CSSLayerStatementRule._(JSObject _)
     implements CSSRule, JSObject {
-  external JSArray get nameList;
+  external JSArray<JSString> get nameList;
 }

--- a/lib/src/dom/css_font_loading.dart
+++ b/lib/src/dom/css_font_loading.dart
@@ -54,7 +54,7 @@ extension type FontFace._(JSObject _) implements JSObject {
     FontFaceDescriptors descriptors,
   ]);
 
-  external JSPromise load();
+  external JSPromise<FontFace> load();
   external set family(String value);
   external String get family;
   external set style(String value);
@@ -78,7 +78,7 @@ extension type FontFace._(JSObject _) implements JSObject {
   external set lineGapOverride(String value);
   external String get lineGapOverride;
   external FontFaceLoadStatus get status;
-  external JSPromise get loaded;
+  external JSPromise<FontFace> get loaded;
   external FontFaceFeatures get features;
   external FontFaceVariations get variations;
   external FontFacePalettes get palettes;
@@ -102,10 +102,10 @@ extension type FontFacePalettes._(JSObject _) implements JSObject {
 }
 extension type FontFaceSetLoadEventInit._(JSObject _)
     implements EventInit, JSObject {
-  external factory FontFaceSetLoadEventInit({JSArray fontfaces});
+  external factory FontFaceSetLoadEventInit({JSArray<FontFace> fontfaces});
 
-  external set fontfaces(JSArray value);
-  external JSArray get fontfaces;
+  external set fontfaces(JSArray<FontFace> value);
+  external JSArray<FontFace> get fontfaces;
 }
 extension type FontFaceSetLoadEvent._(JSObject _) implements Event, JSObject {
   external factory FontFaceSetLoadEvent(
@@ -113,15 +113,15 @@ extension type FontFaceSetLoadEvent._(JSObject _) implements Event, JSObject {
     FontFaceSetLoadEventInit eventInitDict,
   ]);
 
-  external JSArray get fontfaces;
+  external JSArray<FontFace> get fontfaces;
 }
 extension type FontFaceSet._(JSObject _) implements EventTarget, JSObject {
-  external factory FontFaceSet(JSArray initialFaces);
+  external factory FontFaceSet(JSArray<FontFace> initialFaces);
 
   external FontFaceSet add(FontFace font);
   external bool delete(FontFace font);
   external void clear();
-  external JSPromise load(
+  external JSPromise<JSArray<FontFace>> load(
     String font, [
     String text,
   ]);
@@ -135,6 +135,6 @@ extension type FontFaceSet._(JSObject _) implements EventTarget, JSObject {
   external EventHandler get onloadingdone;
   external set onloadingerror(EventHandler value);
   external EventHandler get onloadingerror;
-  external JSPromise get ready;
+  external JSPromise<FontFaceSet> get ready;
   external FontFaceSetLoadStatus get status;
 }

--- a/lib/src/dom/css_layout_api.dart
+++ b/lib/src/dom/css_layout_api.dart
@@ -33,8 +33,8 @@ extension type LayoutOptions._(JSObject _) implements JSObject {
   external LayoutSizingMode get sizing;
 }
 extension type LayoutChild._(JSObject _) implements JSObject {
-  external JSPromise intrinsicSizes();
-  external JSPromise layoutNextFragment(
+  external JSPromise<IntrinsicSizes> intrinsicSizes();
+  external JSPromise<LayoutFragment> layoutNextFragment(
     LayoutConstraintsOptions constraints,
     ChildBreakToken breakToken,
   );
@@ -102,17 +102,17 @@ extension type ChildBreakToken._(JSObject _) implements JSObject {
   external LayoutChild get child;
 }
 extension type BreakToken._(JSObject _) implements JSObject {
-  external JSArray get childBreakTokens;
+  external JSArray<ChildBreakToken> get childBreakTokens;
   external JSAny? get data;
 }
 extension type BreakTokenOptions._(JSObject _) implements JSObject {
   external factory BreakTokenOptions({
-    JSArray childBreakTokens,
+    JSArray<ChildBreakToken> childBreakTokens,
     JSAny? data,
   });
 
-  external set childBreakTokens(JSArray value);
-  external JSArray get childBreakTokens;
+  external set childBreakTokens(JSArray<ChildBreakToken> value);
+  external JSArray<ChildBreakToken> get childBreakTokens;
   external set data(JSAny? value);
   external JSAny? get data;
 }
@@ -129,7 +129,7 @@ extension type FragmentResultOptions._(JSObject _) implements JSObject {
     num inlineSize,
     num blockSize,
     num autoBlockSize,
-    JSArray childFragments,
+    JSArray<LayoutFragment> childFragments,
     JSAny? data,
     BreakTokenOptions breakToken,
   });
@@ -140,8 +140,8 @@ extension type FragmentResultOptions._(JSObject _) implements JSObject {
   external num get blockSize;
   external set autoBlockSize(num value);
   external num get autoBlockSize;
-  external set childFragments(JSArray value);
-  external JSArray get childFragments;
+  external set childFragments(JSArray<LayoutFragment> value);
+  external JSArray<LayoutFragment> get childFragments;
   external set data(JSAny? value);
   external JSAny? get data;
   external set breakToken(BreakTokenOptions value);

--- a/lib/src/dom/css_nav.dart
+++ b/lib/src/dom/css_nav.dart
@@ -20,12 +20,12 @@ extension type FocusableAreasOption._(JSObject _) implements JSObject {
 extension type SpatialNavigationSearchOptions._(JSObject _)
     implements JSObject {
   external factory SpatialNavigationSearchOptions({
-    JSArray? candidates,
+    JSArray<Node>? candidates,
     Node? container,
   });
 
-  external set candidates(JSArray? value);
-  external JSArray? get candidates;
+  external set candidates(JSArray<Node>? value);
+  external JSArray<Node>? get candidates;
   external set container(Node? value);
   external Node? get container;
 }

--- a/lib/src/dom/css_paint_api.dart
+++ b/lib/src/dom/css_paint_api.dart
@@ -130,8 +130,8 @@ extension type PaintRenderingContext2D._(JSObject _) implements JSObject {
     num dw,
     num dh,
   ]);
-  external void setLineDash(JSArray segments);
-  external JSArray getLineDash();
+  external void setLineDash(JSArray<JSNumber> segments);
+  external JSArray<JSNumber> getLineDash();
   external void closePath();
   external void moveTo(
     num x,

--- a/lib/src/dom/css_parser_api.dart
+++ b/lib/src/dom/css_parser_api.dart
@@ -19,52 +19,52 @@ extension type CSSParserAtRule._(JSObject _)
     implements CSSParserRule, JSObject {
   external factory CSSParserAtRule(
     String name,
-    JSArray prelude, [
-    JSArray? body,
+    JSArray<CSSToken> prelude, [
+    JSArray<CSSParserRule>? body,
   ]);
 
   external String get name;
-  external JSArray get prelude;
-  external JSArray? get body;
+  external JSArray<CSSParserValue> get prelude;
+  external JSArray<CSSParserRule>? get body;
 }
 extension type CSSParserQualifiedRule._(JSObject _)
     implements CSSParserRule, JSObject {
   external factory CSSParserQualifiedRule(
-    JSArray prelude, [
-    JSArray? body,
+    JSArray<CSSToken> prelude, [
+    JSArray<CSSParserRule>? body,
   ]);
 
-  external JSArray get prelude;
-  external JSArray get body;
+  external JSArray<CSSParserValue> get prelude;
+  external JSArray<CSSParserRule> get body;
 }
 extension type CSSParserDeclaration._(JSObject _)
     implements CSSParserRule, JSObject {
   external factory CSSParserDeclaration(
     String name, [
-    JSArray body,
+    JSArray<CSSParserRule> body,
   ]);
 
   external String get name;
-  external JSArray get body;
+  external JSArray<CSSParserValue> get body;
 }
 extension type CSSParserValue._(JSObject _) implements JSObject {}
 extension type CSSParserBlock._(JSObject _)
     implements CSSParserValue, JSObject {
   external factory CSSParserBlock(
     String name,
-    JSArray body,
+    JSArray<CSSParserValue> body,
   );
 
   external String get name;
-  external JSArray get body;
+  external JSArray<CSSParserValue> get body;
 }
 extension type CSSParserFunction._(JSObject _)
     implements CSSParserValue, JSObject {
   external factory CSSParserFunction(
     String name,
-    JSArray args,
+    JSArray<JSArray<CSSParserValue>> args,
   );
 
   external String get name;
-  external JSArray get args;
+  external JSArray<JSArray<CSSParserValue>> get args;
 }

--- a/lib/src/dom/css_pseudo.dart
+++ b/lib/src/dom/css_pseudo.dart
@@ -12,7 +12,7 @@ import 'geometry.dart';
 
 extension type CSSPseudoElement._(JSObject _) implements EventTarget, JSObject {
   external CSSPseudoElement? pseudo(String type);
-  external JSArray getBoxQuads([BoxQuadOptions options]);
+  external JSArray<DOMQuad> getBoxQuads([BoxQuadOptions options]);
   external DOMQuad convertQuadFromNode(
     DOMQuadInit quad,
     GeometryNode from, [

--- a/lib/src/dom/css_regions.dart
+++ b/lib/src/dom/css_regions.dart
@@ -10,9 +10,9 @@ import 'dom.dart';
 
 extension type NamedFlowMap._(JSObject _) implements JSObject {}
 extension type NamedFlow._(JSObject _) implements EventTarget, JSObject {
-  external JSArray getRegions();
-  external JSArray getContent();
-  external JSArray getRegionsByContent(Node node);
+  external JSArray<Element> getRegions();
+  external JSArray<Node> getContent();
+  external JSArray<Element> getRegionsByContent(Node node);
   external String get name;
   external bool get overset;
   external int get firstEmptyRegionIndex;

--- a/lib/src/dom/css_typed_om.dart
+++ b/lib/src/dom/css_typed_om.dart
@@ -23,14 +23,14 @@ extension type CSSStyleValue._(JSObject _) implements JSObject {
     String property,
     String cssText,
   );
-  external static JSArray parseAll(
+  external static JSArray<CSSStyleValue> parseAll(
     String property,
     String cssText,
   );
 }
 extension type StylePropertyMapReadOnly._(JSObject _) implements JSObject {
   external CSSStyleValue? get(String property);
-  external JSArray getAll(String property);
+  external JSArray<CSSStyleValue> getAll(String property);
   external bool has(String property);
   external int get size;
 }
@@ -49,7 +49,7 @@ extension type StylePropertyMap._(JSObject _)
 }
 extension type CSSUnparsedValue._(JSObject _)
     implements CSSStyleValue, JSObject {
-  external factory CSSUnparsedValue(JSArray members);
+  external factory CSSUnparsedValue(JSArray<CSSUnparsedSegment> members);
 
   external int get length;
 }
@@ -172,7 +172,7 @@ extension type CSSNumericArray._(JSObject _) implements JSObject {
 }
 extension type CSSTransformValue._(JSObject _)
     implements CSSStyleValue, JSObject {
-  external factory CSSTransformValue(JSArray transforms);
+  external factory CSSTransformValue(JSArray<CSSTransformComponent> transforms);
 
   external DOMMatrix toMatrix();
   external int get length;
@@ -406,14 +406,14 @@ extension type CSSOKLCH._(JSObject _) implements CSSColorValue, JSObject {
 extension type CSSColor._(JSObject _) implements CSSColorValue, JSObject {
   external factory CSSColor(
     CSSKeywordish colorSpace,
-    JSArray channels, [
+    JSArray<CSSColorPercent> channels, [
     CSSNumberish alpha,
   ]);
 
   external set colorSpace(CSSKeywordish value);
   external CSSKeywordish get colorSpace;
-  external set channels(JSArray value);
-  external JSArray get channels;
+  external set channels(JSArray<CSSColorPercent> value);
+  external JSArray<CSSColorPercent> get channels;
   external set alpha(CSSNumberish value);
   external CSSNumberish get alpha;
 }

--- a/lib/src/dom/css_view_transitions.dart
+++ b/lib/src/dom/css_view_transitions.dart
@@ -9,7 +9,7 @@ import 'dart:js_interop';
 typedef UpdateCallback = JSFunction;
 extension type ViewTransition._(JSObject _) implements JSObject {
   external void skipTransition();
-  external JSPromise get updateCallbackDone;
-  external JSPromise get ready;
-  external JSPromise get finished;
+  external JSPromise<JSAny?> get updateCallbackDone;
+  external JSPromise<JSAny?> get ready;
+  external JSPromise<JSAny?> get finished;
 }

--- a/lib/src/dom/cssom.dart
+++ b/lib/src/dom/cssom.dart
@@ -38,7 +38,7 @@ extension type CSSStyleSheet._(JSObject _) implements StyleSheet, JSObject {
     int index,
   ]);
   external void deleteRule(int index);
-  external JSPromise replace(String text);
+  external JSPromise<CSSStyleSheet> replace(String text);
   external void replaceSync(String text);
   external int addRule([
     String selector,
@@ -1409,19 +1409,19 @@ extension type $CSS._(JSObject _) implements JSObject {
     String conditionTextOrProperty, [
     String value,
   ]);
-  external JSPromise parseStylesheet(
+  external JSPromise<JSArray<CSSParserRule>> parseStylesheet(
     CSSStringSource css, [
     CSSParserOptions options,
   ]);
-  external JSPromise parseRuleList(
+  external JSPromise<JSArray<CSSParserRule>> parseRuleList(
     CSSStringSource css, [
     CSSParserOptions options,
   ]);
-  external JSPromise parseRule(
+  external JSPromise<CSSParserRule> parseRule(
     CSSStringSource css, [
     CSSParserOptions options,
   ]);
-  external JSPromise parseDeclarationList(
+  external JSPromise<JSArray<CSSParserRule>> parseDeclarationList(
     CSSStringSource css, [
     CSSParserOptions options,
   ]);
@@ -1430,8 +1430,8 @@ extension type $CSS._(JSObject _) implements JSObject {
     CSSParserOptions options,
   ]);
   external CSSToken parseValue(String css);
-  external JSArray parseValueList(String css);
-  external JSArray parseCommaValueList(String css);
+  external JSArray<CSSToken> parseValueList(String css);
+  external JSArray<JSArray<CSSToken>> parseCommaValueList(String css);
   external void registerProperty(PropertyDefinition definition);
   external CSSUnitValue number(num value);
   external CSSUnitValue percent(num value);

--- a/lib/src/dom/digital_goods.dart
+++ b/lib/src/dom/digital_goods.dart
@@ -10,10 +10,11 @@ import 'payment_request.dart';
 
 typedef ItemType = String;
 extension type DigitalGoodsService._(JSObject _) implements JSObject {
-  external JSPromise getDetails(JSArray itemIds);
-  external JSPromise listPurchases();
-  external JSPromise listPurchaseHistory();
-  external JSPromise consume(String purchaseToken);
+  external JSPromise<JSArray<ItemDetails>> getDetails(
+      JSArray<JSString> itemIds);
+  external JSPromise<JSArray<PurchaseDetails>> listPurchases();
+  external JSPromise<JSArray<PurchaseDetails>> listPurchaseHistory();
+  external JSPromise<JSAny?> consume(String purchaseToken);
 }
 extension type ItemDetails._(JSObject _) implements JSObject {
   external factory ItemDetails({
@@ -22,7 +23,7 @@ extension type ItemDetails._(JSObject _) implements JSObject {
     required PaymentCurrencyAmount price,
     ItemType type,
     String description,
-    JSArray iconURLs,
+    JSArray<JSString> iconURLs,
     String subscriptionPeriod,
     String freeTrialPeriod,
     PaymentCurrencyAmount introductoryPrice,
@@ -40,8 +41,8 @@ extension type ItemDetails._(JSObject _) implements JSObject {
   external ItemType get type;
   external set description(String value);
   external String get description;
-  external set iconURLs(JSArray value);
-  external JSArray get iconURLs;
+  external set iconURLs(JSArray<JSString> value);
+  external JSArray<JSString> get iconURLs;
   external set subscriptionPeriod(String value);
   external String get subscriptionPeriod;
   external set freeTrialPeriod(String value);

--- a/lib/src/dom/document_picture_in_picture.dart
+++ b/lib/src/dom/document_picture_in_picture.dart
@@ -11,7 +11,8 @@ import 'html.dart';
 
 extension type DocumentPictureInPicture._(JSObject _)
     implements EventTarget, JSObject {
-  external JSPromise requestWindow([DocumentPictureInPictureOptions options]);
+  external JSPromise<Window> requestWindow(
+      [DocumentPictureInPictureOptions options]);
   external Window get window;
   external set onenter(EventHandler value);
   external EventHandler get onenter;

--- a/lib/src/dom/dom.dart
+++ b/lib/src/dom/dom.dart
@@ -42,7 +42,7 @@ extension type Event._(JSObject _) implements JSObject {
   external static int get CAPTURING_PHASE;
   external static int get AT_TARGET;
   external static int get BUBBLING_PHASE;
-  external JSArray composedPath();
+  external JSArray<EventTarget> composedPath();
   external void stopPropagation();
   external void stopImmediatePropagation();
   external void preventDefault();
@@ -146,7 +146,7 @@ extension type AbortController._(JSObject _) implements JSObject {
 extension type AbortSignal._(JSObject _) implements EventTarget, JSObject {
   external static AbortSignal abort([JSAny? reason]);
   external static AbortSignal timeout(int milliseconds);
-  external static AbortSignal any(JSArray signals);
+  external static AbortSignal any(JSArray<AbortSignal> signals);
   external void throwIfAborted();
   external bool get aborted;
   external JSAny? get reason;
@@ -170,7 +170,7 @@ extension type MutationObserver._(JSObject _) implements JSObject {
     MutationObserverInit options,
   ]);
   external void disconnect();
-  external JSArray takeRecords();
+  external JSArray<MutationRecord> takeRecords();
 }
 extension type MutationObserverInit._(JSObject _) implements JSObject {
   external factory MutationObserverInit({
@@ -180,7 +180,7 @@ extension type MutationObserverInit._(JSObject _) implements JSObject {
     bool subtree,
     bool attributeOldValue,
     bool characterDataOldValue,
-    JSArray attributeFilter,
+    JSArray<JSString> attributeFilter,
   });
 
   external set childList(bool value);
@@ -195,8 +195,8 @@ extension type MutationObserverInit._(JSObject _) implements JSObject {
   external bool get attributeOldValue;
   external set characterDataOldValue(bool value);
   external bool get characterDataOldValue;
-  external set attributeFilter(JSArray value);
-  external JSArray get attributeFilter;
+  external set attributeFilter(JSArray<JSString> value);
+  external JSArray<JSString> get attributeFilter;
 }
 extension type MutationRecord._(JSObject _) implements JSObject {
   external String get type;
@@ -282,7 +282,7 @@ extension type Document._(JSObject _) implements Node, JSObject {
     num x,
     num y,
   );
-  external JSArray elementsFromPoint(
+  external JSArray<Element> elementsFromPoint(
     num x,
     num y,
   );
@@ -340,7 +340,7 @@ extension type Document._(JSObject _) implements Node, JSObject {
     String text,
     StylePropertyMapReadOnly styleMap,
   );
-  external JSPromise exitFullscreen();
+  external JSPromise<JSAny?> exitFullscreen();
   external NodeList getElementsByName(String elementName);
   external JSObject? open([
     String unused1OrUrl,
@@ -364,15 +364,15 @@ extension type Document._(JSObject _) implements Node, JSObject {
   external void clear();
   external void captureEvents();
   external void releaseEvents();
-  external JSPromise exitPictureInPicture();
+  external JSPromise<JSAny?> exitPictureInPicture();
   external void exitPointerLock();
-  external JSPromise requestStorageAccessFor(String requestedOrigin);
+  external JSPromise<JSAny?> requestStorageAccessFor(String requestedOrigin);
   external Selection? getSelection();
-  external JSPromise hasStorageAccess();
-  external JSPromise requestStorageAccess();
-  external JSPromise hasPrivateTokens(String issuer);
-  external JSPromise hasRedemptionRecord(String issuer);
-  external JSArray getBoxQuads([BoxQuadOptions options]);
+  external JSPromise<JSBoolean> hasStorageAccess();
+  external JSPromise<JSAny?> requestStorageAccess();
+  external JSPromise<JSBoolean> hasPrivateTokens(String issuer);
+  external JSPromise<JSBoolean> hasRedemptionRecord(String issuer);
+  external JSArray<DOMQuad> getBoxQuads([BoxQuadOptions options]);
   external DOMQuad convertQuadFromNode(
     DOMQuadInit quad,
     GeometryNode from, [
@@ -389,7 +389,7 @@ extension type Document._(JSObject _) implements Node, JSObject {
     ConvertCoordinateOptions options,
   ]);
   external Element? getElementById(String elementId);
-  external JSArray getAnimations();
+  external JSArray<Animation> getAnimations();
   external void prepend(JSAny nodes);
   external void append(JSAny nodes);
   external void replaceChildren(JSAny nodes);
@@ -488,8 +488,8 @@ extension type Document._(JSObject _) implements Node, JSObject {
   external DocumentTimeline get timeline;
   external FontFaceSet get fonts;
   external StyleSheetList get styleSheets;
-  external set adoptedStyleSheets(JSArray value);
-  external JSArray get adoptedStyleSheets;
+  external set adoptedStyleSheets(JSArray<CSSStyleSheet> value);
+  external JSArray<CSSStyleSheet> get adoptedStyleSheets;
   external Element? get fullscreenElement;
   external Element? get activeElement;
   external Element? get pictureInPictureElement;
@@ -748,7 +748,7 @@ extension type DocumentFragment._(JSObject _) implements Node, JSObject {
   external int get childElementCount;
 }
 extension type ShadowRoot._(JSObject _) implements DocumentFragment, JSObject {
-  external JSArray getAnimations();
+  external JSArray<Animation> getAnimations();
   external ShadowRootMode get mode;
   external bool get delegatesFocus;
   external SlotAssignmentMode get slotAssignment;
@@ -758,8 +758,8 @@ extension type ShadowRoot._(JSObject _) implements DocumentFragment, JSObject {
   external set innerHTML(String value);
   external String get innerHTML;
   external StyleSheetList get styleSheets;
-  external set adoptedStyleSheets(JSArray value);
-  external JSArray get adoptedStyleSheets;
+  external set adoptedStyleSheets(JSArray<CSSStyleSheet> value);
+  external JSArray<CSSStyleSheet> get adoptedStyleSheets;
   external Element? get fullscreenElement;
   external Element? get activeElement;
   external Element? get pictureInPictureElement;
@@ -771,7 +771,7 @@ extension type Element._(JSObject _) implements Node, JSObject {
     String text,
   );
   external Node getSpatialNavigationContainer();
-  external JSArray focusableAreas([FocusableAreasOption option]);
+  external JSArray<Node> focusableAreas([FocusableAreasOption option]);
   external Node? spatialNavigationSearch(
     SpatialNavigationDirection dir, [
     SpatialNavigationSearchOptions options,
@@ -795,7 +795,7 @@ extension type Element._(JSObject _) implements Node, JSObject {
     num y,
   ]);
   external bool hasAttributes();
-  external JSArray getAttributeNames();
+  external JSArray<JSString> getAttributeNames();
   external String? getAttribute(String qualifiedName);
   external String? getAttributeNS(
     String? namespace,
@@ -850,7 +850,7 @@ extension type Element._(JSObject _) implements Node, JSObject {
     String where,
     String data,
   );
-  external JSPromise requestFullscreen([FullscreenOptions options]);
+  external JSPromise<JSAny?> requestFullscreen([FullscreenOptions options]);
   external void setPointerCapture(int pointerId);
   external void releasePointerCapture(int pointerId);
   external bool hasPointerCapture(int pointerId);
@@ -859,8 +859,8 @@ extension type Element._(JSObject _) implements Node, JSObject {
     String input, [
     SetHTMLOptions options,
   ]);
-  external JSArray? getRegionFlowRanges();
-  external JSArray getBoxQuads([BoxQuadOptions options]);
+  external JSArray<Range>? getRegionFlowRanges();
+  external JSArray<DOMQuad> getBoxQuads([BoxQuadOptions options]);
   external DOMQuad convertQuadFromNode(
     DOMQuadInit quad,
     GeometryNode from, [
@@ -889,7 +889,7 @@ extension type Element._(JSObject _) implements Node, JSObject {
     JSObject? keyframes, [
     JSAny options,
   ]);
-  external JSArray getAnimations([GetAnimationsOptions options]);
+  external JSArray<Animation> getAnimations([GetAnimationsOptions options]);
   external set outerHTML(String value);
   external String get outerHTML;
   external DOMTokenList get part;
@@ -952,24 +952,24 @@ extension type Element._(JSObject _) implements Node, JSObject {
   external String? get ariaColIndexText;
   external set ariaColSpan(String? value);
   external String? get ariaColSpan;
-  external set ariaControlsElements(JSArray? value);
-  external JSArray? get ariaControlsElements;
+  external set ariaControlsElements(JSArray<Element>? value);
+  external JSArray<Element>? get ariaControlsElements;
   external set ariaCurrent(String? value);
   external String? get ariaCurrent;
-  external set ariaDescribedByElements(JSArray? value);
-  external JSArray? get ariaDescribedByElements;
+  external set ariaDescribedByElements(JSArray<Element>? value);
+  external JSArray<Element>? get ariaDescribedByElements;
   external set ariaDescription(String? value);
   external String? get ariaDescription;
-  external set ariaDetailsElements(JSArray? value);
-  external JSArray? get ariaDetailsElements;
+  external set ariaDetailsElements(JSArray<Element>? value);
+  external JSArray<Element>? get ariaDetailsElements;
   external set ariaDisabled(String? value);
   external String? get ariaDisabled;
-  external set ariaErrorMessageElements(JSArray? value);
-  external JSArray? get ariaErrorMessageElements;
+  external set ariaErrorMessageElements(JSArray<Element>? value);
+  external JSArray<Element>? get ariaErrorMessageElements;
   external set ariaExpanded(String? value);
   external String? get ariaExpanded;
-  external set ariaFlowToElements(JSArray? value);
-  external JSArray? get ariaFlowToElements;
+  external set ariaFlowToElements(JSArray<Element>? value);
+  external JSArray<Element>? get ariaFlowToElements;
   external set ariaHasPopup(String? value);
   external String? get ariaHasPopup;
   external set ariaHidden(String? value);
@@ -980,8 +980,8 @@ extension type Element._(JSObject _) implements Node, JSObject {
   external String? get ariaKeyShortcuts;
   external set ariaLabel(String? value);
   external String? get ariaLabel;
-  external set ariaLabelledByElements(JSArray? value);
-  external JSArray? get ariaLabelledByElements;
+  external set ariaLabelledByElements(JSArray<Element>? value);
+  external JSArray<Element>? get ariaLabelledByElements;
   external set ariaLevel(String? value);
   external String? get ariaLevel;
   external set ariaLive(String? value);
@@ -994,8 +994,8 @@ extension type Element._(JSObject _) implements Node, JSObject {
   external String? get ariaMultiSelectable;
   external set ariaOrientation(String? value);
   external String? get ariaOrientation;
-  external set ariaOwnsElements(JSArray? value);
-  external JSArray? get ariaOwnsElements;
+  external set ariaOwnsElements(JSArray<Element>? value);
+  external JSArray<Element>? get ariaOwnsElements;
   external set ariaPlaceholder(String? value);
   external String? get ariaPlaceholder;
   external set ariaPosInSet(String? value);
@@ -1104,7 +1104,7 @@ extension type Text._(JSObject _) implements CharacterData, JSObject {
   external factory Text([String data]);
 
   external Text splitText(int offset);
-  external JSArray getBoxQuads([BoxQuadOptions options]);
+  external JSArray<DOMQuad> getBoxQuads([BoxQuadOptions options]);
   external DOMQuad convertQuadFromNode(
     DOMQuadInit quad,
     GeometryNode from, [

--- a/lib/src/dom/edit_context.dart
+++ b/lib/src/dom/edit_context.dart
@@ -42,10 +42,10 @@ extension type EditContext._(JSObject _) implements EventTarget, JSObject {
   external void updateSelectionBounds(DOMRect selectionBounds);
   external void updateCharacterBounds(
     int rangeStart,
-    JSArray characterBounds,
+    JSArray<DOMRect> characterBounds,
   );
-  external JSArray attachedElements();
-  external JSArray characterBounds();
+  external JSArray<Element> attachedElements();
+  external JSArray<DOMRect> characterBounds();
   external String get text;
   external int get selectionStart;
   external int get selectionEnd;
@@ -134,10 +134,10 @@ extension type TextFormat._(JSObject _) implements JSObject {
 }
 extension type TextFormatUpdateEventInit._(JSObject _)
     implements EventInit, JSObject {
-  external factory TextFormatUpdateEventInit({JSArray textFormats});
+  external factory TextFormatUpdateEventInit({JSArray<TextFormat> textFormats});
 
-  external set textFormats(JSArray value);
-  external JSArray get textFormats;
+  external set textFormats(JSArray<TextFormat> value);
+  external JSArray<TextFormat> get textFormats;
 }
 extension type TextFormatUpdateEvent._(JSObject _) implements Event, JSObject {
   external factory TextFormatUpdateEvent(
@@ -145,7 +145,7 @@ extension type TextFormatUpdateEvent._(JSObject _) implements Event, JSObject {
     TextFormatUpdateEventInit options,
   ]);
 
-  external JSArray getTextFormats();
+  external JSArray<TextFormat> getTextFormats();
 }
 extension type CharacterBoundsUpdateEventInit._(JSObject _)
     implements EventInit, JSObject {

--- a/lib/src/dom/element_capture.dart
+++ b/lib/src/dom/element_capture.dart
@@ -9,5 +9,5 @@ import 'dart:js_interop';
 import 'dom.dart';
 
 extension type RestrictionTarget._(JSObject _) implements JSObject {
-  external static JSPromise fromElement(Element element);
+  external static JSPromise<RestrictionTarget> fromElement(Element element);
 }

--- a/lib/src/dom/encrypted_media.dart
+++ b/lib/src/dom/encrypted_media.dart
@@ -18,28 +18,28 @@ typedef MediaKeyMessageType = String;
 extension type MediaKeySystemConfiguration._(JSObject _) implements JSObject {
   external factory MediaKeySystemConfiguration({
     String label,
-    JSArray initDataTypes,
-    JSArray audioCapabilities,
-    JSArray videoCapabilities,
+    JSArray<JSString> initDataTypes,
+    JSArray<MediaKeySystemMediaCapability> audioCapabilities,
+    JSArray<MediaKeySystemMediaCapability> videoCapabilities,
     MediaKeysRequirement distinctiveIdentifier,
     MediaKeysRequirement persistentState,
-    JSArray sessionTypes,
+    JSArray<JSString> sessionTypes,
   });
 
   external set label(String value);
   external String get label;
-  external set initDataTypes(JSArray value);
-  external JSArray get initDataTypes;
-  external set audioCapabilities(JSArray value);
-  external JSArray get audioCapabilities;
-  external set videoCapabilities(JSArray value);
-  external JSArray get videoCapabilities;
+  external set initDataTypes(JSArray<JSString> value);
+  external JSArray<JSString> get initDataTypes;
+  external set audioCapabilities(JSArray<MediaKeySystemMediaCapability> value);
+  external JSArray<MediaKeySystemMediaCapability> get audioCapabilities;
+  external set videoCapabilities(JSArray<MediaKeySystemMediaCapability> value);
+  external JSArray<MediaKeySystemMediaCapability> get videoCapabilities;
   external set distinctiveIdentifier(MediaKeysRequirement value);
   external MediaKeysRequirement get distinctiveIdentifier;
   external set persistentState(MediaKeysRequirement value);
   external MediaKeysRequirement get persistentState;
-  external set sessionTypes(JSArray value);
-  external JSArray get sessionTypes;
+  external set sessionTypes(JSArray<JSString> value);
+  external JSArray<JSString> get sessionTypes;
 }
 extension type MediaKeySystemMediaCapability._(JSObject _) implements JSObject {
   external factory MediaKeySystemMediaCapability({
@@ -57,25 +57,26 @@ extension type MediaKeySystemMediaCapability._(JSObject _) implements JSObject {
 }
 extension type MediaKeySystemAccess._(JSObject _) implements JSObject {
   external MediaKeySystemConfiguration getConfiguration();
-  external JSPromise createMediaKeys();
+  external JSPromise<MediaKeys> createMediaKeys();
   external String get keySystem;
 }
 extension type MediaKeys._(JSObject _) implements JSObject {
   external MediaKeySession createSession([MediaKeySessionType sessionType]);
-  external JSPromise setServerCertificate(BufferSource serverCertificate);
+  external JSPromise<JSBoolean> setServerCertificate(
+      BufferSource serverCertificate);
 }
 extension type MediaKeySession._(JSObject _) implements EventTarget, JSObject {
-  external JSPromise generateRequest(
+  external JSPromise<JSAny?> generateRequest(
     String initDataType,
     BufferSource initData,
   );
-  external JSPromise load(String sessionId);
-  external JSPromise update(BufferSource response);
-  external JSPromise close();
-  external JSPromise remove();
+  external JSPromise<JSBoolean> load(String sessionId);
+  external JSPromise<JSAny?> update(BufferSource response);
+  external JSPromise<JSAny?> close();
+  external JSPromise<JSAny?> remove();
   external String get sessionId;
   external num get expiration;
-  external JSPromise get closed;
+  external JSPromise<JSString> get closed;
   external MediaKeyStatusMap get keyStatuses;
   external set onkeystatuseschange(EventHandler value);
   external EventHandler get onkeystatuseschange;

--- a/lib/src/dom/eyedropper_api.dart
+++ b/lib/src/dom/eyedropper_api.dart
@@ -23,5 +23,6 @@ extension type ColorSelectionOptions._(JSObject _) implements JSObject {
 extension type EyeDropper._(JSObject _) implements JSObject {
   external factory EyeDropper();
 
-  external JSPromise open([ColorSelectionOptions options]);
+  external JSPromise<ColorSelectionResult> open(
+      [ColorSelectionOptions options]);
 }

--- a/lib/src/dom/fedcm.dart
+++ b/lib/src/dom/fedcm.dart
@@ -16,12 +16,12 @@ extension type IdentityCredential._(JSObject _)
 extension type IdentityCredentialRequestOptions._(JSObject _)
     implements JSObject {
   external factory IdentityCredentialRequestOptions({
-    required JSArray providers,
+    required JSArray<IdentityProviderConfig> providers,
     IdentityCredentialRequestOptionsContext context,
   });
 
-  external set providers(JSArray value);
-  external JSArray get providers;
+  external set providers(JSArray<IdentityProviderConfig> value);
+  external JSArray<IdentityProviderConfig> get providers;
   external set context(IdentityCredentialRequestOptionsContext value);
   external IdentityCredentialRequestOptionsContext get context;
 }
@@ -43,10 +43,11 @@ extension type IdentityProviderConfig._(JSObject _) implements JSObject {
   external String get loginHint;
 }
 extension type IdentityProviderWellKnown._(JSObject _) implements JSObject {
-  external factory IdentityProviderWellKnown({required JSArray provider_urls});
+  external factory IdentityProviderWellKnown(
+      {required JSArray<JSString> provider_urls});
 
-  external set provider_urls(JSArray value);
-  external JSArray get provider_urls;
+  external set provider_urls(JSArray<JSString> value);
+  external JSArray<JSString> get provider_urls;
 }
 extension type IdentityProviderIcon._(JSObject _) implements JSObject {
   external factory IdentityProviderIcon({
@@ -63,7 +64,7 @@ extension type IdentityProviderBranding._(JSObject _) implements JSObject {
   external factory IdentityProviderBranding({
     String background_color,
     String color,
-    JSArray icons,
+    JSArray<IdentityProviderIcon> icons,
     String name,
   });
 
@@ -71,8 +72,8 @@ extension type IdentityProviderBranding._(JSObject _) implements JSObject {
   external String get background_color;
   external set color(String value);
   external String get color;
-  external set icons(JSArray value);
-  external JSArray get icons;
+  external set icons(JSArray<IdentityProviderIcon> value);
+  external JSArray<IdentityProviderIcon> get icons;
   external set name(String value);
   external String get name;
 }
@@ -100,8 +101,8 @@ extension type IdentityProviderAccount._(JSObject _) implements JSObject {
     required String email,
     String given_name,
     String picture,
-    JSArray approved_clients,
-    JSArray login_hints,
+    JSArray<JSString> approved_clients,
+    JSArray<JSString> login_hints,
   });
 
   external set id(String value);
@@ -114,16 +115,17 @@ extension type IdentityProviderAccount._(JSObject _) implements JSObject {
   external String get given_name;
   external set picture(String value);
   external String get picture;
-  external set approved_clients(JSArray value);
-  external JSArray get approved_clients;
-  external set login_hints(JSArray value);
-  external JSArray get login_hints;
+  external set approved_clients(JSArray<JSString> value);
+  external JSArray<JSString> get approved_clients;
+  external set login_hints(JSArray<JSString> value);
+  external JSArray<JSString> get login_hints;
 }
 extension type IdentityProviderAccountList._(JSObject _) implements JSObject {
-  external factory IdentityProviderAccountList({JSArray accounts});
+  external factory IdentityProviderAccountList(
+      {JSArray<IdentityProviderAccount> accounts});
 
-  external set accounts(JSArray value);
-  external JSArray get accounts;
+  external set accounts(JSArray<IdentityProviderAccount> value);
+  external JSArray<IdentityProviderAccount> get accounts;
 }
 extension type IdentityProviderToken._(JSObject _) implements JSObject {
   external factory IdentityProviderToken({required String token});
@@ -161,5 +163,6 @@ extension type IdentityUserInfo._(JSObject _) implements JSObject {
   external String get picture;
 }
 extension type IdentityProvider._(JSObject _) implements JSObject {
-  external static JSPromise getUserInfo(IdentityProviderConfig config);
+  external static JSPromise<JSArray<IdentityUserInfo>> getUserInfo(
+      IdentityProviderConfig config);
 }

--- a/lib/src/dom/fenced_frame.dart
+++ b/lib/src/dom/fenced_frame.dart
@@ -38,7 +38,7 @@ extension type FenceEvent._(JSObject _) implements JSObject {
   external factory FenceEvent({
     String eventType,
     String eventData,
-    JSArray destination,
+    JSArray<JSString> destination,
     bool once,
     String destinationURL,
   });
@@ -47,8 +47,8 @@ extension type FenceEvent._(JSObject _) implements JSObject {
   external String get eventType;
   external set eventData(String value);
   external String get eventData;
-  external set destination(JSArray value);
-  external JSArray get destination;
+  external set destination(JSArray<JSString> value);
+  external JSArray<JSString> get destination;
   external set once(bool value);
   external bool get once;
   external set destinationURL(String value);
@@ -57,5 +57,5 @@ extension type FenceEvent._(JSObject _) implements JSObject {
 extension type Fence._(JSObject _) implements JSObject {
   external void reportEvent([ReportEventType event]);
   external void setReportEventDataForAutomaticBeacons([FenceEvent event]);
-  external JSArray getNestedConfigs();
+  external JSArray<FencedFrameConfig> getNestedConfigs();
 }

--- a/lib/src/dom/fetch.dart
+++ b/lib/src/dom/fetch.dart
@@ -8,10 +8,12 @@ import 'dart:js_interop';
 
 import 'attribution_reporting_api.dart';
 import 'dom.dart';
+import 'fileapi.dart';
 import 'private_network_access.dart';
 import 'referrer_policy.dart';
 import 'streams.dart';
 import 'trust_token_api.dart';
+import 'xhr.dart';
 
 typedef HeadersInit = JSAny;
 typedef XMLHttpRequestBodyInit = JSAny;
@@ -34,7 +36,7 @@ extension type Headers._(JSObject _) implements JSObject {
   );
   external void delete(String name);
   external String? get(String name);
-  external JSArray getSetCookie();
+  external JSArray<JSString> getSetCookie();
   external bool has(String name);
   external void set(
     String name,
@@ -48,11 +50,11 @@ extension type Request._(JSObject _) implements JSObject {
   ]);
 
   external Request clone();
-  external JSPromise arrayBuffer();
-  external JSPromise blob();
-  external JSPromise formData();
-  external JSPromise json();
-  external JSPromise text();
+  external JSPromise<JSArrayBuffer> arrayBuffer();
+  external JSPromise<Blob> blob();
+  external JSPromise<FormData> formData();
+  external JSPromise<JSAny?> json();
+  external JSPromise<JSString> text();
   external String get method;
   external String get url;
   external Headers get headers;
@@ -151,11 +153,11 @@ extension type Response._(JSObject _) implements JSObject {
     ResponseInit init,
   ]);
   external Response clone();
-  external JSPromise arrayBuffer();
-  external JSPromise blob();
-  external JSPromise formData();
-  external JSPromise json();
-  external JSPromise text();
+  external JSPromise<JSArrayBuffer> arrayBuffer();
+  external JSPromise<Blob> blob();
+  external JSPromise<FormData> formData();
+  external JSPromise<JSAny?> json();
+  external JSPromise<JSString> text();
   external ResponseType get type;
   external String get url;
   external bool get redirected;

--- a/lib/src/dom/file_system_access.dart
+++ b/lib/src/dom/file_system_access.dart
@@ -45,14 +45,14 @@ extension type FilePickerAcceptType._(JSObject _) implements JSObject {
 }
 extension type FilePickerOptions._(JSObject _) implements JSObject {
   external factory FilePickerOptions({
-    JSArray types,
+    JSArray<FilePickerAcceptType> types,
     bool excludeAcceptAllOption,
     String id,
     StartInDirectory startIn,
   });
 
-  external set types(JSArray value);
-  external JSArray get types;
+  external set types(JSArray<FilePickerAcceptType> value);
+  external JSArray<FilePickerAcceptType> get types;
   external set excludeAcceptAllOption(bool value);
   external bool get excludeAcceptAllOption;
   external set id(String value);

--- a/lib/src/dom/fileapi.dart
+++ b/lib/src/dom/fileapi.dart
@@ -15,7 +15,7 @@ typedef BlobPart = JSAny;
 typedef EndingType = String;
 extension type Blob._(JSObject _) implements JSObject {
   external factory Blob([
-    JSArray blobParts,
+    JSArray<BlobPart> blobParts,
     BlobPropertyBag options,
   ]);
 
@@ -25,8 +25,8 @@ extension type Blob._(JSObject _) implements JSObject {
     String contentType,
   ]);
   external ReadableStream stream();
-  external JSPromise text();
-  external JSPromise arrayBuffer();
+  external JSPromise<JSString> text();
+  external JSPromise<JSArrayBuffer> arrayBuffer();
   external int get size;
   external String get type;
 }
@@ -43,7 +43,7 @@ extension type BlobPropertyBag._(JSObject _) implements JSObject {
 }
 extension type File._(JSObject _) implements Blob, JSObject {
   external factory File(
-    JSArray fileBits,
+    JSArray<BlobPart> fileBits,
     String fileName, [
     FilePropertyBag options,
   ]);

--- a/lib/src/dom/font_metrics_api.dart
+++ b/lib/src/dom/font_metrics_api.dart
@@ -8,7 +8,7 @@ import 'dart:js_interop';
 
 extension type FontMetrics._(JSObject _) implements JSObject {
   external num get width;
-  external JSArray get advances;
+  external JSArray<JSNumber> get advances;
   external num get boundingBoxLeft;
   external num get boundingBoxRight;
   external num get height;
@@ -19,8 +19,8 @@ extension type FontMetrics._(JSObject _) implements JSObject {
   external num get fontBoundingBoxAscent;
   external num get fontBoundingBoxDescent;
   external Baseline get dominantBaseline;
-  external JSArray get baselines;
-  external JSArray get fonts;
+  external JSArray<Baseline> get baselines;
+  external JSArray<Font> get fonts;
 }
 extension type Baseline._(JSObject _) implements JSObject {
   external String get name;

--- a/lib/src/dom/fs.dart
+++ b/lib/src/dom/fs.dart
@@ -7,6 +7,7 @@
 import 'dart:js_interop';
 
 import 'file_system_access.dart';
+import 'fileapi.dart';
 import 'streams.dart';
 import 'webidl.dart';
 
@@ -14,11 +15,11 @@ typedef FileSystemWriteChunkType = JSAny;
 typedef FileSystemHandleKind = String;
 typedef WriteCommandType = String;
 extension type FileSystemHandle._(JSObject _) implements JSObject {
-  external JSPromise queryPermission(
+  external JSPromise<JSString> queryPermission(
       [FileSystemHandlePermissionDescriptor descriptor]);
-  external JSPromise requestPermission(
+  external JSPromise<JSString> requestPermission(
       [FileSystemHandlePermissionDescriptor descriptor]);
-  external JSPromise isSameEntry(FileSystemHandle other);
+  external JSPromise<JSBoolean> isSameEntry(FileSystemHandle other);
   external FileSystemHandleKind get kind;
   external String get name;
 }
@@ -31,9 +32,10 @@ extension type FileSystemCreateWritableOptions._(JSObject _)
 }
 extension type FileSystemFileHandle._(JSObject _)
     implements FileSystemHandle, JSObject {
-  external JSPromise getFile();
-  external JSPromise createWritable([FileSystemCreateWritableOptions options]);
-  external JSPromise createSyncAccessHandle();
+  external JSPromise<File> getFile();
+  external JSPromise<FileSystemWritableFileStream> createWritable(
+      [FileSystemCreateWritableOptions options]);
+  external JSPromise<FileSystemSyncAccessHandle> createSyncAccessHandle();
 }
 extension type FileSystemGetFileOptions._(JSObject _) implements JSObject {
   external factory FileSystemGetFileOptions({bool create});
@@ -55,19 +57,20 @@ extension type FileSystemRemoveOptions._(JSObject _) implements JSObject {
 }
 extension type FileSystemDirectoryHandle._(JSObject _)
     implements FileSystemHandle, JSObject {
-  external JSPromise getFileHandle(
+  external JSPromise<FileSystemFileHandle> getFileHandle(
     String name, [
     FileSystemGetFileOptions options,
   ]);
-  external JSPromise getDirectoryHandle(
+  external JSPromise<FileSystemDirectoryHandle> getDirectoryHandle(
     String name, [
     FileSystemGetDirectoryOptions options,
   ]);
-  external JSPromise removeEntry(
+  external JSPromise<JSAny?> removeEntry(
     String name, [
     FileSystemRemoveOptions options,
   ]);
-  external JSPromise resolve(FileSystemHandle possibleDescendant);
+  external JSPromise<JSArray<JSString>?> resolve(
+      FileSystemHandle possibleDescendant);
 }
 extension type WriteParams._(JSObject _) implements JSObject {
   external factory WriteParams({
@@ -88,9 +91,9 @@ extension type WriteParams._(JSObject _) implements JSObject {
 }
 extension type FileSystemWritableFileStream._(JSObject _)
     implements WritableStream, JSObject {
-  external JSPromise write(FileSystemWriteChunkType data);
-  external JSPromise seek(int position);
-  external JSPromise truncate(int size);
+  external JSPromise<JSAny?> write(FileSystemWriteChunkType data);
+  external JSPromise<JSAny?> seek(int position);
+  external JSPromise<JSAny?> truncate(int size);
 }
 extension type FileSystemReadWriteOptions._(JSObject _) implements JSObject {
   external factory FileSystemReadWriteOptions({int at});

--- a/lib/src/dom/gamepad.dart
+++ b/lib/src/dom/gamepad.dart
@@ -13,17 +13,17 @@ import 'hr_time.dart';
 typedef GamepadMappingType = String;
 extension type Gamepad._(JSObject _) implements JSObject {
   external GamepadHand get hand;
-  external JSArray get hapticActuators;
+  external JSArray<GamepadHapticActuator> get hapticActuators;
   external GamepadPose? get pose;
-  external JSArray? get touchEvents;
+  external JSArray<GamepadTouch>? get touchEvents;
   external GamepadHapticActuator? get vibrationActuator;
   external String get id;
   external int get index;
   external bool get connected;
   external DOMHighResTimeStamp get timestamp;
   external GamepadMappingType get mapping;
-  external JSArray get axes;
-  external JSArray get buttons;
+  external JSArray<JSNumber> get axes;
+  external JSArray<GamepadButton> get buttons;
 }
 extension type GamepadButton._(JSObject _) implements JSObject {
   external bool get pressed;

--- a/lib/src/dom/gamepad_extensions.dart
+++ b/lib/src/dom/gamepad_extensions.dart
@@ -12,15 +12,15 @@ typedef GamepadHapticActuatorType = String;
 typedef GamepadHapticEffectType = String;
 extension type GamepadHapticActuator._(JSObject _) implements JSObject {
   external bool canPlayEffectType(GamepadHapticEffectType type);
-  external JSPromise playEffect(
+  external JSPromise<JSString> playEffect(
     GamepadHapticEffectType type, [
     GamepadEffectParameters params,
   ]);
-  external JSPromise pulse(
+  external JSPromise<JSBoolean> pulse(
     num value,
     num duration,
   );
-  external JSPromise reset();
+  external JSPromise<JSString> reset();
   external GamepadHapticActuatorType get type;
 }
 extension type GamepadEffectParameters._(JSObject _) implements JSObject {

--- a/lib/src/dom/geolocation_sensor.dart
+++ b/lib/src/dom/geolocation_sensor.dart
@@ -13,7 +13,8 @@ import 'hr_time.dart';
 extension type GeolocationSensor._(JSObject _) implements Sensor, JSObject {
   external factory GeolocationSensor([GeolocationSensorOptions options]);
 
-  external static JSPromise read([ReadOptions readOptions]);
+  external static JSPromise<GeolocationSensorReading> read(
+      [ReadOptions readOptions]);
   external num? get latitude;
   external num? get longitude;
   external num? get altitude;

--- a/lib/src/dom/hr_time.dart
+++ b/lib/src/dom/hr_time.dart
@@ -10,6 +10,7 @@ import 'dom.dart';
 import 'event_timing.dart';
 import 'html.dart';
 import 'navigation_timing.dart';
+import 'performance_measure_memory.dart';
 import 'performance_timeline.dart';
 import 'user_timing.dart';
 
@@ -18,7 +19,7 @@ typedef EpochTimeStamp = int;
 extension type Performance._(JSObject _) implements EventTarget, JSObject {
   external DOMHighResTimeStamp now();
   external JSObject toJSON();
-  external JSPromise measureUserAgentSpecificMemory();
+  external JSPromise<MemoryMeasurement> measureUserAgentSpecificMemory();
   external PerformanceEntryList getEntries();
   external PerformanceEntryList getEntriesByType(String type);
   external PerformanceEntryList getEntriesByName(

--- a/lib/src/dom/html.dart
+++ b/lib/src/dom/html.dart
@@ -8,6 +8,7 @@ import 'dart:js_interop';
 
 import 'audio_session.dart';
 import 'autoplay_detection.dart';
+import 'battery_status.dart';
 import 'clipboard_apis.dart';
 import 'contact_picker.dart';
 import 'cookie_store.dart';
@@ -19,6 +20,7 @@ import 'cssom.dart';
 import 'cssom_view.dart';
 import 'custom_state_pseudo_class.dart';
 import 'device_posture.dart';
+import 'digital_goods.dart';
 import 'document_picture_in_picture.dart';
 import 'dom.dart';
 import 'edit_context.dart';
@@ -28,8 +30,11 @@ import 'fenced_frame.dart';
 import 'fetch.dart';
 import 'file_system_access.dart';
 import 'fileapi.dart';
+import 'fs.dart';
+import 'gamepad.dart';
 import 'geolocation.dart';
 import 'geometry.dart';
+import 'get_installed_related_apps.dart';
 import 'hr_time.dart';
 import 'indexeddb.dart';
 import 'ink_enhancement.dart';
@@ -45,6 +50,7 @@ import 'netinfo.dart';
 import 'performance_timeline.dart';
 import 'permissions.dart';
 import 'permissions_policy.dart';
+import 'picture_in_picture.dart';
 import 'portals.dart';
 import 'presentation_api.dart';
 import 'remote_playback.dart';
@@ -78,6 +84,7 @@ import 'webnn.dart';
 import 'webusb.dart';
 import 'webxr.dart';
 import 'window_controls_overlay.dart';
+import 'window_management.dart';
 import 'xhr.dart';
 
 typedef HTMLOrSVGScriptElement = JSObject;
@@ -771,7 +778,7 @@ extension type HTMLSourceElement._(JSObject _)
 extension type HTMLImageElement._(JSObject _) implements HTMLElement, JSObject {
   external factory HTMLImageElement();
 
-  external JSPromise decode();
+  external JSPromise<JSAny?> decode();
   external int get x;
   external int get y;
   external set alt(String value);
@@ -938,7 +945,7 @@ extension type HTMLVideoElement._(JSObject _)
   external factory HTMLVideoElement();
 
   external VideoPlaybackQuality getVideoPlaybackQuality();
-  external JSPromise requestPictureInPicture();
+  external JSPromise<PictureInPictureWindow> requestPictureInPicture();
   external int requestVideoFrameCallback(VideoFrameRequestCallback callback);
   external void cancelVideoFrameCallback(int handle);
   external set width(int value);
@@ -994,13 +1001,13 @@ extension type HTMLMediaElement._(JSObject _) implements HTMLElement, JSObject {
   external static int get HAVE_CURRENT_DATA;
   external static int get HAVE_FUTURE_DATA;
   external static int get HAVE_ENOUGH_DATA;
-  external JSPromise setSinkId(String sinkId);
-  external JSPromise setMediaKeys(MediaKeys? mediaKeys);
+  external JSPromise<JSAny?> setSinkId(String sinkId);
+  external JSPromise<JSAny?> setMediaKeys(MediaKeys? mediaKeys);
   external void load();
   external CanPlayTypeResult canPlayType(String type);
   external void fastSeek(num time);
   external JSObject getStartDate();
-  external JSPromise play();
+  external JSPromise<JSAny?> play();
   external void pause();
   external TextTrack addTextTrack(
     TextTrackKind kind, [
@@ -1418,7 +1425,7 @@ extension type HTMLInputElement._(JSObject _) implements HTMLElement, JSObject {
   external void showPicker();
   external set webkitdirectory(bool value);
   external bool get webkitdirectory;
-  external JSArray get webkitEntries;
+  external JSArray<FileSystemEntry> get webkitEntries;
   external set capture(String value);
   external String get capture;
   external set accept(String value);
@@ -1862,8 +1869,8 @@ extension type HTMLTemplateElement._(JSObject _)
 extension type HTMLSlotElement._(JSObject _) implements HTMLElement, JSObject {
   external factory HTMLSlotElement();
 
-  external JSArray assignedNodes([AssignedNodesOptions options]);
-  external JSArray assignedElements([AssignedNodesOptions options]);
+  external JSArray<Node> assignedNodes([AssignedNodesOptions options]);
+  external JSArray<Element> assignedElements([AssignedNodesOptions options]);
   external void assign(JSObject nodes);
   external set name(String value);
   external String get name;
@@ -2061,8 +2068,8 @@ extension type CanvasRenderingContext2D._(JSObject _) implements JSObject {
     int dirtyWidth,
     int dirtyHeight,
   ]);
-  external void setLineDash(JSArray segments);
-  external JSArray getLineDash();
+  external void setLineDash(JSArray<JSNumber> segments);
+  external JSArray<JSNumber> getLineDash();
   external void closePath();
   external void moveTo(
     num x,
@@ -2322,7 +2329,7 @@ extension type OffscreenCanvas._(JSObject _) implements EventTarget, JSObject {
     JSAny? options,
   ]);
   external ImageBitmap transferToImageBitmap();
-  external JSPromise convertToBlob([ImageEncodeOptions options]);
+  external JSPromise<Blob> convertToBlob([ImageEncodeOptions options]);
   external set width(int value);
   external int get width;
   external set height(int value);
@@ -2473,8 +2480,8 @@ extension type OffscreenCanvasRenderingContext2D._(JSObject _)
     int dirtyWidth,
     int dirtyHeight,
   ]);
-  external void setLineDash(JSArray segments);
-  external JSArray getLineDash();
+  external void setLineDash(JSArray<JSNumber> segments);
+  external JSArray<JSNumber> getLineDash();
   external void closePath();
   external void moveTo(
     num x,
@@ -2598,7 +2605,7 @@ extension type CustomElementRegistry._(JSObject _) implements JSObject {
   ]);
   external CustomElementConstructor? get(String name);
   external String? getName(CustomElementConstructor constructor);
-  external JSPromise whenDefined(String name);
+  external JSPromise<CustomElementConstructor> whenDefined(String name);
   external void upgrade(Node root);
 }
 extension type ElementDefinitionOptions._(JSObject _) implements JSObject {
@@ -2648,24 +2655,24 @@ extension type ElementInternals._(JSObject _) implements JSObject {
   external String? get ariaColIndexText;
   external set ariaColSpan(String? value);
   external String? get ariaColSpan;
-  external set ariaControlsElements(JSArray? value);
-  external JSArray? get ariaControlsElements;
+  external set ariaControlsElements(JSArray<Element>? value);
+  external JSArray<Element>? get ariaControlsElements;
   external set ariaCurrent(String? value);
   external String? get ariaCurrent;
-  external set ariaDescribedByElements(JSArray? value);
-  external JSArray? get ariaDescribedByElements;
+  external set ariaDescribedByElements(JSArray<Element>? value);
+  external JSArray<Element>? get ariaDescribedByElements;
   external set ariaDescription(String? value);
   external String? get ariaDescription;
-  external set ariaDetailsElements(JSArray? value);
-  external JSArray? get ariaDetailsElements;
+  external set ariaDetailsElements(JSArray<Element>? value);
+  external JSArray<Element>? get ariaDetailsElements;
   external set ariaDisabled(String? value);
   external String? get ariaDisabled;
-  external set ariaErrorMessageElements(JSArray? value);
-  external JSArray? get ariaErrorMessageElements;
+  external set ariaErrorMessageElements(JSArray<Element>? value);
+  external JSArray<Element>? get ariaErrorMessageElements;
   external set ariaExpanded(String? value);
   external String? get ariaExpanded;
-  external set ariaFlowToElements(JSArray? value);
-  external JSArray? get ariaFlowToElements;
+  external set ariaFlowToElements(JSArray<Element>? value);
+  external JSArray<Element>? get ariaFlowToElements;
   external set ariaHasPopup(String? value);
   external String? get ariaHasPopup;
   external set ariaHidden(String? value);
@@ -2676,8 +2683,8 @@ extension type ElementInternals._(JSObject _) implements JSObject {
   external String? get ariaKeyShortcuts;
   external set ariaLabel(String? value);
   external String? get ariaLabel;
-  external set ariaLabelledByElements(JSArray? value);
-  external JSArray? get ariaLabelledByElements;
+  external set ariaLabelledByElements(JSArray<Element>? value);
+  external JSArray<Element>? get ariaLabelledByElements;
   external set ariaLevel(String? value);
   external String? get ariaLevel;
   external set ariaLive(String? value);
@@ -2690,8 +2697,8 @@ extension type ElementInternals._(JSObject _) implements JSObject {
   external String? get ariaMultiSelectable;
   external set ariaOrientation(String? value);
   external String? get ariaOrientation;
-  external set ariaOwnsElements(JSArray? value);
-  external JSArray? get ariaOwnsElements;
+  external set ariaOwnsElements(JSArray<Element>? value);
+  external JSArray<Element>? get ariaOwnsElements;
   external set ariaPlaceholder(String? value);
   external String? get ariaPlaceholder;
   external set ariaPosInSet(String? value);
@@ -2823,7 +2830,7 @@ extension type DataTransfer._(JSObject _) implements JSObject {
   external set effectAllowed(String value);
   external String get effectAllowed;
   external DataTransferItemList get items;
-  external JSArray get types;
+  external JSArray<JSString> get types;
   external FileList get files;
 }
 extension type DataTransferItemList._(JSObject _) implements JSObject {
@@ -2837,7 +2844,7 @@ extension type DataTransferItemList._(JSObject _) implements JSObject {
 }
 extension type DataTransferItem._(JSObject _) implements JSObject {
   external FileSystemEntry? webkitGetAsEntry();
-  external JSPromise getAsFileSystemHandle();
+  external JSPromise<FileSystemHandle?> getAsFileSystemHandle();
   external void getAsString(FunctionStringCallback? callback);
   external File? getAsFile();
   external String get kind;
@@ -2894,10 +2901,14 @@ extension type Window._(JSObject _) implements EventTarget, JSObject {
     Element elt, [
     String? pseudoElt,
   ]);
-  external JSPromise getDigitalGoodsService(String serviceProvider);
-  external JSPromise showOpenFilePicker([OpenFilePickerOptions options]);
-  external JSPromise showSaveFilePicker([SaveFilePickerOptions options]);
-  external JSPromise showDirectoryPicker([DirectoryPickerOptions options]);
+  external JSPromise<DigitalGoodsService> getDigitalGoodsService(
+      String serviceProvider);
+  external JSPromise<JSArray<FileSystemFileHandle>> showOpenFilePicker(
+      [OpenFilePickerOptions options]);
+  external JSPromise<FileSystemFileHandle> showSaveFilePicker(
+      [SaveFilePickerOptions options]);
+  external JSPromise<FileSystemDirectoryHandle> showDirectoryPicker(
+      [DirectoryPickerOptions options]);
   external void close();
   external void stop();
   external void focus();
@@ -2917,19 +2928,19 @@ extension type Window._(JSObject _) implements EventTarget, JSObject {
   external void postMessage(
     JSAny? message, [
     JSAny optionsOrTargetOrigin,
-    JSArray transfer,
+    JSArray<JSObject> transfer,
   ]);
   external void captureEvents();
   external void releaseEvents();
-  external JSPromise queryLocalFonts([QueryOptions options]);
+  external JSPromise<JSArray<FontData>> queryLocalFonts([QueryOptions options]);
   external int requestIdleCallback(
     IdleRequestCallback callback, [
     IdleRequestOptions options,
   ]);
   external void cancelIdleCallback(int handle);
   external Selection? getSelection();
-  external JSPromise getScreenDetails();
-  external JSPromise fetch(
+  external JSPromise<ScreenDetails> getScreenDetails();
+  external JSPromise<Response> fetch(
     RequestInfo input, [
     RequestInit init,
   ]);
@@ -2949,7 +2960,7 @@ extension type Window._(JSObject _) implements EventTarget, JSObject {
   ]);
   external void clearInterval([int id]);
   external void queueMicrotask(VoidFunction callback);
-  external JSPromise createImageBitmap(
+  external JSPromise<ImageBitmap> createImageBitmap(
     ImageBitmapSource image, [
     JSAny optionsOrSx,
     int sy,
@@ -3333,7 +3344,7 @@ extension type History._(JSObject _) implements JSObject {
   external JSAny? get state;
 }
 extension type Navigation._(JSObject _) implements EventTarget, JSObject {
-  external JSArray entries();
+  external JSArray<NavigationHistoryEntry> entries();
   external void updateCurrentEntry(NavigationUpdateCurrentEntryOptions options);
   external NavigationResult navigate(
     String url, [
@@ -3393,14 +3404,14 @@ extension type NavigationReloadOptions._(JSObject _)
 }
 extension type NavigationResult._(JSObject _) implements JSObject {
   external factory NavigationResult({
-    JSPromise committed,
-    JSPromise finished,
+    JSPromise<NavigationHistoryEntry> committed,
+    JSPromise<NavigationHistoryEntry> finished,
   });
 
-  external set committed(JSPromise value);
-  external JSPromise get committed;
-  external set finished(JSPromise value);
-  external JSPromise get finished;
+  external set committed(JSPromise<NavigationHistoryEntry> value);
+  external JSPromise<NavigationHistoryEntry> get committed;
+  external set finished(JSPromise<NavigationHistoryEntry> value);
+  external JSPromise<NavigationHistoryEntry> get finished;
 }
 extension type NavigationHistoryEntry._(JSObject _)
     implements EventTarget, JSObject {
@@ -3416,7 +3427,7 @@ extension type NavigationHistoryEntry._(JSObject _)
 extension type NavigationTransition._(JSObject _) implements JSObject {
   external NavigationType get navigationType;
   external NavigationHistoryEntry get from;
-  external JSPromise get finished;
+  external JSPromise<JSAny?> get finished;
 }
 extension type NavigateEvent._(JSObject _) implements Event, JSObject {
   external factory NavigateEvent(
@@ -3614,18 +3625,18 @@ extension type PromiseRejectionEvent._(JSObject _) implements Event, JSObject {
     PromiseRejectionEventInit eventInitDict,
   );
 
-  external JSPromise get promise;
+  external JSPromise<JSAny?> get promise;
   external JSAny? get reason;
 }
 extension type PromiseRejectionEventInit._(JSObject _)
     implements EventInit, JSObject {
   external factory PromiseRejectionEventInit({
-    required JSPromise promise,
+    required JSPromise<JSAny?> promise,
     JSAny? reason,
   });
 
-  external set promise(JSPromise value);
-  external JSPromise get promise;
+  external set promise(JSPromise<JSAny?> value);
+  external JSPromise<JSAny?> get promise;
   external set reason(JSAny? value);
   external JSAny? get reason;
 }
@@ -3639,36 +3650,37 @@ extension type DOMParser._(JSObject _) implements JSObject {
 }
 extension type Navigator._(JSObject _) implements JSObject {
   external AutoplayPolicy getAutoplayPolicy(JSAny contextOrElementOrType);
-  external JSPromise getBattery();
+  external JSPromise<BatteryManager> getBattery();
   external bool sendBeacon(
     String url, [
     BodyInit? data,
   ]);
-  external JSPromise requestMediaKeySystemAccess(
+  external JSPromise<MediaKeySystemAccess> requestMediaKeySystemAccess(
     String keySystem,
-    JSArray supportedConfigurations,
+    JSArray<MediaKeySystemConfiguration> supportedConfigurations,
   );
-  external JSPromise deprecatedReplaceInURN(
+  external JSPromise<JSAny?> deprecatedReplaceInURN(
     UrnOrConfig urnOrConfig,
     JSAny replacements,
   );
-  external JSArray getGamepads();
-  external JSPromise getInstalledRelatedApps();
+  external JSArray<Gamepad?> getGamepads();
+  external JSPromise<JSArray<RelatedApplication>> getInstalledRelatedApps();
   external void getUserMedia(
     MediaStreamConstraints constraints,
     NavigatorUserMediaSuccessCallback successCallback,
     NavigatorUserMediaErrorCallback errorCallback,
   );
-  external JSPromise joinAdInterestGroup(AuctionAdInterestGroup group);
-  external JSPromise leaveAdInterestGroup([AuctionAdInterestGroupKey group]);
-  external JSPromise runAdAuction(AuctionAdConfig config);
+  external JSPromise<JSAny?> joinAdInterestGroup(AuctionAdInterestGroup group);
+  external JSPromise<JSAny?> leaveAdInterestGroup(
+      [AuctionAdInterestGroupKey group]);
+  external JSPromise<JSAny?> runAdAuction(AuctionAdConfig config);
   external void updateAdInterestGroups();
   external bool vibrate(VibratePattern pattern);
-  external JSPromise share([ShareData data]);
+  external JSPromise<JSAny?> share([ShareData data]);
   external bool canShare([ShareData data]);
-  external JSPromise requestMIDIAccess([MIDIOptions options]);
-  external JSPromise setAppBadge([int contents]);
-  external JSPromise clearAppBadge();
+  external JSPromise<MIDIAccess> requestMIDIAccess([MIDIOptions options]);
+  external JSPromise<JSAny?> setAppBadge([int contents]);
+  external JSPromise<JSAny?> clearAppBadge();
   external bool taintEnabled();
   external void registerProtocolHandler(
     String scheme,
@@ -3716,7 +3728,7 @@ extension type Navigator._(JSObject _) implements JSObject {
   external String get vendorSub;
   external String get oscpu;
   external String get language;
-  external JSArray get languages;
+  external JSArray<JSString> get languages;
   external bool get onLine;
   external bool get cookieEnabled;
   external PluginArray get plugins;
@@ -3799,13 +3811,13 @@ extension type MessageEvent._(JSObject _) implements Event, JSObject {
     String origin,
     String lastEventId,
     MessageEventSource? source,
-    JSArray ports,
+    JSArray<MessagePort> ports,
   ]);
   external JSAny? get data;
   external String get origin;
   external String get lastEventId;
   external MessageEventSource? get source;
-  external JSArray get ports;
+  external JSArray<MessagePort> get ports;
 }
 extension type MessageEventInit._(JSObject _) implements EventInit, JSObject {
   external factory MessageEventInit({
@@ -3813,7 +3825,7 @@ extension type MessageEventInit._(JSObject _) implements EventInit, JSObject {
     String origin,
     String lastEventId,
     MessageEventSource? source,
-    JSArray ports,
+    JSArray<MessagePort> ports,
   });
 
   external set data(JSAny? value);
@@ -3824,8 +3836,8 @@ extension type MessageEventInit._(JSObject _) implements EventInit, JSObject {
   external String get lastEventId;
   external set source(MessageEventSource? value);
   external MessageEventSource? get source;
-  external set ports(JSArray value);
-  external JSArray get ports;
+  external set ports(JSArray<MessagePort> value);
+  external JSArray<MessagePort> get ports;
 }
 extension type EventSource._(JSObject _) implements EventTarget, JSObject {
   external factory EventSource(
@@ -3872,10 +3884,10 @@ extension type MessagePort._(JSObject _) implements EventTarget, JSObject {
   external EventHandler get onmessageerror;
 }
 extension type StructuredSerializeOptions._(JSObject _) implements JSObject {
-  external factory StructuredSerializeOptions({JSArray transfer});
+  external factory StructuredSerializeOptions({JSArray<JSObject> transfer});
 
-  external set transfer(JSArray value);
-  external JSArray get transfer;
+  external set transfer(JSArray<JSObject> value);
+  external JSArray<JSObject> get transfer;
 }
 extension type BroadcastChannel._(JSObject _) implements EventTarget, JSObject {
   external factory BroadcastChannel(String name);
@@ -3891,7 +3903,7 @@ extension type BroadcastChannel._(JSObject _) implements EventTarget, JSObject {
 extension type WorkerGlobalScope._(JSObject _)
     implements EventTarget, JSObject {
   external void importScripts(String urls);
-  external JSPromise fetch(
+  external JSPromise<Response> fetch(
     RequestInfo input, [
     RequestInit init,
   ]);
@@ -3911,7 +3923,7 @@ extension type WorkerGlobalScope._(JSObject _)
   ]);
   external void clearInterval([int id]);
   external void queueMicrotask(VoidFunction callback);
-  external JSPromise createImageBitmap(
+  external JSPromise<ImageBitmap> createImageBitmap(
     ImageBitmapSource image, [
     JSAny optionsOrSx,
     int sy,
@@ -4016,8 +4028,8 @@ extension type SharedWorker._(JSObject _) implements EventTarget, JSObject {
   external EventHandler get onerror;
 }
 extension type WorkerNavigator._(JSObject _) implements JSObject {
-  external JSPromise setAppBadge([int contents]);
-  external JSPromise clearAppBadge();
+  external JSPromise<JSAny?> setAppBadge([int contents]);
+  external JSPromise<JSAny?> clearAppBadge();
   external bool taintEnabled();
   external MediaCapabilities get mediaCapabilities;
   external Permissions get permissions;
@@ -4037,7 +4049,7 @@ extension type WorkerNavigator._(JSObject _) implements JSObject {
   external String get vendorSub;
   external String get oscpu;
   external String get language;
-  external JSArray get languages;
+  external JSArray<JSString> get languages;
   external bool get onLine;
   external int get hardwareConcurrency;
   external NetworkInformation get connection;
@@ -4061,7 +4073,7 @@ extension type WorkerLocation._(JSObject _) implements JSObject {
 }
 extension type WorkletGlobalScope._(JSObject _) implements JSObject {}
 extension type Worklet._(JSObject _) implements JSObject {
-  external JSPromise addModule(
+  external JSPromise<JSAny?> addModule(
     String moduleURL, [
     WorkletOptions options,
   ]);

--- a/lib/src/dom/idle_detection.dart
+++ b/lib/src/dom/idle_detection.dart
@@ -25,8 +25,8 @@ extension type IdleOptions._(JSObject _) implements JSObject {
 extension type IdleDetector._(JSObject _) implements EventTarget, JSObject {
   external factory IdleDetector();
 
-  external static JSPromise requestPermission();
-  external JSPromise start([IdleOptions options]);
+  external static JSPromise<JSString> requestPermission();
+  external JSPromise<JSAny?> start([IdleOptions options]);
   external UserIdleState? get userState;
   external ScreenIdleState? get screenState;
   external set onchange(EventHandler value);

--- a/lib/src/dom/image_capture.dart
+++ b/lib/src/dom/image_capture.dart
@@ -6,6 +6,8 @@
 
 import 'dart:js_interop';
 
+import 'fileapi.dart';
+import 'html.dart';
 import 'mediacapture_streams.dart';
 
 typedef ConstrainPoint2D = JSObject;
@@ -15,10 +17,10 @@ typedef MeteringMode = String;
 extension type ImageCapture._(JSObject _) implements JSObject {
   external factory ImageCapture(MediaStreamTrack videoTrack);
 
-  external JSPromise takePhoto([PhotoSettings photoSettings]);
-  external JSPromise getPhotoCapabilities();
-  external JSPromise getPhotoSettings();
-  external JSPromise grabFrame();
+  external JSPromise<Blob> takePhoto([PhotoSettings photoSettings]);
+  external JSPromise<PhotoCapabilities> getPhotoCapabilities();
+  external JSPromise<PhotoSettings> getPhotoSettings();
+  external JSPromise<ImageBitmap> grabFrame();
   external MediaStreamTrack get track;
 }
 extension type PhotoCapabilities._(JSObject _) implements JSObject {
@@ -26,7 +28,7 @@ extension type PhotoCapabilities._(JSObject _) implements JSObject {
     RedEyeReduction redEyeReduction,
     MediaSettingsRange imageHeight,
     MediaSettingsRange imageWidth,
-    JSArray fillLightMode,
+    JSArray<JSString> fillLightMode,
   });
 
   external set redEyeReduction(RedEyeReduction value);
@@ -35,8 +37,8 @@ extension type PhotoCapabilities._(JSObject _) implements JSObject {
   external MediaSettingsRange get imageHeight;
   external set imageWidth(MediaSettingsRange value);
   external MediaSettingsRange get imageWidth;
-  external set fillLightMode(JSArray value);
-  external JSArray get fillLightMode;
+  external set fillLightMode(JSArray<JSString> value);
+  external JSArray<JSString> get fillLightMode;
 }
 extension type PhotoSettings._(JSObject _) implements JSObject {
   external factory PhotoSettings({
@@ -71,14 +73,14 @@ extension type MediaSettingsRange._(JSObject _) implements JSObject {
 }
 extension type ConstrainPoint2DParameters._(JSObject _) implements JSObject {
   external factory ConstrainPoint2DParameters({
-    JSArray exact,
-    JSArray ideal,
+    JSArray<Point2D> exact,
+    JSArray<Point2D> ideal,
   });
 
-  external set exact(JSArray value);
-  external JSArray get exact;
-  external set ideal(JSArray value);
-  external JSArray get ideal;
+  external set exact(JSArray<Point2D> value);
+  external JSArray<Point2D> get exact;
+  external set ideal(JSArray<Point2D> value);
+  external JSArray<Point2D> get ideal;
 }
 extension type Point2D._(JSObject _) implements JSObject {
   external factory Point2D({

--- a/lib/src/dom/indexeddb.dart
+++ b/lib/src/dom/indexeddb.dart
@@ -58,7 +58,7 @@ extension type IDBFactory._(JSObject _) implements JSObject {
     int version,
   ]);
   external IDBOpenDBRequest deleteDatabase(String name);
-  external JSPromise databases();
+  external JSPromise<JSArray<IDBDatabaseInfo>> databases();
   external int cmp(
     JSAny? first,
     JSAny? second,

--- a/lib/src/dom/ink_enhancement.dart
+++ b/lib/src/dom/ink_enhancement.dart
@@ -10,7 +10,7 @@ import 'dom.dart';
 import 'pointerevents.dart';
 
 extension type Ink._(JSObject _) implements JSObject {
-  external JSPromise requestPresenter([InkPresenterParam param]);
+  external JSPromise<InkPresenter> requestPresenter([InkPresenterParam param]);
 }
 extension type InkPresenterParam._(JSObject _) implements JSObject {
   external factory InkPresenterParam({Element? presentationArea});

--- a/lib/src/dom/intersection_observer.dart
+++ b/lib/src/dom/intersection_observer.dart
@@ -20,11 +20,11 @@ extension type IntersectionObserver._(JSObject _) implements JSObject {
   external void observe(Element target);
   external void unobserve(Element target);
   external void disconnect();
-  external JSArray takeRecords();
+  external JSArray<IntersectionObserverEntry> takeRecords();
   external JSObject? get root;
   external String get rootMargin;
   external String get scrollMargin;
-  external JSArray get thresholds;
+  external JSArray<JSNumber> get thresholds;
 }
 extension type IntersectionObserverEntry._(JSObject _) implements JSObject {
   external factory IntersectionObserverEntry(

--- a/lib/src/dom/js_self_profiling.dart
+++ b/lib/src/dom/js_self_profiling.dart
@@ -13,26 +13,26 @@ typedef ProfilerResource = String;
 extension type Profiler._(JSObject _) implements EventTarget, JSObject {
   external factory Profiler(ProfilerInitOptions options);
 
-  external JSPromise stop();
+  external JSPromise<ProfilerTrace> stop();
   external DOMHighResTimeStamp get sampleInterval;
   external bool get stopped;
 }
 extension type ProfilerTrace._(JSObject _) implements JSObject {
   external factory ProfilerTrace({
-    required JSArray resources,
-    required JSArray frames,
-    required JSArray stacks,
-    required JSArray samples,
+    required JSArray<JSString> resources,
+    required JSArray<ProfilerFrame> frames,
+    required JSArray<ProfilerStack> stacks,
+    required JSArray<ProfilerSample> samples,
   });
 
-  external set resources(JSArray value);
-  external JSArray get resources;
-  external set frames(JSArray value);
-  external JSArray get frames;
-  external set stacks(JSArray value);
-  external JSArray get stacks;
-  external set samples(JSArray value);
-  external JSArray get samples;
+  external set resources(JSArray<JSString> value);
+  external JSArray<JSString> get resources;
+  external set frames(JSArray<ProfilerFrame> value);
+  external JSArray<ProfilerFrame> get frames;
+  external set stacks(JSArray<ProfilerStack> value);
+  external JSArray<ProfilerStack> get stacks;
+  external set samples(JSArray<ProfilerSample> value);
+  external JSArray<ProfilerSample> get samples;
 }
 extension type ProfilerSample._(JSObject _) implements JSObject {
   external factory ProfilerSample({

--- a/lib/src/dom/keyboard_lock.dart
+++ b/lib/src/dom/keyboard_lock.dart
@@ -8,11 +8,12 @@ import 'dart:js_interop';
 
 import 'dom.dart';
 import 'html.dart';
+import 'keyboard_map.dart';
 
 extension type Keyboard._(JSObject _) implements EventTarget, JSObject {
-  external JSPromise lock([JSArray keyCodes]);
+  external JSPromise<JSAny?> lock([JSArray<JSString> keyCodes]);
   external void unlock();
-  external JSPromise getLayoutMap();
+  external JSPromise<KeyboardLayoutMap> getLayoutMap();
   external set onlayoutchange(EventHandler value);
   external EventHandler get onlayoutchange;
 }

--- a/lib/src/dom/layout_instability.dart
+++ b/lib/src/dom/layout_instability.dart
@@ -16,7 +16,7 @@ extension type LayoutShift._(JSObject _) implements PerformanceEntry, JSObject {
   external num get value;
   external bool get hadRecentInput;
   external DOMHighResTimeStamp get lastInputTime;
-  external JSArray get sources;
+  external JSArray<LayoutShiftAttribution> get sources;
 }
 extension type LayoutShiftAttribution._(JSObject _) implements JSObject {
   external Node? get node;

--- a/lib/src/dom/local_font_access.dart
+++ b/lib/src/dom/local_font_access.dart
@@ -6,14 +6,16 @@
 
 import 'dart:js_interop';
 
-extension type QueryOptions._(JSObject _) implements JSObject {
-  external factory QueryOptions({JSArray postscriptNames});
+import 'fileapi.dart';
 
-  external set postscriptNames(JSArray value);
-  external JSArray get postscriptNames;
+extension type QueryOptions._(JSObject _) implements JSObject {
+  external factory QueryOptions({JSArray<JSString> postscriptNames});
+
+  external set postscriptNames(JSArray<JSString> value);
+  external JSArray<JSString> get postscriptNames;
 }
 extension type FontData._(JSObject _) implements JSObject {
-  external JSPromise blob();
+  external JSPromise<Blob> blob();
   external String get postscriptName;
   external String get fullName;
   external String get family;

--- a/lib/src/dom/longtasks.dart
+++ b/lib/src/dom/longtasks.dart
@@ -11,7 +11,7 @@ import 'performance_timeline.dart';
 extension type PerformanceLongTaskTiming._(JSObject _)
     implements PerformanceEntry, JSObject {
   external JSObject toJSON();
-  external JSArray get attribution;
+  external JSArray<TaskAttributionTiming> get attribution;
 }
 extension type TaskAttributionTiming._(JSObject _)
     implements PerformanceEntry, JSObject {

--- a/lib/src/dom/manifest_incubations.dart
+++ b/lib/src/dom/manifest_incubations.dart
@@ -16,7 +16,7 @@ extension type BeforeInstallPromptEvent._(JSObject _)
     EventInit eventInitDict,
   ]);
 
-  external JSPromise prompt();
+  external JSPromise<PromptResponseObject> prompt();
 }
 extension type PromptResponseObject._(JSObject _) implements JSObject {
   external factory PromptResponseObject({AppBannerPromptOutcome userChoice});

--- a/lib/src/dom/media_capabilities.dart
+++ b/lib/src/dom/media_capabilities.dart
@@ -110,7 +110,7 @@ extension type MediaCapabilitiesKeySystemConfiguration._(JSObject _)
     String initDataType,
     MediaKeysRequirement distinctiveIdentifier,
     MediaKeysRequirement persistentState,
-    JSArray sessionTypes,
+    JSArray<JSString> sessionTypes,
     KeySystemTrackConfiguration audio,
     KeySystemTrackConfiguration video,
   });
@@ -123,8 +123,8 @@ extension type MediaCapabilitiesKeySystemConfiguration._(JSObject _)
   external MediaKeysRequirement get distinctiveIdentifier;
   external set persistentState(MediaKeysRequirement value);
   external MediaKeysRequirement get persistentState;
-  external set sessionTypes(JSArray value);
-  external JSArray get sessionTypes;
+  external set sessionTypes(JSArray<JSString> value);
+  external JSArray<JSString> get sessionTypes;
   external set audio(KeySystemTrackConfiguration value);
   external KeySystemTrackConfiguration get audio;
   external set video(KeySystemTrackConfiguration value);
@@ -176,6 +176,8 @@ extension type MediaCapabilitiesEncodingInfo._(JSObject _)
   external MediaEncodingConfiguration get configuration;
 }
 extension type MediaCapabilities._(JSObject _) implements JSObject {
-  external JSPromise decodingInfo(MediaDecodingConfiguration configuration);
-  external JSPromise encodingInfo(MediaEncodingConfiguration configuration);
+  external JSPromise<MediaCapabilitiesDecodingInfo> decodingInfo(
+      MediaDecodingConfiguration configuration);
+  external JSPromise<MediaCapabilitiesEncodingInfo> encodingInfo(
+      MediaEncodingConfiguration configuration);
 }

--- a/lib/src/dom/mediacapture_region.dart
+++ b/lib/src/dom/mediacapture_region.dart
@@ -11,11 +11,11 @@ import 'element_capture.dart';
 import 'mediacapture_streams.dart';
 
 extension type CropTarget._(JSObject _) implements JSObject {
-  external static JSPromise fromElement(Element element);
+  external static JSPromise<CropTarget> fromElement(Element element);
 }
 extension type BrowserCaptureMediaStreamTrack._(JSObject _)
     implements MediaStreamTrack, JSObject {
-  external JSPromise restrictTo(RestrictionTarget? RestrictionTarget);
-  external JSPromise cropTo(CropTarget? cropTarget);
+  external JSPromise<JSAny?> restrictTo(RestrictionTarget? RestrictionTarget);
+  external JSPromise<JSAny?> cropTo(CropTarget? cropTarget);
   external BrowserCaptureMediaStreamTrack clone();
 }

--- a/lib/src/dom/mediacapture_streams.dart
+++ b/lib/src/dom/mediacapture_streams.dart
@@ -30,9 +30,9 @@ typedef MediaDeviceKind = String;
 extension type MediaStream._(JSObject _) implements EventTarget, JSObject {
   external factory MediaStream([JSObject streamOrTracks]);
 
-  external JSArray getAudioTracks();
-  external JSArray getVideoTracks();
-  external JSArray getTracks();
+  external JSArray<MediaStreamTrack> getAudioTracks();
+  external JSArray<MediaStreamTrack> getVideoTracks();
+  external JSArray<MediaStreamTrack> getTracks();
   external MediaStreamTrack? getTrackById(String trackId);
   external void addTrack(MediaStreamTrack track);
   external void removeTrack(MediaStreamTrack track);
@@ -46,14 +46,15 @@ extension type MediaStream._(JSObject _) implements EventTarget, JSObject {
 }
 extension type MediaStreamTrack._(JSObject _) implements EventTarget, JSObject {
   external CaptureHandle? getCaptureHandle();
-  external JSArray getSupportedCaptureActions();
-  external JSPromise sendCaptureAction(CaptureAction action);
+  external JSArray<JSString> getSupportedCaptureActions();
+  external JSPromise<JSAny?> sendCaptureAction(CaptureAction action);
   external MediaStreamTrack clone();
   external void stop();
   external MediaTrackCapabilities getCapabilities();
   external MediaTrackConstraints getConstraints();
   external MediaTrackSettings getSettings();
-  external JSPromise applyConstraints([MediaTrackConstraints constraints]);
+  external JSPromise<JSAny?> applyConstraints(
+      [MediaTrackConstraints constraints]);
   external set oncapturehandlechange(EventHandler value);
   external EventHandler get oncapturehandlechange;
   external String get kind;
@@ -194,9 +195,9 @@ extension type MediaTrackSupportedConstraints._(JSObject _)
 }
 extension type MediaTrackCapabilities._(JSObject _) implements JSObject {
   external factory MediaTrackCapabilities({
-    JSArray whiteBalanceMode,
-    JSArray exposureMode,
-    JSArray focusMode,
+    JSArray<JSString> whiteBalanceMode,
+    JSArray<JSString> exposureMode,
+    JSArray<JSString> focusMode,
     MediaSettingsRange exposureCompensation,
     MediaSettingsRange exposureTime,
     MediaSettingsRange colorTemperature,
@@ -214,28 +215,28 @@ extension type MediaTrackCapabilities._(JSObject _) implements JSObject {
     ULongRange height,
     DoubleRange aspectRatio,
     DoubleRange frameRate,
-    JSArray facingMode,
-    JSArray resizeMode,
+    JSArray<JSString> facingMode,
+    JSArray<JSString> resizeMode,
     ULongRange sampleRate,
     ULongRange sampleSize,
-    JSArray echoCancellation,
-    JSArray autoGainControl,
-    JSArray noiseSuppression,
+    JSArray<JSBoolean> echoCancellation,
+    JSArray<JSBoolean> autoGainControl,
+    JSArray<JSBoolean> noiseSuppression,
     DoubleRange latency,
     ULongRange channelCount,
     String deviceId,
     String groupId,
     String displaySurface,
     bool logicalSurface,
-    JSArray cursor,
+    JSArray<JSString> cursor,
   });
 
-  external set whiteBalanceMode(JSArray value);
-  external JSArray get whiteBalanceMode;
-  external set exposureMode(JSArray value);
-  external JSArray get exposureMode;
-  external set focusMode(JSArray value);
-  external JSArray get focusMode;
+  external set whiteBalanceMode(JSArray<JSString> value);
+  external JSArray<JSString> get whiteBalanceMode;
+  external set exposureMode(JSArray<JSString> value);
+  external JSArray<JSString> get exposureMode;
+  external set focusMode(JSArray<JSString> value);
+  external JSArray<JSString> get focusMode;
   external set exposureCompensation(MediaSettingsRange value);
   external MediaSettingsRange get exposureCompensation;
   external set exposureTime(MediaSettingsRange value);
@@ -270,20 +271,20 @@ extension type MediaTrackCapabilities._(JSObject _) implements JSObject {
   external DoubleRange get aspectRatio;
   external set frameRate(DoubleRange value);
   external DoubleRange get frameRate;
-  external set facingMode(JSArray value);
-  external JSArray get facingMode;
-  external set resizeMode(JSArray value);
-  external JSArray get resizeMode;
+  external set facingMode(JSArray<JSString> value);
+  external JSArray<JSString> get facingMode;
+  external set resizeMode(JSArray<JSString> value);
+  external JSArray<JSString> get resizeMode;
   external set sampleRate(ULongRange value);
   external ULongRange get sampleRate;
   external set sampleSize(ULongRange value);
   external ULongRange get sampleSize;
-  external set echoCancellation(JSArray value);
-  external JSArray get echoCancellation;
-  external set autoGainControl(JSArray value);
-  external JSArray get autoGainControl;
-  external set noiseSuppression(JSArray value);
-  external JSArray get noiseSuppression;
+  external set echoCancellation(JSArray<JSBoolean> value);
+  external JSArray<JSBoolean> get echoCancellation;
+  external set autoGainControl(JSArray<JSBoolean> value);
+  external JSArray<JSBoolean> get autoGainControl;
+  external set noiseSuppression(JSArray<JSBoolean> value);
+  external JSArray<JSBoolean> get noiseSuppression;
   external set latency(DoubleRange value);
   external DoubleRange get latency;
   external set channelCount(ULongRange value);
@@ -296,15 +297,16 @@ extension type MediaTrackCapabilities._(JSObject _) implements JSObject {
   external String get displaySurface;
   external set logicalSurface(bool value);
   external bool get logicalSurface;
-  external set cursor(JSArray value);
-  external JSArray get cursor;
+  external set cursor(JSArray<JSString> value);
+  external JSArray<JSString> get cursor;
 }
 extension type MediaTrackConstraints._(JSObject _)
     implements MediaTrackConstraintSet, JSObject {
-  external factory MediaTrackConstraints({JSArray advanced});
+  external factory MediaTrackConstraints(
+      {JSArray<MediaTrackConstraintSet> advanced});
 
-  external set advanced(JSArray value);
-  external JSArray get advanced;
+  external set advanced(JSArray<MediaTrackConstraintSet> value);
+  external JSArray<MediaTrackConstraintSet> get advanced;
 }
 extension type MediaTrackConstraintSet._(JSObject _) implements JSObject {
   external factory MediaTrackConstraintSet({
@@ -427,7 +429,7 @@ extension type MediaTrackSettings._(JSObject _) implements JSObject {
     String whiteBalanceMode,
     String exposureMode,
     String focusMode,
-    JSArray pointsOfInterest,
+    JSArray<Point2D> pointsOfInterest,
     num exposureCompensation,
     num exposureTime,
     num colorTemperature,
@@ -469,8 +471,8 @@ extension type MediaTrackSettings._(JSObject _) implements JSObject {
   external String get exposureMode;
   external set focusMode(String value);
   external String get focusMode;
-  external set pointsOfInterest(JSArray value);
-  external JSArray get pointsOfInterest;
+  external set pointsOfInterest(JSArray<Point2D> value);
+  external JSArray<Point2D> get pointsOfInterest;
   external set exposureCompensation(num value);
   external num get exposureCompensation;
   external set exposureTime(num value);
@@ -563,15 +565,18 @@ extension type OverconstrainedError._(JSObject _)
   external String get constraint;
 }
 extension type MediaDevices._(JSObject _) implements EventTarget, JSObject {
-  external JSPromise selectAudioOutput([AudioOutputOptions options]);
+  external JSPromise<MediaDeviceInfo> selectAudioOutput(
+      [AudioOutputOptions options]);
   external void setCaptureHandleConfig([CaptureHandleConfig config]);
-  external void setSupportedCaptureActions(JSArray actions);
-  external JSPromise enumerateDevices();
+  external void setSupportedCaptureActions(JSArray<JSString> actions);
+  external JSPromise<JSArray<MediaDeviceInfo>> enumerateDevices();
   external MediaTrackSupportedConstraints getSupportedConstraints();
-  external JSPromise getUserMedia([MediaStreamConstraints constraints]);
-  external JSPromise getViewportMedia(
+  external JSPromise<MediaStream> getUserMedia(
+      [MediaStreamConstraints constraints]);
+  external JSPromise<MediaStream> getViewportMedia(
       [ViewportMediaStreamConstraints constraints]);
-  external JSPromise getDisplayMedia([DisplayMediaStreamOptions options]);
+  external JSPromise<MediaStream> getDisplayMedia(
+      [DisplayMediaStreamOptions options]);
   external set oncaptureaction(EventHandler value);
   external EventHandler get oncaptureaction;
   external set ondevicechange(EventHandler value);

--- a/lib/src/dom/mediasession.dart
+++ b/lib/src/dom/mediasession.dart
@@ -31,15 +31,15 @@ extension type MediaMetadata._(JSObject _) implements JSObject {
   external String get artist;
   external set album(String value);
   external String get album;
-  external set artwork(JSArray value);
-  external JSArray get artwork;
+  external set artwork(JSArray<MediaImage> value);
+  external JSArray<MediaImage> get artwork;
 }
 extension type MediaMetadataInit._(JSObject _) implements JSObject {
   external factory MediaMetadataInit({
     String title,
     String artist,
     String album,
-    JSArray artwork,
+    JSArray<MediaImage> artwork,
   });
 
   external set title(String value);
@@ -48,8 +48,8 @@ extension type MediaMetadataInit._(JSObject _) implements JSObject {
   external String get artist;
   external set album(String value);
   external String get album;
-  external set artwork(JSArray value);
-  external JSArray get artwork;
+  external set artwork(JSArray<MediaImage> value);
+  external JSArray<MediaImage> get artwork;
 }
 extension type MediaImage._(JSObject _) implements JSObject {
   external factory MediaImage({

--- a/lib/src/dom/notifications.dart
+++ b/lib/src/dom/notifications.dart
@@ -21,7 +21,7 @@ extension type Notification._(JSObject _) implements EventTarget, JSObject {
     NotificationOptions options,
   ]);
 
-  external static JSPromise requestPermission(
+  external static JSPromise<JSString> requestPermission(
       [NotificationPermissionCallback deprecatedCallback]);
   external static NotificationPermission get permission;
   external static int get maxActions;
@@ -42,13 +42,13 @@ extension type Notification._(JSObject _) implements EventTarget, JSObject {
   external String get image;
   external String get icon;
   external String get badge;
-  external JSArray get vibrate;
+  external JSArray<JSNumber> get vibrate;
   external EpochTimeStamp get timestamp;
   external bool get renotify;
   external bool? get silent;
   external bool get requireInteraction;
   external JSAny? get data;
-  external JSArray get actions;
+  external JSArray<NotificationAction> get actions;
 }
 extension type NotificationOptions._(JSObject _) implements JSObject {
   external factory NotificationOptions({
@@ -65,7 +65,7 @@ extension type NotificationOptions._(JSObject _) implements JSObject {
     bool? silent,
     bool requireInteraction,
     JSAny? data,
-    JSArray actions,
+    JSArray<NotificationAction> actions,
   });
 
   external set dir(NotificationDirection value);
@@ -94,8 +94,8 @@ extension type NotificationOptions._(JSObject _) implements JSObject {
   external bool get requireInteraction;
   external set data(JSAny? value);
   external JSAny? get data;
-  external set actions(JSArray value);
-  external JSArray get actions;
+  external set actions(JSArray<NotificationAction> value);
+  external JSArray<NotificationAction> get actions;
 }
 extension type NotificationAction._(JSObject _) implements JSObject {
   external factory NotificationAction({

--- a/lib/src/dom/orientation_event.dart
+++ b/lib/src/dom/orientation_event.dart
@@ -14,7 +14,7 @@ extension type DeviceOrientationEvent._(JSObject _) implements Event, JSObject {
     DeviceOrientationEventInit eventInitDict,
   ]);
 
-  external static JSPromise requestPermission();
+  external static JSPromise<JSString> requestPermission();
   external num? get alpha;
   external num? get beta;
   external num? get gamma;
@@ -54,7 +54,7 @@ extension type DeviceMotionEvent._(JSObject _) implements Event, JSObject {
     DeviceMotionEventInit eventInitDict,
   ]);
 
-  external static JSPromise requestPermission();
+  external static JSPromise<JSString> requestPermission();
   external DeviceMotionEventAcceleration? get acceleration;
   external DeviceMotionEventAcceleration? get accelerationIncludingGravity;
   external DeviceMotionEventRotationRate? get rotationRate;

--- a/lib/src/dom/orientation_sensor.dart
+++ b/lib/src/dom/orientation_sensor.dart
@@ -12,7 +12,7 @@ typedef RotationMatrixType = JSObject;
 typedef OrientationSensorLocalCoordinateSystem = String;
 extension type OrientationSensor._(JSObject _) implements Sensor, JSObject {
   external void populateMatrix(RotationMatrixType targetMatrix);
-  external JSArray? get quaternion;
+  external JSArray<JSNumber>? get quaternion;
 }
 extension type OrientationSensorOptions._(JSObject _)
     implements SensorOptions, JSObject {
@@ -35,10 +35,10 @@ extension type RelativeOrientationSensor._(JSObject _)
 extension type AbsoluteOrientationReadingValues._(JSObject _)
     implements JSObject {
   external factory AbsoluteOrientationReadingValues(
-      {required JSArray? quaternion});
+      {required JSArray<JSNumber>? quaternion});
 
-  external set quaternion(JSArray? value);
-  external JSArray? get quaternion;
+  external set quaternion(JSArray<JSNumber>? value);
+  external JSArray<JSNumber>? get quaternion;
 }
 extension type RelativeOrientationReadingValues._(JSObject _)
     implements AbsoluteOrientationReadingValues, JSObject {

--- a/lib/src/dom/payment_handler.dart
+++ b/lib/src/dom/payment_handler.dart
@@ -12,7 +12,7 @@ import 'service_workers.dart';
 typedef PaymentDelegation = String;
 typedef PaymentShippingType = String;
 extension type PaymentManager._(JSObject _) implements JSObject {
-  external JSPromise enableDelegations(JSArray delegations);
+  external JSPromise<JSAny?> enableDelegations(JSArray<JSString> delegations);
   external set userHint(String value);
   external String get userHint;
 }
@@ -20,14 +20,14 @@ extension type CanMakePaymentEvent._(JSObject _)
     implements ExtendableEvent, JSObject {
   external factory CanMakePaymentEvent(String type);
 
-  external void respondWith(JSPromise canMakePaymentResponse);
+  external void respondWith(JSPromise<JSBoolean> canMakePaymentResponse);
 }
 extension type PaymentRequestDetailsUpdate._(JSObject _) implements JSObject {
   external factory PaymentRequestDetailsUpdate({
     String error,
     PaymentCurrencyAmount total,
-    JSArray modifiers,
-    JSArray shippingOptions,
+    JSArray<PaymentDetailsModifier> modifiers,
+    JSArray<PaymentShippingOption> shippingOptions,
     JSObject paymentMethodErrors,
     AddressErrors shippingAddressErrors,
   });
@@ -36,10 +36,10 @@ extension type PaymentRequestDetailsUpdate._(JSObject _) implements JSObject {
   external String get error;
   external set total(PaymentCurrencyAmount value);
   external PaymentCurrencyAmount get total;
-  external set modifiers(JSArray value);
-  external JSArray get modifiers;
-  external set shippingOptions(JSArray value);
-  external JSArray get shippingOptions;
+  external set modifiers(JSArray<PaymentDetailsModifier> value);
+  external JSArray<PaymentDetailsModifier> get modifiers;
+  external set shippingOptions(JSArray<PaymentShippingOption> value);
+  external JSArray<PaymentShippingOption> get shippingOptions;
   external set paymentMethodErrors(JSObject value);
   external JSObject get paymentMethodErrors;
   external set shippingAddressErrors(AddressErrors value);
@@ -52,22 +52,25 @@ extension type PaymentRequestEvent._(JSObject _)
     PaymentRequestEventInit eventInitDict,
   ]);
 
-  external JSPromise openWindow(String url);
-  external JSPromise changePaymentMethod(
+  external JSPromise<WindowClient?> openWindow(String url);
+  external JSPromise<PaymentRequestDetailsUpdate?> changePaymentMethod(
     String methodName, [
     JSObject? methodDetails,
   ]);
-  external JSPromise changeShippingAddress([AddressInit shippingAddress]);
-  external JSPromise changeShippingOption(String shippingOption);
-  external void respondWith(JSPromise handlerResponsePromise);
+  external JSPromise<PaymentRequestDetailsUpdate?> changeShippingAddress(
+      [AddressInit shippingAddress]);
+  external JSPromise<PaymentRequestDetailsUpdate?> changeShippingOption(
+      String shippingOption);
+  external void respondWith(
+      JSPromise<PaymentHandlerResponse> handlerResponsePromise);
   external String get topOrigin;
   external String get paymentRequestOrigin;
   external String get paymentRequestId;
-  external JSArray get methodData;
+  external JSArray<PaymentMethodData> get methodData;
   external JSObject get total;
-  external JSArray get modifiers;
+  external JSArray<PaymentDetailsModifier> get modifiers;
   external JSObject? get paymentOptions;
-  external JSArray? get shippingOptions;
+  external JSArray<PaymentShippingOption>? get shippingOptions;
 }
 extension type PaymentRequestEventInit._(JSObject _)
     implements ExtendableEventInit, JSObject {
@@ -75,11 +78,11 @@ extension type PaymentRequestEventInit._(JSObject _)
     String topOrigin,
     String paymentRequestOrigin,
     String paymentRequestId,
-    JSArray methodData,
+    JSArray<PaymentMethodData> methodData,
     PaymentCurrencyAmount total,
-    JSArray modifiers,
+    JSArray<PaymentDetailsModifier> modifiers,
     PaymentOptions paymentOptions,
-    JSArray shippingOptions,
+    JSArray<PaymentShippingOption> shippingOptions,
   });
 
   external set topOrigin(String value);
@@ -88,16 +91,16 @@ extension type PaymentRequestEventInit._(JSObject _)
   external String get paymentRequestOrigin;
   external set paymentRequestId(String value);
   external String get paymentRequestId;
-  external set methodData(JSArray value);
-  external JSArray get methodData;
+  external set methodData(JSArray<PaymentMethodData> value);
+  external JSArray<PaymentMethodData> get methodData;
   external set total(PaymentCurrencyAmount value);
   external PaymentCurrencyAmount get total;
-  external set modifiers(JSArray value);
-  external JSArray get modifiers;
+  external set modifiers(JSArray<PaymentDetailsModifier> value);
+  external JSArray<PaymentDetailsModifier> get modifiers;
   external set paymentOptions(PaymentOptions value);
   external PaymentOptions get paymentOptions;
-  external set shippingOptions(JSArray value);
-  external JSArray get shippingOptions;
+  external set shippingOptions(JSArray<PaymentShippingOption> value);
+  external JSArray<PaymentShippingOption> get shippingOptions;
 }
 extension type PaymentHandlerResponse._(JSObject _) implements JSObject {
   external factory PaymentHandlerResponse({
@@ -128,7 +131,7 @@ extension type PaymentHandlerResponse._(JSObject _) implements JSObject {
 extension type AddressInit._(JSObject _) implements JSObject {
   external factory AddressInit({
     String country,
-    JSArray addressLine,
+    JSArray<JSString> addressLine,
     String region,
     String city,
     String dependentLocality,
@@ -141,8 +144,8 @@ extension type AddressInit._(JSObject _) implements JSObject {
 
   external set country(String value);
   external String get country;
-  external set addressLine(JSArray value);
-  external JSArray get addressLine;
+  external set addressLine(JSArray<JSString> value);
+  external JSArray<JSString> get addressLine;
   external set region(String value);
   external String get region;
   external set city(String value);

--- a/lib/src/dom/payment_request.dart
+++ b/lib/src/dom/payment_request.dart
@@ -12,14 +12,15 @@ import 'html.dart';
 typedef PaymentComplete = String;
 extension type PaymentRequest._(JSObject _) implements EventTarget, JSObject {
   external factory PaymentRequest(
-    JSArray methodData,
+    JSArray<PaymentMethodData> methodData,
     PaymentDetailsInit details,
   );
 
-  external static JSPromise isSecurePaymentConfirmationAvailable();
-  external JSPromise show([JSPromise detailsPromise]);
-  external JSPromise abort();
-  external JSPromise canMakePayment();
+  external static JSPromise<JSBoolean> isSecurePaymentConfirmationAvailable();
+  external JSPromise<PaymentResponse> show(
+      [JSPromise<PaymentDetailsUpdate> detailsPromise]);
+  external JSPromise<JSAny?> abort();
+  external JSPromise<JSBoolean> canMakePayment();
   external String get id;
   external set onpaymentmethodchange(EventHandler value);
   external EventHandler get onpaymentmethodchange;
@@ -48,14 +49,14 @@ extension type PaymentCurrencyAmount._(JSObject _) implements JSObject {
 }
 extension type PaymentDetailsBase._(JSObject _) implements JSObject {
   external factory PaymentDetailsBase({
-    JSArray displayItems,
-    JSArray modifiers,
+    JSArray<PaymentItem> displayItems,
+    JSArray<PaymentDetailsModifier> modifiers,
   });
 
-  external set displayItems(JSArray value);
-  external JSArray get displayItems;
-  external set modifiers(JSArray value);
-  external JSArray get modifiers;
+  external set displayItems(JSArray<PaymentItem> value);
+  external JSArray<PaymentItem> get displayItems;
+  external set modifiers(JSArray<PaymentDetailsModifier> value);
+  external JSArray<PaymentDetailsModifier> get modifiers;
 }
 extension type PaymentDetailsInit._(JSObject _)
     implements PaymentDetailsBase, JSObject {
@@ -85,7 +86,7 @@ extension type PaymentDetailsModifier._(JSObject _) implements JSObject {
   external factory PaymentDetailsModifier({
     required String supportedMethods,
     PaymentItem total,
-    JSArray additionalDisplayItems,
+    JSArray<PaymentItem> additionalDisplayItems,
     JSObject data,
   });
 
@@ -93,8 +94,8 @@ extension type PaymentDetailsModifier._(JSObject _) implements JSObject {
   external String get supportedMethods;
   external set total(PaymentItem value);
   external PaymentItem get total;
-  external set additionalDisplayItems(JSArray value);
-  external JSArray get additionalDisplayItems;
+  external set additionalDisplayItems(JSArray<PaymentItem> value);
+  external JSArray<PaymentItem> get additionalDisplayItems;
   external set data(JSObject value);
   external JSObject get data;
 }
@@ -120,11 +121,11 @@ extension type PaymentCompleteDetails._(JSObject _) implements JSObject {
 }
 extension type PaymentResponse._(JSObject _) implements EventTarget, JSObject {
   external JSObject toJSON();
-  external JSPromise complete([
+  external JSPromise<JSAny?> complete([
     PaymentComplete result,
     PaymentCompleteDetails details,
   ]);
-  external JSPromise retry([PaymentValidationErrors errorFields]);
+  external JSPromise<JSAny?> retry([PaymentValidationErrors errorFields]);
   external String get requestId;
   external String get methodName;
   external JSObject get details;
@@ -169,7 +170,7 @@ extension type PaymentRequestUpdateEvent._(JSObject _)
     PaymentRequestUpdateEventInit eventInitDict,
   ]);
 
-  external void updateWith(JSPromise detailsPromise);
+  external void updateWith(JSPromise<PaymentDetailsUpdate> detailsPromise);
 }
 extension type PaymentRequestUpdateEventInit._(JSObject _)
     implements EventInit, JSObject {

--- a/lib/src/dom/performance_measure_memory.dart
+++ b/lib/src/dom/performance_measure_memory.dart
@@ -9,27 +9,27 @@ import 'dart:js_interop';
 extension type MemoryMeasurement._(JSObject _) implements JSObject {
   external factory MemoryMeasurement({
     int bytes,
-    JSArray breakdown,
+    JSArray<MemoryBreakdownEntry> breakdown,
   });
 
   external set bytes(int value);
   external int get bytes;
-  external set breakdown(JSArray value);
-  external JSArray get breakdown;
+  external set breakdown(JSArray<MemoryBreakdownEntry> value);
+  external JSArray<MemoryBreakdownEntry> get breakdown;
 }
 extension type MemoryBreakdownEntry._(JSObject _) implements JSObject {
   external factory MemoryBreakdownEntry({
     int bytes,
-    JSArray attribution,
-    JSArray types,
+    JSArray<MemoryAttribution> attribution,
+    JSArray<JSString> types,
   });
 
   external set bytes(int value);
   external int get bytes;
-  external set attribution(JSArray value);
-  external JSArray get attribution;
-  external set types(JSArray value);
-  external JSArray get types;
+  external set attribution(JSArray<MemoryAttribution> value);
+  external JSArray<MemoryAttribution> get attribution;
+  external set types(JSArray<JSString> value);
+  external JSArray<JSString> get types;
 }
 extension type MemoryAttribution._(JSObject _) implements JSObject {
   external factory MemoryAttribution({

--- a/lib/src/dom/performance_timeline.dart
+++ b/lib/src/dom/performance_timeline.dart
@@ -8,7 +8,7 @@ import 'dart:js_interop';
 
 import 'hr_time.dart';
 
-typedef PerformanceEntryList = JSArray;
+typedef PerformanceEntryList = JSArray<PerformanceEntry>;
 typedef PerformanceObserverCallback = JSFunction;
 extension type PerformanceEntry._(JSObject _) implements JSObject {
   external JSObject toJSON();
@@ -20,7 +20,7 @@ extension type PerformanceEntry._(JSObject _) implements JSObject {
 extension type PerformanceObserver._(JSObject _) implements JSObject {
   external factory PerformanceObserver(PerformanceObserverCallback callback);
 
-  external static JSArray get supportedEntryTypes;
+  external static JSArray<JSString> get supportedEntryTypes;
   external void observe([PerformanceObserverInit options]);
   external void disconnect();
   external PerformanceEntryList takeRecords();
@@ -36,15 +36,15 @@ extension type PerformanceObserverCallbackOptions._(JSObject _)
 extension type PerformanceObserverInit._(JSObject _) implements JSObject {
   external factory PerformanceObserverInit({
     DOMHighResTimeStamp durationThreshold,
-    JSArray entryTypes,
+    JSArray<JSString> entryTypes,
     String type,
     bool buffered,
   });
 
   external set durationThreshold(DOMHighResTimeStamp value);
   external DOMHighResTimeStamp get durationThreshold;
-  external set entryTypes(JSArray value);
-  external JSArray get entryTypes;
+  external set entryTypes(JSArray<JSString> value);
+  external JSArray<JSString> get entryTypes;
   external set type(String value);
   external String get type;
   external set buffered(bool value);

--- a/lib/src/dom/periodic_background_sync.dart
+++ b/lib/src/dom/periodic_background_sync.dart
@@ -9,12 +9,12 @@ import 'dart:js_interop';
 import 'service_workers.dart';
 
 extension type PeriodicSyncManager._(JSObject _) implements JSObject {
-  external JSPromise register(
+  external JSPromise<JSAny?> register(
     String tag, [
     BackgroundSyncOptions options,
   ]);
-  external JSPromise getTags();
-  external JSPromise unregister(String tag);
+  external JSPromise<JSArray<JSString>> getTags();
+  external JSPromise<JSAny?> unregister(String tag);
 }
 extension type BackgroundSyncOptions._(JSObject _) implements JSObject {
   external factory BackgroundSyncOptions({int minInterval});

--- a/lib/src/dom/permissions.dart
+++ b/lib/src/dom/permissions.dart
@@ -11,9 +11,9 @@ import 'html.dart';
 
 typedef PermissionState = String;
 extension type Permissions._(JSObject _) implements JSObject {
-  external JSPromise request(JSObject permissionDesc);
-  external JSPromise revoke(JSObject permissionDesc);
-  external JSPromise query(JSObject permissionDesc);
+  external JSPromise<PermissionStatus> request(JSObject permissionDesc);
+  external JSPromise<PermissionStatus> revoke(JSObject permissionDesc);
+  external JSPromise<PermissionStatus> query(JSObject permissionDesc);
 }
 extension type PermissionDescriptor._(JSObject _) implements JSObject {
   external factory PermissionDescriptor({required String name});

--- a/lib/src/dom/permissions_policy.dart
+++ b/lib/src/dom/permissions_policy.dart
@@ -13,9 +13,9 @@ extension type PermissionsPolicy._(JSObject _) implements JSObject {
     String feature, [
     String origin,
   ]);
-  external JSArray features();
-  external JSArray allowedFeatures();
-  external JSArray getAllowlistForFeature(String feature);
+  external JSArray<JSString> features();
+  external JSArray<JSString> allowedFeatures();
+  external JSArray<JSString> getAllowlistForFeature(String feature);
 }
 extension type PermissionsPolicyViolationReportBody._(JSObject _)
     implements ReportBody, JSObject {

--- a/lib/src/dom/pointerevents.dart
+++ b/lib/src/dom/pointerevents.dart
@@ -23,8 +23,8 @@ extension type PointerEventInit._(JSObject _)
     num azimuthAngle,
     String pointerType,
     bool isPrimary,
-    JSArray coalescedEvents,
-    JSArray predictedEvents,
+    JSArray<PointerEvent> coalescedEvents,
+    JSArray<PointerEvent> predictedEvents,
   });
 
   external set pointerId(int value);
@@ -51,10 +51,10 @@ extension type PointerEventInit._(JSObject _)
   external String get pointerType;
   external set isPrimary(bool value);
   external bool get isPrimary;
-  external set coalescedEvents(JSArray value);
-  external JSArray get coalescedEvents;
-  external set predictedEvents(JSArray value);
-  external JSArray get predictedEvents;
+  external set coalescedEvents(JSArray<PointerEvent> value);
+  external JSArray<PointerEvent> get coalescedEvents;
+  external set predictedEvents(JSArray<PointerEvent> value);
+  external JSArray<PointerEvent> get predictedEvents;
 }
 extension type PointerEvent._(JSObject _) implements MouseEvent, JSObject {
   external factory PointerEvent(
@@ -62,8 +62,8 @@ extension type PointerEvent._(JSObject _) implements MouseEvent, JSObject {
     PointerEventInit eventInitDict,
   ]);
 
-  external JSArray getCoalescedEvents();
-  external JSArray getPredictedEvents();
+  external JSArray<PointerEvent> getCoalescedEvents();
+  external JSArray<PointerEvent> getPredictedEvents();
   external int get pointerId;
   external num get width;
   external num get height;

--- a/lib/src/dom/portals.dart
+++ b/lib/src/dom/portals.dart
@@ -13,7 +13,7 @@ extension type HTMLPortalElement._(JSObject _)
     implements HTMLElement, JSObject {
   external factory HTMLPortalElement();
 
-  external JSPromise activate([PortalActivateOptions options]);
+  external JSPromise<JSAny?> activate([PortalActivateOptions options]);
   external void postMessage(
     JSAny? message, [
     StructuredSerializeOptions options,

--- a/lib/src/dom/presentation_api.dart
+++ b/lib/src/dom/presentation_api.dart
@@ -21,9 +21,9 @@ extension type PresentationRequest._(JSObject _)
     implements EventTarget, JSObject {
   external factory PresentationRequest(JSAny urlOrUrls);
 
-  external JSPromise start();
-  external JSPromise reconnect(String presentationId);
-  external JSPromise getAvailability();
+  external JSPromise<PresentationConnection> start();
+  external JSPromise<PresentationConnection> reconnect(String presentationId);
+  external JSPromise<PresentationAvailability> getAvailability();
   external set onconnectionavailable(EventHandler value);
   external EventHandler get onconnectionavailable;
 }
@@ -92,11 +92,11 @@ extension type PresentationConnectionCloseEventInit._(JSObject _)
   external String get message;
 }
 extension type PresentationReceiver._(JSObject _) implements JSObject {
-  external JSPromise get connectionList;
+  external JSPromise<PresentationConnectionList> get connectionList;
 }
 extension type PresentationConnectionList._(JSObject _)
     implements EventTarget, JSObject {
-  external JSArray get connections;
+  external JSArray<PresentationConnection> get connections;
   external set onconnectionavailable(EventHandler value);
   external EventHandler get onconnectionavailable;
 }

--- a/lib/src/dom/push_api.dart
+++ b/lib/src/dom/push_api.dart
@@ -21,10 +21,12 @@ extension type PushPermissionDescriptor._(JSObject _)
   external bool get userVisibleOnly;
 }
 extension type PushManager._(JSObject _) implements JSObject {
-  external static JSArray get supportedContentEncodings;
-  external JSPromise subscribe([PushSubscriptionOptionsInit options]);
-  external JSPromise getSubscription();
-  external JSPromise permissionState([PushSubscriptionOptionsInit options]);
+  external static JSArray<JSString> get supportedContentEncodings;
+  external JSPromise<PushSubscription> subscribe(
+      [PushSubscriptionOptionsInit options]);
+  external JSPromise<PushSubscription?> getSubscription();
+  external JSPromise<JSString> permissionState(
+      [PushSubscriptionOptionsInit options]);
 }
 extension type PushSubscriptionOptions._(JSObject _) implements JSObject {
   external bool get userVisibleOnly;
@@ -43,7 +45,7 @@ extension type PushSubscriptionOptionsInit._(JSObject _) implements JSObject {
 }
 extension type PushSubscription._(JSObject _) implements JSObject {
   external JSArrayBuffer? getKey(PushEncryptionKeyName name);
-  external JSPromise unsubscribe();
+  external JSPromise<JSBoolean> unsubscribe();
   external PushSubscriptionJSON toJSON();
   external String get endpoint;
   external EpochTimeStamp? get expirationTime;

--- a/lib/src/dom/real_world_meshing.dart
+++ b/lib/src/dom/real_world_meshing.dart
@@ -11,7 +11,7 @@ import 'webxr.dart';
 
 extension type XRMesh._(JSObject _) implements JSObject {
   external XRSpace get meshSpace;
-  external JSArray get vertices;
+  external JSArray<JSFloat32Array> get vertices;
   external JSUint32Array get indices;
   external DOMHighResTimeStamp get lastChangedTime;
   external String? get semanticLabel;

--- a/lib/src/dom/remote_playback.dart
+++ b/lib/src/dom/remote_playback.dart
@@ -12,10 +12,10 @@ import 'html.dart';
 typedef RemotePlaybackAvailabilityCallback = JSFunction;
 typedef RemotePlaybackState = String;
 extension type RemotePlayback._(JSObject _) implements EventTarget, JSObject {
-  external JSPromise watchAvailability(
+  external JSPromise<JSNumber> watchAvailability(
       RemotePlaybackAvailabilityCallback callback);
-  external JSPromise cancelWatchAvailability([int id]);
-  external JSPromise prompt();
+  external JSPromise<JSAny?> cancelWatchAvailability([int id]);
+  external JSPromise<JSAny?> prompt();
   external RemotePlaybackState get state;
   external set onconnecting(EventHandler value);
   external EventHandler get onconnecting;

--- a/lib/src/dom/reporting.dart
+++ b/lib/src/dom/reporting.dart
@@ -6,7 +6,7 @@
 
 import 'dart:js_interop';
 
-typedef ReportList = JSArray;
+typedef ReportList = JSArray<Report>;
 typedef ReportingObserverCallback = JSFunction;
 extension type ReportBody._(JSObject _) implements JSObject {
   external JSObject toJSON();
@@ -29,12 +29,12 @@ extension type ReportingObserver._(JSObject _) implements JSObject {
 }
 extension type ReportingObserverOptions._(JSObject _) implements JSObject {
   external factory ReportingObserverOptions({
-    JSArray types,
+    JSArray<JSString> types,
     bool buffered,
   });
 
-  external set types(JSArray value);
-  external JSArray get types;
+  external set types(JSArray<JSString> value);
+  external JSArray<JSString> get types;
   external set buffered(bool value);
   external bool get buffered;
 }

--- a/lib/src/dom/resize_observer.dart
+++ b/lib/src/dom/resize_observer.dart
@@ -30,9 +30,9 @@ extension type ResizeObserver._(JSObject _) implements JSObject {
 extension type ResizeObserverEntry._(JSObject _) implements JSObject {
   external Element get target;
   external DOMRectReadOnly get contentRect;
-  external JSArray get borderBoxSize;
-  external JSArray get contentBoxSize;
-  external JSArray get devicePixelContentBoxSize;
+  external JSArray<ResizeObserverSize> get borderBoxSize;
+  external JSArray<ResizeObserverSize> get contentBoxSize;
+  external JSArray<ResizeObserverSize> get devicePixelContentBoxSize;
 }
 extension type ResizeObserverSize._(JSObject _) implements JSObject {
   external num get inlineSize;

--- a/lib/src/dom/resource_timing.dart
+++ b/lib/src/dom/resource_timing.dart
@@ -8,6 +8,7 @@ import 'dart:js_interop';
 
 import 'hr_time.dart';
 import 'performance_timeline.dart';
+import 'server_timing.dart';
 
 typedef RenderBlockingStatusType = String;
 extension type PerformanceResourceTiming._(JSObject _)
@@ -35,5 +36,5 @@ extension type PerformanceResourceTiming._(JSObject _)
   external int get responseStatus;
   external RenderBlockingStatusType get renderBlockingStatus;
   external String get contentType;
-  external JSArray get serverTiming;
+  external JSArray<PerformanceServerTiming> get serverTiming;
 }

--- a/lib/src/dom/sanitizer_api.dart
+++ b/lib/src/dom/sanitizer_api.dart
@@ -28,9 +28,9 @@ extension type SetHTMLOptions._(JSObject _) implements JSObject {
 }
 extension type SanitizerConfig._(JSObject _) implements JSObject {
   external factory SanitizerConfig({
-    JSArray allowElements,
-    JSArray blockElements,
-    JSArray dropElements,
+    JSArray<JSString> allowElements,
+    JSArray<JSString> blockElements,
+    JSArray<JSString> dropElements,
     AttributeMatchList allowAttributes,
     AttributeMatchList dropAttributes,
     bool allowCustomElements,
@@ -38,12 +38,12 @@ extension type SanitizerConfig._(JSObject _) implements JSObject {
     bool allowComments,
   });
 
-  external set allowElements(JSArray value);
-  external JSArray get allowElements;
-  external set blockElements(JSArray value);
-  external JSArray get blockElements;
-  external set dropElements(JSArray value);
-  external JSArray get dropElements;
+  external set allowElements(JSArray<JSString> value);
+  external JSArray<JSString> get allowElements;
+  external set blockElements(JSArray<JSString> value);
+  external JSArray<JSString> get blockElements;
+  external set dropElements(JSArray<JSString> value);
+  external JSArray<JSString> get dropElements;
   external set allowAttributes(AttributeMatchList value);
   external AttributeMatchList get allowAttributes;
   external set dropAttributes(AttributeMatchList value);

--- a/lib/src/dom/scheduling_apis.dart
+++ b/lib/src/dom/scheduling_apis.dart
@@ -26,7 +26,7 @@ extension type SchedulerPostTaskOptions._(JSObject _) implements JSObject {
   external int get delay;
 }
 extension type Scheduler._(JSObject _) implements JSObject {
-  external JSPromise postTask(
+  external JSPromise<JSAny?> postTask(
     SchedulerPostTaskCallback callback, [
     SchedulerPostTaskOptions options,
   ]);
@@ -68,7 +68,7 @@ extension type TaskSignalAnyInit._(JSObject _) implements JSObject {
 }
 extension type TaskSignal._(JSObject _) implements AbortSignal, JSObject {
   external static TaskSignal any(
-    JSArray signals, [
+    JSArray<AbortSignal> signals, [
     TaskSignalAnyInit init,
   ]);
   external TaskPriority get priority;

--- a/lib/src/dom/screen_orientation.dart
+++ b/lib/src/dom/screen_orientation.dart
@@ -13,7 +13,7 @@ typedef OrientationLockType = String;
 typedef OrientationType = String;
 extension type ScreenOrientation._(JSObject _)
     implements EventTarget, JSObject {
-  external JSPromise lock(OrientationLockType orientation);
+  external JSPromise<JSAny?> lock(OrientationLockType orientation);
   external void unlock();
   external OrientationType get type;
   external int get angle;

--- a/lib/src/dom/screen_wake_lock.dart
+++ b/lib/src/dom/screen_wake_lock.dart
@@ -11,10 +11,10 @@ import 'html.dart';
 
 typedef WakeLockType = String;
 extension type WakeLock._(JSObject _) implements JSObject {
-  external JSPromise request([WakeLockType type]);
+  external JSPromise<WakeLockSentinel> request([WakeLockType type]);
 }
 extension type WakeLockSentinel._(JSObject _) implements EventTarget, JSObject {
-  external JSPromise release();
+  external JSPromise<JSAny?> release();
   external bool get released;
   external WakeLockType get type;
   external set onrelease(EventHandler value);

--- a/lib/src/dom/secure_payment_confirmation.dart
+++ b/lib/src/dom/secure_payment_confirmation.dart
@@ -15,13 +15,13 @@ extension type SecurePaymentConfirmationRequest._(JSObject _)
   external factory SecurePaymentConfirmationRequest({
     required BufferSource challenge,
     required String rpId,
-    required JSArray credentialIds,
+    required JSArray<BufferSource> credentialIds,
     required PaymentCredentialInstrument instrument,
     int timeout,
     String payeeName,
     String payeeOrigin,
     AuthenticationExtensionsClientInputs extensions,
-    JSArray locale,
+    JSArray<JSString> locale,
     bool showOptOut,
   });
 
@@ -29,8 +29,8 @@ extension type SecurePaymentConfirmationRequest._(JSObject _)
   external BufferSource get challenge;
   external set rpId(String value);
   external String get rpId;
-  external set credentialIds(JSArray value);
-  external JSArray get credentialIds;
+  external set credentialIds(JSArray<BufferSource> value);
+  external JSArray<BufferSource> get credentialIds;
   external set instrument(PaymentCredentialInstrument value);
   external PaymentCredentialInstrument get instrument;
   external set timeout(int value);
@@ -41,8 +41,8 @@ extension type SecurePaymentConfirmationRequest._(JSObject _)
   external String get payeeOrigin;
   external set extensions(AuthenticationExtensionsClientInputs value);
   external AuthenticationExtensionsClientInputs get extensions;
-  external set locale(JSArray value);
-  external JSArray get locale;
+  external set locale(JSArray<JSString> value);
+  external JSArray<JSString> get locale;
   external set showOptOut(bool value);
   external bool get showOptOut;
 }

--- a/lib/src/dom/selection_api.dart
+++ b/lib/src/dom/selection_api.dart
@@ -14,7 +14,7 @@ extension type Selection._(JSObject _) implements JSObject {
   external void removeRange(Range range);
   external void removeAllRanges();
   external void empty();
-  external JSArray getComposedRanges(ShadowRoot shadowRoots);
+  external JSArray<StaticRange> getComposedRanges(ShadowRoot shadowRoots);
   external void collapse(
     Node? node, [
     int offset,

--- a/lib/src/dom/serial.dart
+++ b/lib/src/dom/serial.dart
@@ -14,8 +14,9 @@ import 'web_bluetooth.dart';
 typedef ParityType = String;
 typedef FlowControlType = String;
 extension type Serial._(JSObject _) implements EventTarget, JSObject {
-  external JSPromise getPorts();
-  external JSPromise requestPort([SerialPortRequestOptions options]);
+  external JSPromise<JSArray<SerialPort>> getPorts();
+  external JSPromise<SerialPort> requestPort(
+      [SerialPortRequestOptions options]);
   external set onconnect(EventHandler value);
   external EventHandler get onconnect;
   external set ondisconnect(EventHandler value);
@@ -23,14 +24,15 @@ extension type Serial._(JSObject _) implements EventTarget, JSObject {
 }
 extension type SerialPortRequestOptions._(JSObject _) implements JSObject {
   external factory SerialPortRequestOptions({
-    JSArray filters,
-    JSArray allowedBluetoothServiceClassIds,
+    JSArray<SerialPortFilter> filters,
+    JSArray<BluetoothServiceUUID> allowedBluetoothServiceClassIds,
   });
 
-  external set filters(JSArray value);
-  external JSArray get filters;
-  external set allowedBluetoothServiceClassIds(JSArray value);
-  external JSArray get allowedBluetoothServiceClassIds;
+  external set filters(JSArray<SerialPortFilter> value);
+  external JSArray<SerialPortFilter> get filters;
+  external set allowedBluetoothServiceClassIds(
+      JSArray<BluetoothServiceUUID> value);
+  external JSArray<BluetoothServiceUUID> get allowedBluetoothServiceClassIds;
 }
 extension type SerialPortFilter._(JSObject _) implements JSObject {
   external factory SerialPortFilter({
@@ -48,11 +50,11 @@ extension type SerialPortFilter._(JSObject _) implements JSObject {
 }
 extension type SerialPort._(JSObject _) implements EventTarget, JSObject {
   external SerialPortInfo getInfo();
-  external JSPromise open(SerialOptions options);
-  external JSPromise setSignals([SerialOutputSignals signals]);
-  external JSPromise getSignals();
-  external JSPromise close();
-  external JSPromise forget();
+  external JSPromise<JSAny?> open(SerialOptions options);
+  external JSPromise<JSAny?> setSignals([SerialOutputSignals signals]);
+  external JSPromise<SerialInputSignals> getSignals();
+  external JSPromise<JSAny?> close();
+  external JSPromise<JSAny?> forget();
   external set onconnect(EventHandler value);
   external EventHandler get onconnect;
   external set ondisconnect(EventHandler value);

--- a/lib/src/dom/service_workers.dart
+++ b/lib/src/dom/service_workers.dart
@@ -37,13 +37,14 @@ extension type ServiceWorker._(JSObject _) implements EventTarget, JSObject {
 }
 extension type ServiceWorkerRegistration._(JSObject _)
     implements EventTarget, JSObject {
-  external JSPromise showNotification(
+  external JSPromise<JSAny?> showNotification(
     String title, [
     NotificationOptions options,
   ]);
-  external JSPromise getNotifications([GetNotificationOptions filter]);
-  external JSPromise update();
-  external JSPromise unregister();
+  external JSPromise<JSArray<Notification>> getNotifications(
+      [GetNotificationOptions filter]);
+  external JSPromise<JSAny?> update();
+  external JSPromise<JSBoolean> unregister();
   external BackgroundFetchManager get backgroundFetch;
   external SyncManager get sync;
   external ContentIndex get index;
@@ -62,15 +63,16 @@ extension type ServiceWorkerRegistration._(JSObject _)
 }
 extension type ServiceWorkerContainer._(JSObject _)
     implements EventTarget, JSObject {
-  external JSPromise register(
+  external JSPromise<ServiceWorkerRegistration> register(
     String scriptURL, [
     RegistrationOptions options,
   ]);
-  external JSPromise getRegistration([String clientURL]);
-  external JSPromise getRegistrations();
+  external JSPromise<ServiceWorkerRegistration?> getRegistration(
+      [String clientURL]);
+  external JSPromise<JSArray<ServiceWorkerRegistration>> getRegistrations();
   external void startMessages();
   external ServiceWorker? get controller;
-  external JSPromise get ready;
+  external JSPromise<ServiceWorkerRegistration> get ready;
   external set oncontrollerchange(EventHandler value);
   external EventHandler get oncontrollerchange;
   external set onmessage(EventHandler value);
@@ -93,10 +95,10 @@ extension type RegistrationOptions._(JSObject _) implements JSObject {
   external ServiceWorkerUpdateViaCache get updateViaCache;
 }
 extension type NavigationPreloadManager._(JSObject _) implements JSObject {
-  external JSPromise enable();
-  external JSPromise disable();
-  external JSPromise setHeaderValue(String value);
-  external JSPromise getState();
+  external JSPromise<JSAny?> enable();
+  external JSPromise<JSAny?> disable();
+  external JSPromise<JSAny?> setHeaderValue(String value);
+  external JSPromise<NavigationPreloadState> getState();
 }
 extension type NavigationPreloadState._(JSObject _) implements JSObject {
   external factory NavigationPreloadState({
@@ -111,7 +113,7 @@ extension type NavigationPreloadState._(JSObject _) implements JSObject {
 }
 extension type ServiceWorkerGlobalScope._(JSObject _)
     implements WorkerGlobalScope, JSObject {
-  external JSPromise skipWaiting();
+  external JSPromise<JSAny?> skipWaiting();
   external set onbackgroundfetchsuccess(EventHandler value);
   external EventHandler get onbackgroundfetchsuccess;
   external set onbackgroundfetchfail(EventHandler value);
@@ -167,17 +169,17 @@ extension type Client._(JSObject _) implements JSObject {
   external ClientType get type;
 }
 extension type WindowClient._(JSObject _) implements Client, JSObject {
-  external JSPromise focus();
-  external JSPromise navigate(String url);
+  external JSPromise<WindowClient> focus();
+  external JSPromise<WindowClient?> navigate(String url);
   external DocumentVisibilityState get visibilityState;
   external bool get focused;
-  external JSArray get ancestorOrigins;
+  external JSArray<JSString> get ancestorOrigins;
 }
 extension type Clients._(JSObject _) implements JSObject {
-  external JSPromise get(String id);
-  external JSPromise matchAll([ClientQueryOptions options]);
-  external JSPromise openWindow(String url);
-  external JSPromise claim();
+  external JSPromise<Client?> get(String id);
+  external JSPromise<JSArray<Client>> matchAll([ClientQueryOptions options]);
+  external JSPromise<WindowClient?> openWindow(String url);
+  external JSPromise<JSAny?> claim();
 }
 extension type ClientQueryOptions._(JSObject _) implements JSObject {
   external factory ClientQueryOptions({
@@ -196,7 +198,7 @@ extension type ExtendableEvent._(JSObject _) implements Event, JSObject {
     ExtendableEventInit eventInitDict,
   ]);
 
-  external void waitUntil(JSPromise f);
+  external void waitUntil(JSPromise<JSAny?> f);
 }
 extension type ExtendableEventInit._(JSObject _)
     implements EventInit, JSObject {
@@ -208,37 +210,37 @@ extension type FetchEvent._(JSObject _) implements ExtendableEvent, JSObject {
     FetchEventInit eventInitDict,
   );
 
-  external void respondWith(JSPromise r);
+  external void respondWith(JSPromise<Response> r);
   external Request get request;
-  external JSPromise get preloadResponse;
+  external JSPromise<JSAny?> get preloadResponse;
   external String get clientId;
   external String get resultingClientId;
   external String get replacesClientId;
-  external JSPromise get handled;
+  external JSPromise<JSAny?> get handled;
 }
 extension type FetchEventInit._(JSObject _)
     implements ExtendableEventInit, JSObject {
   external factory FetchEventInit({
     required Request request,
-    JSPromise preloadResponse,
+    JSPromise<JSAny?> preloadResponse,
     String clientId,
     String resultingClientId,
     String replacesClientId,
-    JSPromise handled,
+    JSPromise<JSAny?> handled,
   });
 
   external set request(Request value);
   external Request get request;
-  external set preloadResponse(JSPromise value);
-  external JSPromise get preloadResponse;
+  external set preloadResponse(JSPromise<JSAny?> value);
+  external JSPromise<JSAny?> get preloadResponse;
   external set clientId(String value);
   external String get clientId;
   external set resultingClientId(String value);
   external String get resultingClientId;
   external set replacesClientId(String value);
   external String get replacesClientId;
-  external set handled(JSPromise value);
-  external JSPromise get handled;
+  external set handled(JSPromise<JSAny?> value);
+  external JSPromise<JSAny?> get handled;
 }
 extension type ExtendableMessageEvent._(JSObject _)
     implements ExtendableEvent, JSObject {
@@ -251,7 +253,7 @@ extension type ExtendableMessageEvent._(JSObject _)
   external String get origin;
   external String get lastEventId;
   external JSObject? get source;
-  external JSArray get ports;
+  external JSArray<MessagePort> get ports;
 }
 extension type ExtendableMessageEventInit._(JSObject _)
     implements ExtendableEventInit, JSObject {
@@ -260,7 +262,7 @@ extension type ExtendableMessageEventInit._(JSObject _)
     String origin,
     String lastEventId,
     JSObject? source,
-    JSArray ports,
+    JSArray<MessagePort> ports,
   });
 
   external set data(JSAny? value);
@@ -271,29 +273,29 @@ extension type ExtendableMessageEventInit._(JSObject _)
   external String get lastEventId;
   external set source(JSObject? value);
   external JSObject? get source;
-  external set ports(JSArray value);
-  external JSArray get ports;
+  external set ports(JSArray<MessagePort> value);
+  external JSArray<MessagePort> get ports;
 }
 extension type Cache._(JSObject _) implements JSObject {
-  external JSPromise match(
+  external JSPromise<Response?> match(
     RequestInfo request, [
     CacheQueryOptions options,
   ]);
-  external JSPromise matchAll([
+  external JSPromise<JSArray<Response>> matchAll([
     RequestInfo request,
     CacheQueryOptions options,
   ]);
-  external JSPromise add(RequestInfo request);
-  external JSPromise addAll(JSArray requests);
-  external JSPromise put(
+  external JSPromise<JSAny?> add(RequestInfo request);
+  external JSPromise<JSAny?> addAll(JSArray<RequestInfo> requests);
+  external JSPromise<JSAny?> put(
     RequestInfo request,
     Response response,
   );
-  external JSPromise delete(
+  external JSPromise<JSBoolean> delete(
     RequestInfo request, [
     CacheQueryOptions options,
   ]);
-  external JSPromise keys([
+  external JSPromise<JSArray<Request>> keys([
     RequestInfo request,
     CacheQueryOptions options,
   ]);
@@ -313,14 +315,14 @@ extension type CacheQueryOptions._(JSObject _) implements JSObject {
   external bool get ignoreVary;
 }
 extension type CacheStorage._(JSObject _) implements JSObject {
-  external JSPromise match(
+  external JSPromise<Response?> match(
     RequestInfo request, [
     MultiCacheQueryOptions options,
   ]);
-  external JSPromise has(String cacheName);
-  external JSPromise open(String cacheName);
-  external JSPromise delete(String cacheName);
-  external JSPromise keys();
+  external JSPromise<JSBoolean> has(String cacheName);
+  external JSPromise<Cache> open(String cacheName);
+  external JSPromise<JSBoolean> delete(String cacheName);
+  external JSPromise<JSArray<JSString>> keys();
 }
 extension type MultiCacheQueryOptions._(JSObject _)
     implements CacheQueryOptions, JSObject {

--- a/lib/src/dom/shape_detection_api.dart
+++ b/lib/src/dom/shape_detection_api.dart
@@ -8,13 +8,14 @@ import 'dart:js_interop';
 
 import 'geometry.dart';
 import 'html.dart';
+import 'image_capture.dart';
 
 typedef LandmarkType = String;
 typedef BarcodeFormat = String;
 extension type FaceDetector._(JSObject _) implements JSObject {
   external factory FaceDetector([FaceDetectorOptions faceDetectorOptions]);
 
-  external JSPromise detect(ImageBitmapSource image);
+  external JSPromise<JSArray<DetectedFace>> detect(ImageBitmapSource image);
 }
 extension type FaceDetectorOptions._(JSObject _) implements JSObject {
   external factory FaceDetectorOptions({
@@ -30,22 +31,22 @@ extension type FaceDetectorOptions._(JSObject _) implements JSObject {
 extension type DetectedFace._(JSObject _) implements JSObject {
   external factory DetectedFace({
     required DOMRectReadOnly boundingBox,
-    required JSArray? landmarks,
+    required JSArray<Landmark>? landmarks,
   });
 
   external set boundingBox(DOMRectReadOnly value);
   external DOMRectReadOnly get boundingBox;
-  external set landmarks(JSArray? value);
-  external JSArray? get landmarks;
+  external set landmarks(JSArray<Landmark>? value);
+  external JSArray<Landmark>? get landmarks;
 }
 extension type Landmark._(JSObject _) implements JSObject {
   external factory Landmark({
-    required JSArray locations,
+    required JSArray<Point2D> locations,
     LandmarkType type,
   });
 
-  external set locations(JSArray value);
-  external JSArray get locations;
+  external set locations(JSArray<Point2D> value);
+  external JSArray<Point2D> get locations;
   external set type(LandmarkType value);
   external LandmarkType get type;
 }
@@ -53,21 +54,21 @@ extension type BarcodeDetector._(JSObject _) implements JSObject {
   external factory BarcodeDetector(
       [BarcodeDetectorOptions barcodeDetectorOptions]);
 
-  external static JSPromise getSupportedFormats();
-  external JSPromise detect(ImageBitmapSource image);
+  external static JSPromise<JSArray<JSString>> getSupportedFormats();
+  external JSPromise<JSArray<DetectedBarcode>> detect(ImageBitmapSource image);
 }
 extension type BarcodeDetectorOptions._(JSObject _) implements JSObject {
-  external factory BarcodeDetectorOptions({JSArray formats});
+  external factory BarcodeDetectorOptions({JSArray<JSString> formats});
 
-  external set formats(JSArray value);
-  external JSArray get formats;
+  external set formats(JSArray<JSString> value);
+  external JSArray<JSString> get formats;
 }
 extension type DetectedBarcode._(JSObject _) implements JSObject {
   external factory DetectedBarcode({
     required DOMRectReadOnly boundingBox,
     required String rawValue,
     required BarcodeFormat format,
-    required JSArray cornerPoints,
+    required JSArray<Point2D> cornerPoints,
   });
 
   external set boundingBox(DOMRectReadOnly value);
@@ -76,6 +77,6 @@ extension type DetectedBarcode._(JSObject _) implements JSObject {
   external String get rawValue;
   external set format(BarcodeFormat value);
   external BarcodeFormat get format;
-  external set cornerPoints(JSArray value);
-  external JSArray get cornerPoints;
+  external set cornerPoints(JSArray<Point2D> value);
+  external JSArray<Point2D> get cornerPoints;
 }

--- a/lib/src/dom/shared_storage.dart
+++ b/lib/src/dom/shared_storage.dart
@@ -38,27 +38,27 @@ extension type SharedStorageRunOperationMethodOptions._(JSObject _)
 }
 extension type SharedStorageRunOperation._(JSObject _)
     implements SharedStorageOperation, JSObject {
-  external JSPromise run(JSObject data);
+  external JSPromise<JSAny?> run(JSObject data);
 }
 extension type SharedStorageSelectURLOperation._(JSObject _)
     implements SharedStorageOperation, JSObject {
-  external JSPromise run(
+  external JSPromise<JSNumber> run(
     JSObject data,
-    JSArray urls,
+    JSArray<SharedStorageUrlWithMetadata> urls,
   );
 }
 extension type SharedStorage._(JSObject _) implements JSObject {
-  external JSPromise set(
+  external JSPromise<JSAny?> set(
     String key,
     String value, [
     SharedStorageSetMethodOptions options,
   ]);
-  external JSPromise append(
+  external JSPromise<JSAny?> append(
     String key,
     String value,
   );
-  external JSPromise delete(String key);
-  external JSPromise clear();
+  external JSPromise<JSAny?> delete(String key);
+  external JSPromise<JSAny?> clear();
 }
 extension type SharedStorageSetMethodOptions._(JSObject _) implements JSObject {
   external factory SharedStorageSetMethodOptions({bool ignoreIfPresent});
@@ -68,13 +68,13 @@ extension type SharedStorageSetMethodOptions._(JSObject _) implements JSObject {
 }
 extension type WindowSharedStorage._(JSObject _)
     implements SharedStorage, JSObject {
-  external JSPromise run(
+  external JSPromise<JSAny?> run(
     String name, [
     SharedStorageRunOperationMethodOptions options,
   ]);
-  external JSPromise selectURL(
+  external JSPromise<SharedStorageResponse> selectURL(
     String name,
-    JSArray urls, [
+    JSArray<SharedStorageUrlWithMetadata> urls, [
     SharedStorageRunOperationMethodOptions options,
   ]);
   external SharedStorageWorklet get worklet;
@@ -92,7 +92,7 @@ extension type SharedStorageUrlWithMetadata._(JSObject _) implements JSObject {
 }
 extension type WorkletSharedStorage._(JSObject _)
     implements SharedStorage, JSObject {
-  external JSPromise get(String key);
-  external JSPromise length();
-  external JSPromise remainingBudget();
+  external JSPromise<JSString> get(String key);
+  external JSPromise<JSNumber> length();
+  external JSPromise<JSNumber> remainingBudget();
 }

--- a/lib/src/dom/speech_api.dart
+++ b/lib/src/dom/speech_api.dart
@@ -132,7 +132,7 @@ extension type SpeechSynthesis._(JSObject _) implements EventTarget, JSObject {
   external void cancel();
   external void pause();
   external void resume();
-  external JSArray getVoices();
+  external JSArray<SpeechSynthesisVoice> getVoices();
   external bool get pending;
   external bool get speaking;
   external bool get paused;

--- a/lib/src/dom/storage.dart
+++ b/lib/src/dom/storage.dart
@@ -6,11 +6,13 @@
 
 import 'dart:js_interop';
 
+import 'fs.dart';
+
 extension type StorageManager._(JSObject _) implements JSObject {
-  external JSPromise getDirectory();
-  external JSPromise persisted();
-  external JSPromise persist();
-  external JSPromise estimate();
+  external JSPromise<FileSystemDirectoryHandle> getDirectory();
+  external JSPromise<JSBoolean> persisted();
+  external JSPromise<JSBoolean> persist();
+  external JSPromise<StorageEstimate> estimate();
 }
 extension type StorageEstimate._(JSObject _) implements JSObject {
   external factory StorageEstimate({

--- a/lib/src/dom/storage_buckets.dart
+++ b/lib/src/dom/storage_buckets.dart
@@ -6,17 +6,19 @@
 
 import 'dart:js_interop';
 
+import 'fs.dart';
 import 'hr_time.dart';
 import 'indexeddb.dart';
 import 'service_workers.dart';
+import 'storage.dart';
 
 extension type StorageBucketManager._(JSObject _) implements JSObject {
-  external JSPromise open(
+  external JSPromise<StorageBucket> open(
     String name, [
     StorageBucketOptions options,
   ]);
-  external JSPromise keys();
-  external JSPromise delete(String name);
+  external JSPromise<JSArray<JSString>> keys();
+  external JSPromise<JSAny?> delete(String name);
 }
 extension type StorageBucketOptions._(JSObject _) implements JSObject {
   external factory StorageBucketOptions({
@@ -33,12 +35,12 @@ extension type StorageBucketOptions._(JSObject _) implements JSObject {
   external DOMHighResTimeStamp? get expires;
 }
 extension type StorageBucket._(JSObject _) implements JSObject {
-  external JSPromise persist();
-  external JSPromise persisted();
-  external JSPromise estimate();
-  external JSPromise setExpires(DOMHighResTimeStamp expires);
-  external JSPromise expires();
-  external JSPromise getDirectory();
+  external JSPromise<JSBoolean> persist();
+  external JSPromise<JSBoolean> persisted();
+  external JSPromise<StorageEstimate> estimate();
+  external JSPromise<JSAny?> setExpires(DOMHighResTimeStamp expires);
+  external JSPromise<JSNumber> expires();
+  external JSPromise<FileSystemDirectoryHandle> getDirectory();
   external String get name;
   external IDBFactory get indexedDB;
   external CacheStorage get caches;

--- a/lib/src/dom/streams.dart
+++ b/lib/src/dom/streams.dart
@@ -32,18 +32,18 @@ extension type ReadableStream._(JSObject _) implements JSObject {
   ]);
 
   external static ReadableStream from(JSAny? asyncIterable);
-  external JSPromise cancel([JSAny? reason]);
+  external JSPromise<JSAny?> cancel([JSAny? reason]);
   external ReadableStreamReader getReader(
       [ReadableStreamGetReaderOptions options]);
   external ReadableStream pipeThrough(
     ReadableWritablePair transform, [
     StreamPipeOptions options,
   ]);
-  external JSPromise pipeTo(
+  external JSPromise<JSAny?> pipeTo(
     WritableStream destination, [
     StreamPipeOptions options,
   ]);
-  external JSArray tee();
+  external JSArray<ReadableStream> tee();
   external bool get locked;
 }
 extension type ReadableStreamGetReaderOptions._(JSObject _)
@@ -111,10 +111,10 @@ extension type UnderlyingSource._(JSObject _) implements JSObject {
 extension type ReadableStreamDefaultReader._(JSObject _) implements JSObject {
   external factory ReadableStreamDefaultReader(ReadableStream stream);
 
-  external JSPromise read();
+  external JSPromise<ReadableStreamReadResult> read();
   external void releaseLock();
-  external JSPromise cancel([JSAny? reason]);
-  external JSPromise get closed;
+  external JSPromise<JSAny?> cancel([JSAny? reason]);
+  external JSPromise<JSAny?> get closed;
 }
 extension type ReadableStreamReadResult._(JSObject _) implements JSObject {
   external factory ReadableStreamReadResult({
@@ -130,10 +130,10 @@ extension type ReadableStreamReadResult._(JSObject _) implements JSObject {
 extension type ReadableStreamBYOBReader._(JSObject _) implements JSObject {
   external factory ReadableStreamBYOBReader(ReadableStream stream);
 
-  external JSPromise read(ArrayBufferView view);
+  external JSPromise<ReadableStreamReadResult> read(ArrayBufferView view);
   external void releaseLock();
-  external JSPromise cancel([JSAny? reason]);
-  external JSPromise get closed;
+  external JSPromise<JSAny?> cancel([JSAny? reason]);
+  external JSPromise<JSAny?> get closed;
 }
 extension type ReadableStreamDefaultController._(JSObject _)
     implements JSObject {
@@ -160,8 +160,8 @@ extension type WritableStream._(JSObject _) implements JSObject {
     QueuingStrategy strategy,
   ]);
 
-  external JSPromise abort([JSAny? reason]);
-  external JSPromise close();
+  external JSPromise<JSAny?> abort([JSAny? reason]);
+  external JSPromise<JSAny?> close();
   external WritableStreamDefaultWriter getWriter();
   external bool get locked;
 }
@@ -188,13 +188,13 @@ extension type UnderlyingSink._(JSObject _) implements JSObject {
 extension type WritableStreamDefaultWriter._(JSObject _) implements JSObject {
   external factory WritableStreamDefaultWriter(WritableStream stream);
 
-  external JSPromise abort([JSAny? reason]);
-  external JSPromise close();
+  external JSPromise<JSAny?> abort([JSAny? reason]);
+  external JSPromise<JSAny?> close();
   external void releaseLock();
-  external JSPromise write([JSAny? chunk]);
-  external JSPromise get closed;
+  external JSPromise<JSAny?> write([JSAny? chunk]);
+  external JSPromise<JSAny?> get closed;
   external num? get desiredSize;
-  external JSPromise get ready;
+  external JSPromise<JSAny?> get ready;
 }
 extension type WritableStreamDefaultController._(JSObject _)
     implements JSObject {

--- a/lib/src/dom/testutils.dart
+++ b/lib/src/dom/testutils.dart
@@ -10,5 +10,5 @@ import 'dart:js_interop';
 external $TestUtils get TestUtils;
 @JS('TestUtils')
 extension type $TestUtils._(JSObject _) implements JSObject {
-  external JSPromise gc();
+  external JSPromise<JSAny?> gc();
 }

--- a/lib/src/dom/text_detection_api.dart
+++ b/lib/src/dom/text_detection_api.dart
@@ -8,23 +8,24 @@ import 'dart:js_interop';
 
 import 'geometry.dart';
 import 'html.dart';
+import 'image_capture.dart';
 
 extension type TextDetector._(JSObject _) implements JSObject {
   external factory TextDetector();
 
-  external JSPromise detect(ImageBitmapSource image);
+  external JSPromise<JSArray<DetectedText>> detect(ImageBitmapSource image);
 }
 extension type DetectedText._(JSObject _) implements JSObject {
   external factory DetectedText({
     required DOMRectReadOnly boundingBox,
     required String rawValue,
-    required JSArray cornerPoints,
+    required JSArray<Point2D> cornerPoints,
   });
 
   external set boundingBox(DOMRectReadOnly value);
   external DOMRectReadOnly get boundingBox;
   external set rawValue(String value);
   external String get rawValue;
-  external set cornerPoints(JSArray value);
-  external JSArray get cornerPoints;
+  external set cornerPoints(JSArray<Point2D> value);
+  external JSArray<Point2D> get cornerPoints;
 }

--- a/lib/src/dom/touch_events.dart
+++ b/lib/src/dom/touch_events.dart
@@ -86,17 +86,17 @@ extension type TouchList._(JSObject _) implements JSObject {
 extension type TouchEventInit._(JSObject _)
     implements EventModifierInit, JSObject {
   external factory TouchEventInit({
-    JSArray touches,
-    JSArray targetTouches,
-    JSArray changedTouches,
+    JSArray<Touch> touches,
+    JSArray<Touch> targetTouches,
+    JSArray<Touch> changedTouches,
   });
 
-  external set touches(JSArray value);
-  external JSArray get touches;
-  external set targetTouches(JSArray value);
-  external JSArray get targetTouches;
-  external set changedTouches(JSArray value);
-  external JSArray get changedTouches;
+  external set touches(JSArray<Touch> value);
+  external JSArray<Touch> get touches;
+  external set targetTouches(JSArray<Touch> value);
+  external JSArray<Touch> get targetTouches;
+  external set changedTouches(JSArray<Touch> value);
+  external JSArray<Touch> get changedTouches;
 }
 extension type TouchEvent._(JSObject _) implements UIEvent, JSObject {
   external factory TouchEvent(

--- a/lib/src/dom/trust_token_api.dart
+++ b/lib/src/dom/trust_token_api.dart
@@ -14,7 +14,7 @@ extension type PrivateToken._(JSObject _) implements JSObject {
     required TokenVersion version,
     required OperationType operation,
     RefreshPolicy refreshPolicy,
-    JSArray issuers,
+    JSArray<JSString> issuers,
   });
 
   external set version(TokenVersion value);
@@ -23,6 +23,6 @@ extension type PrivateToken._(JSObject _) implements JSObject {
   external OperationType get operation;
   external set refreshPolicy(RefreshPolicy value);
   external RefreshPolicy get refreshPolicy;
-  external set issuers(JSArray value);
-  external JSArray get issuers;
+  external set issuers(JSArray<JSString> value);
+  external JSArray<JSString> get issuers;
 }

--- a/lib/src/dom/turtledove.dart
+++ b/lib/src/dom/turtledove.dart
@@ -14,7 +14,7 @@ extension type AuctionAd._(JSObject _) implements JSObject {
     JSAny? metadata,
     String buyerReportingId,
     String buyerAndSellerReportingId,
-    JSArray allowedReportingOrigins,
+    JSArray<JSString> allowedReportingOrigins,
   });
 
   external set renderURL(String value);
@@ -25,8 +25,8 @@ extension type AuctionAd._(JSObject _) implements JSObject {
   external String get buyerReportingId;
   external set buyerAndSellerReportingId(String value);
   external String get buyerAndSellerReportingId;
-  external set allowedReportingOrigins(JSArray value);
-  external JSArray get allowedReportingOrigins;
+  external set allowedReportingOrigins(JSArray<JSString> value);
+  external JSArray<JSString> get allowedReportingOrigins;
 }
 extension type GenerateBidInterestGroup._(JSObject _) implements JSObject {
   external factory GenerateBidInterestGroup({
@@ -40,10 +40,10 @@ extension type GenerateBidInterestGroup._(JSObject _) implements JSObject {
     String biddingWasmHelperURL,
     String updateURL,
     String trustedBiddingSignalsURL,
-    JSArray trustedBiddingSignalsKeys,
+    JSArray<JSString> trustedBiddingSignalsKeys,
     JSAny? userBiddingSignals,
-    JSArray ads,
-    JSArray adComponents,
+    JSArray<AuctionAd> ads,
+    JSArray<AuctionAd> adComponents,
   });
 
   external set owner(String value);
@@ -66,14 +66,14 @@ extension type GenerateBidInterestGroup._(JSObject _) implements JSObject {
   external String get updateURL;
   external set trustedBiddingSignalsURL(String value);
   external String get trustedBiddingSignalsURL;
-  external set trustedBiddingSignalsKeys(JSArray value);
-  external JSArray get trustedBiddingSignalsKeys;
+  external set trustedBiddingSignalsKeys(JSArray<JSString> value);
+  external JSArray<JSString> get trustedBiddingSignalsKeys;
   external set userBiddingSignals(JSAny? value);
   external JSAny? get userBiddingSignals;
-  external set ads(JSArray value);
-  external JSArray get ads;
-  external set adComponents(JSArray value);
-  external JSArray get adComponents;
+  external set ads(JSArray<AuctionAd> value);
+  external JSArray<AuctionAd> get ads;
+  external set adComponents(JSArray<AuctionAd> value);
+  external JSArray<AuctionAd> get adComponents;
 }
 extension type AuctionAdInterestGroup._(JSObject _)
     implements GenerateBidInterestGroup, JSObject {
@@ -103,22 +103,22 @@ extension type AuctionAdConfig._(JSObject _) implements JSObject {
     required String seller,
     required String decisionLogicURL,
     String trustedScoringSignalsURL,
-    JSArray interestGroupBuyers,
-    JSPromise auctionSignals,
-    JSPromise sellerSignals,
-    JSPromise directFromSellerSignals,
+    JSArray<JSString> interestGroupBuyers,
+    JSPromise<JSAny?> auctionSignals,
+    JSPromise<JSAny?> sellerSignals,
+    JSPromise<JSString> directFromSellerSignals,
     int sellerTimeout,
     int sellerExperimentGroupId,
     String sellerCurrency,
-    JSPromise perBuyerSignals,
-    JSPromise perBuyerTimeouts,
+    JSPromise<JSAny> perBuyerSignals,
+    JSPromise<JSAny> perBuyerTimeouts,
     JSAny perBuyerGroupLimits,
     JSAny perBuyerExperimentGroupIds,
     JSAny perBuyerPrioritySignals,
-    JSPromise perBuyerCurrencies,
-    JSArray componentAuctions,
+    JSPromise<JSAny> perBuyerCurrencies,
+    JSArray<AuctionAdConfig> componentAuctions,
     AbortSignal? signal,
-    JSPromise resolveToConfig,
+    JSPromise<JSBoolean> resolveToConfig,
   });
 
   external set seller(String value);
@@ -127,38 +127,38 @@ extension type AuctionAdConfig._(JSObject _) implements JSObject {
   external String get decisionLogicURL;
   external set trustedScoringSignalsURL(String value);
   external String get trustedScoringSignalsURL;
-  external set interestGroupBuyers(JSArray value);
-  external JSArray get interestGroupBuyers;
-  external set auctionSignals(JSPromise value);
-  external JSPromise get auctionSignals;
-  external set sellerSignals(JSPromise value);
-  external JSPromise get sellerSignals;
-  external set directFromSellerSignals(JSPromise value);
-  external JSPromise get directFromSellerSignals;
+  external set interestGroupBuyers(JSArray<JSString> value);
+  external JSArray<JSString> get interestGroupBuyers;
+  external set auctionSignals(JSPromise<JSAny?> value);
+  external JSPromise<JSAny?> get auctionSignals;
+  external set sellerSignals(JSPromise<JSAny?> value);
+  external JSPromise<JSAny?> get sellerSignals;
+  external set directFromSellerSignals(JSPromise<JSString> value);
+  external JSPromise<JSString> get directFromSellerSignals;
   external set sellerTimeout(int value);
   external int get sellerTimeout;
   external set sellerExperimentGroupId(int value);
   external int get sellerExperimentGroupId;
   external set sellerCurrency(String value);
   external String get sellerCurrency;
-  external set perBuyerSignals(JSPromise value);
-  external JSPromise get perBuyerSignals;
-  external set perBuyerTimeouts(JSPromise value);
-  external JSPromise get perBuyerTimeouts;
+  external set perBuyerSignals(JSPromise<JSAny> value);
+  external JSPromise<JSAny> get perBuyerSignals;
+  external set perBuyerTimeouts(JSPromise<JSAny> value);
+  external JSPromise<JSAny> get perBuyerTimeouts;
   external set perBuyerGroupLimits(JSAny value);
   external JSAny get perBuyerGroupLimits;
   external set perBuyerExperimentGroupIds(JSAny value);
   external JSAny get perBuyerExperimentGroupIds;
   external set perBuyerPrioritySignals(JSAny value);
   external JSAny get perBuyerPrioritySignals;
-  external set perBuyerCurrencies(JSPromise value);
-  external JSPromise get perBuyerCurrencies;
-  external set componentAuctions(JSArray value);
-  external JSArray get componentAuctions;
+  external set perBuyerCurrencies(JSPromise<JSAny> value);
+  external JSPromise<JSAny> get perBuyerCurrencies;
+  external set componentAuctions(JSArray<AuctionAdConfig> value);
+  external JSArray<AuctionAdConfig> get componentAuctions;
   external set signal(AbortSignal? value);
   external AbortSignal? get signal;
-  external set resolveToConfig(JSPromise value);
-  external JSPromise get resolveToConfig;
+  external set resolveToConfig(JSPromise<JSBoolean> value);
+  external JSPromise<JSBoolean> get resolveToConfig;
 }
 extension type InterestGroupScriptRunnerGlobalScope._(JSObject _)
     implements JSObject {}
@@ -191,7 +191,7 @@ extension type GenerateBidOutput._(JSObject _) implements JSObject {
     String bidCurrency,
     JSAny render,
     JSAny? ad,
-    JSArray adComponents,
+    JSArray<JSAny> adComponents,
     num adCost,
     num modelingSignals,
     bool allowComponentAuction,
@@ -205,8 +205,8 @@ extension type GenerateBidOutput._(JSObject _) implements JSObject {
   external JSAny get render;
   external set ad(JSAny? value);
   external JSAny? get ad;
-  external set adComponents(JSArray value);
-  external JSArray get adComponents;
+  external set adComponents(JSArray<JSAny> value);
+  external JSArray<JSAny> get adComponents;
   external set adCost(num value);
   external num get adCost;
   external set modelingSignals(num value);
@@ -244,7 +244,7 @@ extension type BiddingBrowserSignals._(JSObject _) implements JSObject {
     required int bidCount,
     required int recency,
     String topLevelSeller,
-    JSArray prevWinsMs,
+    JSArray<PreviousWin> prevWinsMs,
     JSObject wasmHelper,
     int dataVersion,
   });
@@ -261,8 +261,8 @@ extension type BiddingBrowserSignals._(JSObject _) implements JSObject {
   external int get recency;
   external set topLevelSeller(String value);
   external String get topLevelSeller;
-  external set prevWinsMs(JSArray value);
-  external JSArray get prevWinsMs;
+  external set prevWinsMs(JSArray<PreviousWin> value);
+  external JSArray<PreviousWin> get prevWinsMs;
   external set wasmHelper(JSObject value);
   external JSObject get wasmHelper;
   external set dataVersion(int value);
@@ -276,7 +276,7 @@ extension type ScoringBrowserSignals._(JSObject _) implements JSObject {
     required int biddingDurationMsec,
     required String bidCurrency,
     int dataVersion,
-    JSArray adComponents,
+    JSArray<JSString> adComponents,
   });
 
   external set topWindowHostname(String value);
@@ -291,8 +291,8 @@ extension type ScoringBrowserSignals._(JSObject _) implements JSObject {
   external String get bidCurrency;
   external set dataVersion(int value);
   external int get dataVersion;
-  external set adComponents(JSArray value);
-  external JSArray get adComponents;
+  external set adComponents(JSArray<JSString> value);
+  external JSArray<JSString> get adComponents;
 }
 extension type ReportingBrowserSignals._(JSObject _) implements JSObject {
   external factory ReportingBrowserSignals({

--- a/lib/src/dom/ua_client_hints.dart
+++ b/lib/src/dom/ua_client_hints.dart
@@ -21,9 +21,9 @@ extension type UADataValues._(JSObject _) implements JSObject {
   external factory UADataValues({
     String architecture,
     String bitness,
-    JSArray brands,
-    JSArray formFactor,
-    JSArray fullVersionList,
+    JSArray<NavigatorUABrandVersion> brands,
+    JSArray<JSString> formFactor,
+    JSArray<NavigatorUABrandVersion> fullVersionList,
     String model,
     bool mobile,
     String platform,
@@ -36,12 +36,12 @@ extension type UADataValues._(JSObject _) implements JSObject {
   external String get architecture;
   external set bitness(String value);
   external String get bitness;
-  external set brands(JSArray value);
-  external JSArray get brands;
-  external set formFactor(JSArray value);
-  external JSArray get formFactor;
-  external set fullVersionList(JSArray value);
-  external JSArray get fullVersionList;
+  external set brands(JSArray<NavigatorUABrandVersion> value);
+  external JSArray<NavigatorUABrandVersion> get brands;
+  external set formFactor(JSArray<JSString> value);
+  external JSArray<JSString> get formFactor;
+  external set fullVersionList(JSArray<NavigatorUABrandVersion> value);
+  external JSArray<NavigatorUABrandVersion> get fullVersionList;
   external set model(String value);
   external String get model;
   external set mobile(bool value);
@@ -57,22 +57,23 @@ extension type UADataValues._(JSObject _) implements JSObject {
 }
 extension type UALowEntropyJSON._(JSObject _) implements JSObject {
   external factory UALowEntropyJSON({
-    JSArray brands,
+    JSArray<NavigatorUABrandVersion> brands,
     bool mobile,
     String platform,
   });
 
-  external set brands(JSArray value);
-  external JSArray get brands;
+  external set brands(JSArray<NavigatorUABrandVersion> value);
+  external JSArray<NavigatorUABrandVersion> get brands;
   external set mobile(bool value);
   external bool get mobile;
   external set platform(String value);
   external String get platform;
 }
 extension type NavigatorUAData._(JSObject _) implements JSObject {
-  external JSPromise getHighEntropyValues(JSArray hints);
+  external JSPromise<UADataValues> getHighEntropyValues(
+      JSArray<JSString> hints);
   external UALowEntropyJSON toJSON();
-  external JSArray get brands;
+  external JSArray<NavigatorUABrandVersion> get brands;
   external bool get mobile;
   external String get platform;
 }

--- a/lib/src/dom/uievents.dart
+++ b/lib/src/dom/uievents.dart
@@ -224,7 +224,7 @@ extension type InputEvent._(JSObject _) implements UIEvent, JSObject {
     InputEventInit eventInitDict,
   ]);
 
-  external JSArray getTargetRanges();
+  external JSArray<StaticRange> getTargetRanges();
   external DataTransfer? get dataTransfer;
   external String? get data;
   external bool get isComposing;
@@ -233,7 +233,7 @@ extension type InputEvent._(JSObject _) implements UIEvent, JSObject {
 extension type InputEventInit._(JSObject _) implements UIEventInit, JSObject {
   external factory InputEventInit({
     DataTransfer? dataTransfer,
-    JSArray targetRanges,
+    JSArray<StaticRange> targetRanges,
     String? data,
     bool isComposing,
     String inputType,
@@ -241,8 +241,8 @@ extension type InputEventInit._(JSObject _) implements UIEventInit, JSObject {
 
   external set dataTransfer(DataTransfer? value);
   external DataTransfer? get dataTransfer;
-  external set targetRanges(JSArray value);
-  external JSArray get targetRanges;
+  external set targetRanges(JSArray<StaticRange> value);
+  external JSArray<StaticRange> get targetRanges;
   external set data(String? value);
   external String? get data;
   external set isComposing(bool value);

--- a/lib/src/dom/url.dart
+++ b/lib/src/dom/url.dart
@@ -54,7 +54,7 @@ extension type URLSearchParams._(JSObject _) implements JSObject {
     String value,
   ]);
   external String? get(String name);
-  external JSArray getAll(String name);
+  external JSArray<JSString> getAll(String name);
   external bool has(
     String name, [
     String value,

--- a/lib/src/dom/urlpattern.dart
+++ b/lib/src/dom/urlpattern.dart
@@ -71,7 +71,7 @@ extension type URLPatternOptions._(JSObject _) implements JSObject {
 }
 extension type URLPatternResult._(JSObject _) implements JSObject {
   external factory URLPatternResult({
-    JSArray inputs,
+    JSArray<URLPatternInput> inputs,
     URLPatternComponentResult protocol,
     URLPatternComponentResult username,
     URLPatternComponentResult password,
@@ -82,8 +82,8 @@ extension type URLPatternResult._(JSObject _) implements JSObject {
     URLPatternComponentResult hash,
   });
 
-  external set inputs(JSArray value);
-  external JSArray get inputs;
+  external set inputs(JSArray<URLPatternInput> value);
+  external JSArray<URLPatternInput> get inputs;
   external set protocol(URLPatternComponentResult value);
   external URLPatternComponentResult get protocol;
   external set username(URLPatternComponentResult value);

--- a/lib/src/dom/wasm_js_api.dart
+++ b/lib/src/dom/wasm_js_api.dart
@@ -6,6 +6,7 @@
 
 import 'dart:js_interop';
 
+import 'fetch.dart';
 import 'webidl.dart';
 
 typedef ImportExportKind = String;
@@ -27,14 +28,14 @@ external $WebAssembly get WebAssembly;
 @JS('WebAssembly')
 extension type $WebAssembly._(JSObject _) implements JSObject {
   external bool validate(BufferSource bytes);
-  external JSPromise compile(BufferSource bytes);
-  external JSPromise instantiate(
+  external JSPromise<Module> compile(BufferSource bytes);
+  external JSPromise<WebAssemblyInstantiatedSource> instantiate(
     JSObject bytesOrModuleObject, [
     JSObject importObject,
   ]);
-  external JSPromise compileStreaming(JSPromise source);
-  external JSPromise instantiateStreaming(
-    JSPromise source, [
+  external JSPromise<Module> compileStreaming(JSPromise<Response> source);
+  external JSPromise<WebAssemblyInstantiatedSource> instantiateStreaming(
+    JSPromise<Response> source, [
     JSObject importObject,
   ]);
 }
@@ -66,9 +67,9 @@ extension type ModuleImportDescriptor._(JSObject _) implements JSObject {
 extension type Module._(JSObject _) implements JSObject {
   external factory Module(BufferSource bytes);
 
-  external static JSArray exports(Module moduleObject);
-  external static JSArray imports(Module moduleObject);
-  external static JSArray customSections(
+  external static JSArray<ModuleExportDescriptor> exports(Module moduleObject);
+  external static JSArray<ModuleImportDescriptor> imports(Module moduleObject);
+  external static JSArray<JSArrayBuffer> customSections(
     Module moduleObject,
     String sectionName,
   );

--- a/lib/src/dom/web_animations.dart
+++ b/lib/src/dom/web_animations.dart
@@ -62,8 +62,8 @@ extension type Animation._(JSObject _) implements EventTarget, JSObject {
   external AnimationPlayState get playState;
   external AnimationReplaceState get replaceState;
   external bool get pending;
-  external JSPromise get ready;
-  external JSPromise get finished;
+  external JSPromise<Animation> get ready;
+  external JSPromise<Animation> get finished;
   external set onfinish(EventHandler value);
   external EventHandler get onfinish;
   external set oncancel(EventHandler value);
@@ -179,7 +179,7 @@ extension type KeyframeEffect._(JSObject _)
     JSAny options,
   ]);
 
-  external JSArray getKeyframes();
+  external JSArray<JSObject> getKeyframes();
   external void setKeyframes(JSObject? keyframes);
   external set iterationComposite(IterationCompositeOperation value);
   external IterationCompositeOperation get iterationComposite;

--- a/lib/src/dom/web_animations_2.dart
+++ b/lib/src/dom/web_animations_2.dart
@@ -14,7 +14,7 @@ typedef EffectCallback = JSFunction;
 typedef IterationCompositeOperation = String;
 extension type GroupEffect._(JSObject _) implements JSObject {
   external factory GroupEffect(
-    JSArray? children, [
+    JSArray<AnimationEffect>? children, [
     JSAny timing,
   ]);
 
@@ -31,7 +31,7 @@ extension type AnimationNodeList._(JSObject _) implements JSObject {
 }
 extension type SequenceEffect._(JSObject _) implements GroupEffect, JSObject {
   external factory SequenceEffect(
-    JSArray? children, [
+    JSArray<AnimationEffect>? children, [
     JSAny timing,
   ]);
 

--- a/lib/src/dom/web_app_launch.dart
+++ b/lib/src/dom/web_app_launch.dart
@@ -6,10 +6,12 @@
 
 import 'dart:js_interop';
 
+import 'fs.dart';
+
 typedef LaunchConsumer = JSFunction;
 extension type LaunchParams._(JSObject _) implements JSObject {
   external String? get targetURL;
-  external JSArray get files;
+  external JSArray<FileSystemHandle> get files;
 }
 extension type LaunchQueue._(JSObject _) implements JSObject {
   external void setConsumer(LaunchConsumer consumer);

--- a/lib/src/dom/web_bluetooth.dart
+++ b/lib/src/dom/web_bluetooth.dart
@@ -44,48 +44,50 @@ extension type BluetoothServiceDataFilterInit._(JSObject _)
 }
 extension type BluetoothLEScanFilterInit._(JSObject _) implements JSObject {
   external factory BluetoothLEScanFilterInit({
-    JSArray services,
+    JSArray<BluetoothServiceUUID> services,
     String name,
     String namePrefix,
-    JSArray manufacturerData,
-    JSArray serviceData,
+    JSArray<BluetoothManufacturerDataFilterInit> manufacturerData,
+    JSArray<BluetoothServiceDataFilterInit> serviceData,
   });
 
-  external set services(JSArray value);
-  external JSArray get services;
+  external set services(JSArray<BluetoothServiceUUID> value);
+  external JSArray<BluetoothServiceUUID> get services;
   external set name(String value);
   external String get name;
   external set namePrefix(String value);
   external String get namePrefix;
-  external set manufacturerData(JSArray value);
-  external JSArray get manufacturerData;
-  external set serviceData(JSArray value);
-  external JSArray get serviceData;
+  external set manufacturerData(
+      JSArray<BluetoothManufacturerDataFilterInit> value);
+  external JSArray<BluetoothManufacturerDataFilterInit> get manufacturerData;
+  external set serviceData(JSArray<BluetoothServiceDataFilterInit> value);
+  external JSArray<BluetoothServiceDataFilterInit> get serviceData;
 }
 extension type RequestDeviceOptions._(JSObject _) implements JSObject {
   external factory RequestDeviceOptions({
-    JSArray filters,
-    JSArray exclusionFilters,
-    JSArray optionalServices,
-    JSArray optionalManufacturerData,
+    JSArray<BluetoothLEScanFilterInit> filters,
+    JSArray<BluetoothLEScanFilterInit> exclusionFilters,
+    JSArray<BluetoothServiceUUID> optionalServices,
+    JSArray<JSNumber> optionalManufacturerData,
     bool acceptAllDevices,
   });
 
-  external set filters(JSArray value);
-  external JSArray get filters;
-  external set exclusionFilters(JSArray value);
-  external JSArray get exclusionFilters;
-  external set optionalServices(JSArray value);
-  external JSArray get optionalServices;
-  external set optionalManufacturerData(JSArray value);
-  external JSArray get optionalManufacturerData;
+  external set filters(JSArray<BluetoothLEScanFilterInit> value);
+  external JSArray<BluetoothLEScanFilterInit> get filters;
+  external set exclusionFilters(JSArray<BluetoothLEScanFilterInit> value);
+  external JSArray<BluetoothLEScanFilterInit> get exclusionFilters;
+  external set optionalServices(JSArray<BluetoothServiceUUID> value);
+  external JSArray<BluetoothServiceUUID> get optionalServices;
+  external set optionalManufacturerData(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get optionalManufacturerData;
   external set acceptAllDevices(bool value);
   external bool get acceptAllDevices;
 }
 extension type Bluetooth._(JSObject _) implements EventTarget, JSObject {
-  external JSPromise getAvailability();
-  external JSPromise getDevices();
-  external JSPromise requestDevice([RequestDeviceOptions options]);
+  external JSPromise<JSBoolean> getAvailability();
+  external JSPromise<JSArray<BluetoothDevice>> getDevices();
+  external JSPromise<BluetoothDevice> requestDevice(
+      [RequestDeviceOptions options]);
   external set onavailabilitychanged(EventHandler value);
   external EventHandler get onavailabilitychanged;
   external BluetoothDevice? get referringDevice;
@@ -106,20 +108,20 @@ extension type BluetoothPermissionDescriptor._(JSObject _)
     implements PermissionDescriptor, JSObject {
   external factory BluetoothPermissionDescriptor({
     String deviceId,
-    JSArray filters,
-    JSArray optionalServices,
-    JSArray optionalManufacturerData,
+    JSArray<BluetoothLEScanFilterInit> filters,
+    JSArray<BluetoothServiceUUID> optionalServices,
+    JSArray<JSNumber> optionalManufacturerData,
     bool acceptAllDevices,
   });
 
   external set deviceId(String value);
   external String get deviceId;
-  external set filters(JSArray value);
-  external JSArray get filters;
-  external set optionalServices(JSArray value);
-  external JSArray get optionalServices;
-  external set optionalManufacturerData(JSArray value);
-  external JSArray get optionalManufacturerData;
+  external set filters(JSArray<BluetoothLEScanFilterInit> value);
+  external JSArray<BluetoothLEScanFilterInit> get filters;
+  external set optionalServices(JSArray<BluetoothServiceUUID> value);
+  external JSArray<BluetoothServiceUUID> get optionalServices;
+  external set optionalManufacturerData(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get optionalManufacturerData;
   external set acceptAllDevices(bool value);
   external bool get acceptAllDevices;
 }
@@ -128,7 +130,7 @@ extension type AllowedBluetoothDevice._(JSObject _) implements JSObject {
     required String deviceId,
     required bool mayUseGATT,
     required JSAny allowedServices,
-    required JSArray allowedManufacturerData,
+    required JSArray<JSNumber> allowedManufacturerData,
   });
 
   external set deviceId(String value);
@@ -137,20 +139,20 @@ extension type AllowedBluetoothDevice._(JSObject _) implements JSObject {
   external bool get mayUseGATT;
   external set allowedServices(JSAny value);
   external JSAny get allowedServices;
-  external set allowedManufacturerData(JSArray value);
-  external JSArray get allowedManufacturerData;
+  external set allowedManufacturerData(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get allowedManufacturerData;
 }
 extension type BluetoothPermissionStorage._(JSObject _) implements JSObject {
   external factory BluetoothPermissionStorage(
-      {required JSArray allowedDevices});
+      {required JSArray<AllowedBluetoothDevice> allowedDevices});
 
-  external set allowedDevices(JSArray value);
-  external JSArray get allowedDevices;
+  external set allowedDevices(JSArray<AllowedBluetoothDevice> value);
+  external JSArray<AllowedBluetoothDevice> get allowedDevices;
 }
 extension type BluetoothPermissionResult._(JSObject _)
     implements PermissionStatus, JSObject {
-  external set devices(JSArray value);
-  external JSArray get devices;
+  external set devices(JSArray<BluetoothDevice> value);
+  external JSArray<BluetoothDevice> get devices;
 }
 extension type ValueEvent._(JSObject _) implements Event, JSObject {
   external factory ValueEvent(
@@ -167,8 +169,9 @@ extension type ValueEventInit._(JSObject _) implements EventInit, JSObject {
   external JSAny? get value;
 }
 extension type BluetoothDevice._(JSObject _) implements EventTarget, JSObject {
-  external JSPromise forget();
-  external JSPromise watchAdvertisements([WatchAdvertisementsOptions options]);
+  external JSPromise<JSAny?> forget();
+  external JSPromise<JSAny?> watchAdvertisements(
+      [WatchAdvertisementsOptions options]);
   external String get id;
   external String? get name;
   external BluetoothRemoteGATTServer? get gatt;
@@ -202,7 +205,7 @@ extension type BluetoothAdvertisingEvent._(JSObject _)
   );
 
   external BluetoothDevice get device;
-  external JSArray get uuids;
+  external JSArray<JSString> get uuids;
   external String? get name;
   external int? get appearance;
   external int? get txPower;
@@ -214,7 +217,7 @@ extension type BluetoothAdvertisingEventInit._(JSObject _)
     implements EventInit, JSObject {
   external factory BluetoothAdvertisingEventInit({
     required BluetoothDevice device,
-    JSArray uuids,
+    JSArray<JSAny> uuids,
     String name,
     int appearance,
     int txPower,
@@ -225,8 +228,8 @@ extension type BluetoothAdvertisingEventInit._(JSObject _)
 
   external set device(BluetoothDevice value);
   external BluetoothDevice get device;
-  external set uuids(JSArray value);
-  external JSArray get uuids;
+  external set uuids(JSArray<JSAny> value);
+  external JSArray<JSAny> get uuids;
   external set name(String value);
   external String get name;
   external set appearance(int value);
@@ -241,21 +244,25 @@ extension type BluetoothAdvertisingEventInit._(JSObject _)
   external BluetoothServiceDataMap get serviceData;
 }
 extension type BluetoothRemoteGATTServer._(JSObject _) implements JSObject {
-  external JSPromise connect();
+  external JSPromise<BluetoothRemoteGATTServer> connect();
   external void disconnect();
-  external JSPromise getPrimaryService(BluetoothServiceUUID service);
-  external JSPromise getPrimaryServices([BluetoothServiceUUID service]);
+  external JSPromise<BluetoothRemoteGATTService> getPrimaryService(
+      BluetoothServiceUUID service);
+  external JSPromise<JSArray<BluetoothRemoteGATTService>> getPrimaryServices(
+      [BluetoothServiceUUID service]);
   external BluetoothDevice get device;
   external bool get connected;
 }
 extension type BluetoothRemoteGATTService._(JSObject _)
     implements EventTarget, JSObject {
-  external JSPromise getCharacteristic(
+  external JSPromise<BluetoothRemoteGATTCharacteristic> getCharacteristic(
       BluetoothCharacteristicUUID characteristic);
-  external JSPromise getCharacteristics(
-      [BluetoothCharacteristicUUID characteristic]);
-  external JSPromise getIncludedService(BluetoothServiceUUID service);
-  external JSPromise getIncludedServices([BluetoothServiceUUID service]);
+  external JSPromise<JSArray<BluetoothRemoteGATTCharacteristic>>
+      getCharacteristics([BluetoothCharacteristicUUID characteristic]);
+  external JSPromise<BluetoothRemoteGATTService> getIncludedService(
+      BluetoothServiceUUID service);
+  external JSPromise<JSArray<BluetoothRemoteGATTService>> getIncludedServices(
+      [BluetoothServiceUUID service]);
   external BluetoothDevice get device;
   external UUID get uuid;
   external bool get isPrimary;
@@ -270,14 +277,16 @@ extension type BluetoothRemoteGATTService._(JSObject _)
 }
 extension type BluetoothRemoteGATTCharacteristic._(JSObject _)
     implements EventTarget, JSObject {
-  external JSPromise getDescriptor(BluetoothDescriptorUUID descriptor);
-  external JSPromise getDescriptors([BluetoothDescriptorUUID descriptor]);
-  external JSPromise readValue();
-  external JSPromise writeValue(BufferSource value);
-  external JSPromise writeValueWithResponse(BufferSource value);
-  external JSPromise writeValueWithoutResponse(BufferSource value);
-  external JSPromise startNotifications();
-  external JSPromise stopNotifications();
+  external JSPromise<BluetoothRemoteGATTDescriptor> getDescriptor(
+      BluetoothDescriptorUUID descriptor);
+  external JSPromise<JSArray<BluetoothRemoteGATTDescriptor>> getDescriptors(
+      [BluetoothDescriptorUUID descriptor]);
+  external JSPromise<JSDataView> readValue();
+  external JSPromise<JSAny?> writeValue(BufferSource value);
+  external JSPromise<JSAny?> writeValueWithResponse(BufferSource value);
+  external JSPromise<JSAny?> writeValueWithoutResponse(BufferSource value);
+  external JSPromise<BluetoothRemoteGATTCharacteristic> startNotifications();
+  external JSPromise<BluetoothRemoteGATTCharacteristic> stopNotifications();
   external BluetoothRemoteGATTService get service;
   external UUID get uuid;
   external BluetoothCharacteristicProperties get properties;
@@ -298,8 +307,8 @@ extension type BluetoothCharacteristicProperties._(JSObject _)
   external bool get writableAuxiliaries;
 }
 extension type BluetoothRemoteGATTDescriptor._(JSObject _) implements JSObject {
-  external JSPromise readValue();
-  external JSPromise writeValue(BufferSource value);
+  external JSPromise<JSDataView> readValue();
+  external JSPromise<JSAny?> writeValue(BufferSource value);
   external BluetoothRemoteGATTCharacteristic get characteristic;
   external UUID get uuid;
   external JSDataView? get value;

--- a/lib/src/dom/web_locks.dart
+++ b/lib/src/dom/web_locks.dart
@@ -11,12 +11,12 @@ import 'dom.dart';
 typedef LockGrantedCallback = JSFunction;
 typedef LockMode = String;
 extension type LockManager._(JSObject _) implements JSObject {
-  external JSPromise request(
+  external JSPromise<JSAny?> request(
     String name,
     JSObject callbackOrOptions, [
     LockGrantedCallback callback,
   ]);
-  external JSPromise query();
+  external JSPromise<LockManagerSnapshot> query();
 }
 extension type LockOptions._(JSObject _) implements JSObject {
   external factory LockOptions({
@@ -37,14 +37,14 @@ extension type LockOptions._(JSObject _) implements JSObject {
 }
 extension type LockManagerSnapshot._(JSObject _) implements JSObject {
   external factory LockManagerSnapshot({
-    JSArray held,
-    JSArray pending,
+    JSArray<LockInfo> held,
+    JSArray<LockInfo> pending,
   });
 
-  external set held(JSArray value);
-  external JSArray get held;
-  external set pending(JSArray value);
-  external JSArray get pending;
+  external set held(JSArray<LockInfo> value);
+  external JSArray<LockInfo> get held;
+  external set pending(JSArray<LockInfo> value);
+  external JSArray<LockInfo> get pending;
 }
 extension type LockInfo._(JSObject _) implements JSObject {
   external factory LockInfo({

--- a/lib/src/dom/web_nfc.dart
+++ b/lib/src/dom/web_nfc.dart
@@ -13,18 +13,18 @@ typedef NDEFMessageSource = JSAny;
 extension type NDEFMessage._(JSObject _) implements JSObject {
   external factory NDEFMessage(NDEFMessageInit messageInit);
 
-  external JSArray get records;
+  external JSArray<NDEFRecord> get records;
 }
 extension type NDEFMessageInit._(JSObject _) implements JSObject {
-  external factory NDEFMessageInit({required JSArray records});
+  external factory NDEFMessageInit({required JSArray<NDEFRecordInit> records});
 
-  external set records(JSArray value);
-  external JSArray get records;
+  external set records(JSArray<NDEFRecordInit> value);
+  external JSArray<NDEFRecordInit> get records;
 }
 extension type NDEFRecord._(JSObject _) implements JSObject {
   external factory NDEFRecord(NDEFRecordInit recordInit);
 
-  external JSArray? toRecords();
+  external JSArray<NDEFRecord>? toRecords();
   external String get recordType;
   external String? get mediaType;
   external String? get id;
@@ -58,12 +58,12 @@ extension type NDEFRecordInit._(JSObject _) implements JSObject {
 extension type NDEFReader._(JSObject _) implements EventTarget, JSObject {
   external factory NDEFReader();
 
-  external JSPromise scan([NDEFScanOptions options]);
-  external JSPromise write(
+  external JSPromise<JSAny?> scan([NDEFScanOptions options]);
+  external JSPromise<JSAny?> write(
     NDEFMessageSource message, [
     NDEFWriteOptions options,
   ]);
-  external JSPromise makeReadOnly([NDEFMakeReadOnlyOptions options]);
+  external JSPromise<JSAny?> makeReadOnly([NDEFMakeReadOnlyOptions options]);
   external set onreading(EventHandler value);
   external EventHandler get onreading;
   external set onreadingerror(EventHandler value);

--- a/lib/src/dom/web_otp.dart
+++ b/lib/src/dom/web_otp.dart
@@ -13,8 +13,8 @@ extension type OTPCredential._(JSObject _) implements Credential, JSObject {
   external String get code;
 }
 extension type OTPCredentialRequestOptions._(JSObject _) implements JSObject {
-  external factory OTPCredentialRequestOptions({JSArray transport});
+  external factory OTPCredentialRequestOptions({JSArray<JSString> transport});
 
-  external set transport(JSArray value);
-  external JSArray get transport;
+  external set transport(JSArray<JSString> value);
+  external JSArray<JSString> get transport;
 }

--- a/lib/src/dom/web_share.dart
+++ b/lib/src/dom/web_share.dart
@@ -6,16 +6,18 @@
 
 import 'dart:js_interop';
 
+import 'fileapi.dart';
+
 extension type ShareData._(JSObject _) implements JSObject {
   external factory ShareData({
-    JSArray files,
+    JSArray<File> files,
     String title,
     String text,
     String url,
   });
 
-  external set files(JSArray value);
-  external JSArray get files;
+  external set files(JSArray<File> value);
+  external JSArray<File> get files;
   external set title(String value);
   external String get title;
   external set text(String value);

--- a/lib/src/dom/webaudio.dart
+++ b/lib/src/dom/webaudio.dart
@@ -44,14 +44,14 @@ extension type BaseAudioContext._(JSObject _) implements EventTarget, JSObject {
   external DynamicsCompressorNode createDynamicsCompressor();
   external GainNode createGain();
   external IIRFilterNode createIIRFilter(
-    JSArray feedforward,
-    JSArray feedback,
+    JSArray<JSNumber> feedforward,
+    JSArray<JSNumber> feedback,
   );
   external OscillatorNode createOscillator();
   external PannerNode createPanner();
   external PeriodicWave createPeriodicWave(
-    JSArray real,
-    JSArray imag, [
+    JSArray<JSNumber> real,
+    JSArray<JSNumber> imag, [
     PeriodicWaveConstraints constraints,
   ]);
   external ScriptProcessorNode createScriptProcessor([
@@ -61,7 +61,7 @@ extension type BaseAudioContext._(JSObject _) implements EventTarget, JSObject {
   ]);
   external StereoPannerNode createStereoPanner();
   external WaveShaperNode createWaveShaper();
-  external JSPromise decodeAudioData(
+  external JSPromise<AudioBuffer> decodeAudioData(
     JSArrayBuffer audioData, [
     DecodeSuccessCallback? successCallback,
     DecodeErrorCallback? errorCallback,
@@ -81,10 +81,10 @@ extension type AudioContext._(JSObject _)
   external factory AudioContext([AudioContextOptions contextOptions]);
 
   external AudioTimestamp getOutputTimestamp();
-  external JSPromise resume();
-  external JSPromise suspend();
-  external JSPromise close();
-  external JSPromise setSinkId(JSAny sinkId);
+  external JSPromise<JSAny?> resume();
+  external JSPromise<JSAny?> suspend();
+  external JSPromise<JSAny?> close();
+  external JSPromise<JSAny?> setSinkId(JSAny sinkId);
   external MediaElementAudioSourceNode createMediaElementSource(
       HTMLMediaElement mediaElement);
   external MediaStreamAudioSourceNode createMediaStreamSource(
@@ -187,9 +187,9 @@ extension type OfflineAudioContext._(JSObject _)
     num sampleRate,
   ]);
 
-  external JSPromise startRendering();
-  external JSPromise resume();
-  external JSPromise suspend(num suspendTime);
+  external JSPromise<AudioBuffer> startRendering();
+  external JSPromise<JSAny?> resume();
+  external JSPromise<JSAny?> suspend(num suspendTime);
   external int get length;
   external set oncomplete(EventHandler value);
   external EventHandler get oncomplete;
@@ -315,7 +315,7 @@ extension type AudioParam._(JSObject _) implements JSObject {
     num timeConstant,
   );
   external AudioParam setValueCurveAtTime(
-    JSArray values,
+    JSArray<JSNumber> values,
     num startTime,
     num duration,
   );
@@ -661,14 +661,14 @@ extension type IIRFilterNode._(JSObject _) implements AudioNode, JSObject {
 extension type IIRFilterOptions._(JSObject _)
     implements AudioNodeOptions, JSObject {
   external factory IIRFilterOptions({
-    required JSArray feedforward,
-    required JSArray feedback,
+    required JSArray<JSNumber> feedforward,
+    required JSArray<JSNumber> feedback,
   });
 
-  external set feedforward(JSArray value);
-  external JSArray get feedforward;
-  external set feedback(JSArray value);
-  external JSArray get feedback;
+  external set feedforward(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get feedforward;
+  external set feedback(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get feedback;
 }
 extension type MediaElementAudioSourceNode._(JSObject _)
     implements AudioNode, JSObject {
@@ -860,14 +860,14 @@ extension type PeriodicWaveConstraints._(JSObject _) implements JSObject {
 extension type PeriodicWaveOptions._(JSObject _)
     implements PeriodicWaveConstraints, JSObject {
   external factory PeriodicWaveOptions({
-    JSArray real,
-    JSArray imag,
+    JSArray<JSNumber> real,
+    JSArray<JSNumber> imag,
   });
 
-  external set real(JSArray value);
-  external JSArray get real;
-  external set imag(JSArray value);
-  external JSArray get imag;
+  external set real(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get real;
+  external set imag(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get imag;
 }
 extension type ScriptProcessorNode._(JSObject _)
     implements AudioNode, JSObject {
@@ -904,12 +904,12 @@ extension type WaveShaperNode._(JSObject _) implements AudioNode, JSObject {
 extension type WaveShaperOptions._(JSObject _)
     implements AudioNodeOptions, JSObject {
   external factory WaveShaperOptions({
-    JSArray curve,
+    JSArray<JSNumber> curve,
     OverSampleType oversample,
   });
 
-  external set curve(JSArray value);
-  external JSArray get curve;
+  external set curve(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get curve;
   external set oversample(OverSampleType value);
   external OverSampleType get oversample;
 }
@@ -946,7 +946,7 @@ extension type AudioWorkletNodeOptions._(JSObject _)
   external factory AudioWorkletNodeOptions({
     int numberOfInputs,
     int numberOfOutputs,
-    JSArray outputChannelCount,
+    JSArray<JSNumber> outputChannelCount,
     JSAny parameterData,
     JSObject processorOptions,
   });
@@ -955,8 +955,8 @@ extension type AudioWorkletNodeOptions._(JSObject _)
   external int get numberOfInputs;
   external set numberOfOutputs(int value);
   external int get numberOfOutputs;
-  external set outputChannelCount(JSArray value);
-  external JSArray get outputChannelCount;
+  external set outputChannelCount(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get outputChannelCount;
   external set parameterData(JSAny value);
   external JSAny get parameterData;
   external set processorOptions(JSObject value);

--- a/lib/src/dom/webauthn.dart
+++ b/lib/src/dom/webauthn.dart
@@ -14,8 +14,8 @@ import 'webidl.dart';
 typedef Base64URLString = String;
 typedef PublicKeyCredentialJSON = JSObject;
 typedef COSEAlgorithmIdentifier = int;
-typedef UvmEntry = JSArray;
-typedef UvmEntries = JSArray;
+typedef UvmEntry = JSArray<JSNumber>;
+typedef UvmEntries = JSArray<UvmEntry>;
 typedef AuthenticatorAttachment = String;
 typedef ResidentKeyRequirement = String;
 typedef AttestationConveyancePreference = String;
@@ -27,9 +27,11 @@ typedef PublicKeyCredentialHints = String;
 typedef LargeBlobSupport = String;
 extension type PublicKeyCredential._(JSObject _)
     implements Credential, JSObject {
-  external static JSPromise isConditionalMediationAvailable();
-  external static JSPromise isUserVerifyingPlatformAuthenticatorAvailable();
-  external static JSPromise isPasskeyPlatformAuthenticatorAvailable();
+  external static JSPromise<JSBoolean> isConditionalMediationAvailable();
+  external static JSPromise<JSBoolean>
+      isUserVerifyingPlatformAuthenticatorAvailable();
+  external static JSPromise<JSBoolean>
+      isPasskeyPlatformAuthenticatorAvailable();
   external static PublicKeyCredentialCreationOptions
       parseCreationOptionsFromJSON(
           PublicKeyCredentialCreationOptionsJSON options);
@@ -70,7 +72,7 @@ extension type AuthenticatorAttestationResponseJSON._(JSObject _)
   external factory AuthenticatorAttestationResponseJSON({
     required Base64URLString clientDataJSON,
     required Base64URLString authenticatorData,
-    required JSArray transports,
+    required JSArray<JSString> transports,
     Base64URLString publicKey,
     required int publicKeyAlgorithm,
     required Base64URLString attestationObject,
@@ -80,8 +82,8 @@ extension type AuthenticatorAttestationResponseJSON._(JSObject _)
   external Base64URLString get clientDataJSON;
   external set authenticatorData(Base64URLString value);
   external Base64URLString get authenticatorData;
-  external set transports(JSArray value);
-  external JSArray get transports;
+  external set transports(JSArray<JSString> value);
+  external JSArray<JSString> get transports;
   external set publicKey(Base64URLString value);
   external Base64URLString get publicKey;
   external set publicKeyAlgorithm(int value);
@@ -144,13 +146,13 @@ extension type PublicKeyCredentialCreationOptionsJSON._(JSObject _)
     required PublicKeyCredentialRpEntity rp,
     required PublicKeyCredentialUserEntityJSON user,
     required Base64URLString challenge,
-    required JSArray pubKeyCredParams,
+    required JSArray<PublicKeyCredentialParameters> pubKeyCredParams,
     int timeout,
-    JSArray excludeCredentials,
+    JSArray<PublicKeyCredentialDescriptorJSON> excludeCredentials,
     AuthenticatorSelectionCriteria authenticatorSelection,
-    JSArray hints,
+    JSArray<JSString> hints,
     String attestation,
-    JSArray attestationFormats,
+    JSArray<JSString> attestationFormats,
     AuthenticationExtensionsClientInputsJSON extensions,
   });
 
@@ -160,20 +162,21 @@ extension type PublicKeyCredentialCreationOptionsJSON._(JSObject _)
   external PublicKeyCredentialUserEntityJSON get user;
   external set challenge(Base64URLString value);
   external Base64URLString get challenge;
-  external set pubKeyCredParams(JSArray value);
-  external JSArray get pubKeyCredParams;
+  external set pubKeyCredParams(JSArray<PublicKeyCredentialParameters> value);
+  external JSArray<PublicKeyCredentialParameters> get pubKeyCredParams;
   external set timeout(int value);
   external int get timeout;
-  external set excludeCredentials(JSArray value);
-  external JSArray get excludeCredentials;
+  external set excludeCredentials(
+      JSArray<PublicKeyCredentialDescriptorJSON> value);
+  external JSArray<PublicKeyCredentialDescriptorJSON> get excludeCredentials;
   external set authenticatorSelection(AuthenticatorSelectionCriteria value);
   external AuthenticatorSelectionCriteria get authenticatorSelection;
-  external set hints(JSArray value);
-  external JSArray get hints;
+  external set hints(JSArray<JSString> value);
+  external JSArray<JSString> get hints;
   external set attestation(String value);
   external String get attestation;
-  external set attestationFormats(JSArray value);
-  external JSArray get attestationFormats;
+  external set attestationFormats(JSArray<JSString> value);
+  external JSArray<JSString> get attestationFormats;
   external set extensions(AuthenticationExtensionsClientInputsJSON value);
   external AuthenticationExtensionsClientInputsJSON get extensions;
 }
@@ -197,15 +200,15 @@ extension type PublicKeyCredentialDescriptorJSON._(JSObject _)
   external factory PublicKeyCredentialDescriptorJSON({
     required Base64URLString id,
     required String type,
-    JSArray transports,
+    JSArray<JSString> transports,
   });
 
   external set id(Base64URLString value);
   external Base64URLString get id;
   external set type(String value);
   external String get type;
-  external set transports(JSArray value);
-  external JSArray get transports;
+  external set transports(JSArray<JSString> value);
+  external JSArray<JSString> get transports;
 }
 extension type AuthenticationExtensionsClientInputsJSON._(JSObject _)
     implements JSObject {
@@ -217,11 +220,11 @@ extension type PublicKeyCredentialRequestOptionsJSON._(JSObject _)
     required Base64URLString challenge,
     int timeout,
     String rpId,
-    JSArray allowCredentials,
+    JSArray<PublicKeyCredentialDescriptorJSON> allowCredentials,
     String userVerification,
-    JSArray hints,
+    JSArray<JSString> hints,
     String attestation,
-    JSArray attestationFormats,
+    JSArray<JSString> attestationFormats,
     AuthenticationExtensionsClientInputsJSON extensions,
   });
 
@@ -231,16 +234,17 @@ extension type PublicKeyCredentialRequestOptionsJSON._(JSObject _)
   external int get timeout;
   external set rpId(String value);
   external String get rpId;
-  external set allowCredentials(JSArray value);
-  external JSArray get allowCredentials;
+  external set allowCredentials(
+      JSArray<PublicKeyCredentialDescriptorJSON> value);
+  external JSArray<PublicKeyCredentialDescriptorJSON> get allowCredentials;
   external set userVerification(String value);
   external String get userVerification;
-  external set hints(JSArray value);
-  external JSArray get hints;
+  external set hints(JSArray<JSString> value);
+  external JSArray<JSString> get hints;
   external set attestation(String value);
   external String get attestation;
-  external set attestationFormats(JSArray value);
-  external JSArray get attestationFormats;
+  external set attestationFormats(JSArray<JSString> value);
+  external JSArray<JSString> get attestationFormats;
   external set extensions(AuthenticationExtensionsClientInputsJSON value);
   external AuthenticationExtensionsClientInputsJSON get extensions;
 }
@@ -249,7 +253,7 @@ extension type AuthenticatorResponse._(JSObject _) implements JSObject {
 }
 extension type AuthenticatorAttestationResponse._(JSObject _)
     implements AuthenticatorResponse, JSObject {
-  external JSArray getTransports();
+  external JSArray<JSString> getTransports();
   external JSArrayBuffer getAuthenticatorData();
   external JSArrayBuffer? getPublicKey();
   external COSEAlgorithmIdentifier getPublicKeyAlgorithm();
@@ -279,13 +283,13 @@ extension type PublicKeyCredentialCreationOptions._(JSObject _)
     required PublicKeyCredentialRpEntity rp,
     required PublicKeyCredentialUserEntity user,
     required BufferSource challenge,
-    required JSArray pubKeyCredParams,
+    required JSArray<PublicKeyCredentialParameters> pubKeyCredParams,
     int timeout,
-    JSArray excludeCredentials,
+    JSArray<PublicKeyCredentialDescriptor> excludeCredentials,
     AuthenticatorSelectionCriteria authenticatorSelection,
-    JSArray hints,
+    JSArray<JSString> hints,
     String attestation,
-    JSArray attestationFormats,
+    JSArray<JSString> attestationFormats,
     AuthenticationExtensionsClientInputs extensions,
   });
 
@@ -295,20 +299,20 @@ extension type PublicKeyCredentialCreationOptions._(JSObject _)
   external PublicKeyCredentialUserEntity get user;
   external set challenge(BufferSource value);
   external BufferSource get challenge;
-  external set pubKeyCredParams(JSArray value);
-  external JSArray get pubKeyCredParams;
+  external set pubKeyCredParams(JSArray<PublicKeyCredentialParameters> value);
+  external JSArray<PublicKeyCredentialParameters> get pubKeyCredParams;
   external set timeout(int value);
   external int get timeout;
-  external set excludeCredentials(JSArray value);
-  external JSArray get excludeCredentials;
+  external set excludeCredentials(JSArray<PublicKeyCredentialDescriptor> value);
+  external JSArray<PublicKeyCredentialDescriptor> get excludeCredentials;
   external set authenticatorSelection(AuthenticatorSelectionCriteria value);
   external AuthenticatorSelectionCriteria get authenticatorSelection;
-  external set hints(JSArray value);
-  external JSArray get hints;
+  external set hints(JSArray<JSString> value);
+  external JSArray<JSString> get hints;
   external set attestation(String value);
   external String get attestation;
-  external set attestationFormats(JSArray value);
-  external JSArray get attestationFormats;
+  external set attestationFormats(JSArray<JSString> value);
+  external JSArray<JSString> get attestationFormats;
   external set extensions(AuthenticationExtensionsClientInputs value);
   external AuthenticationExtensionsClientInputs get extensions;
 }
@@ -361,11 +365,11 @@ extension type PublicKeyCredentialRequestOptions._(JSObject _)
     required BufferSource challenge,
     int timeout,
     String rpId,
-    JSArray allowCredentials,
+    JSArray<PublicKeyCredentialDescriptor> allowCredentials,
     String userVerification,
-    JSArray hints,
+    JSArray<JSString> hints,
     String attestation,
-    JSArray attestationFormats,
+    JSArray<JSString> attestationFormats,
     AuthenticationExtensionsClientInputs extensions,
   });
 
@@ -375,16 +379,16 @@ extension type PublicKeyCredentialRequestOptions._(JSObject _)
   external int get timeout;
   external set rpId(String value);
   external String get rpId;
-  external set allowCredentials(JSArray value);
-  external JSArray get allowCredentials;
+  external set allowCredentials(JSArray<PublicKeyCredentialDescriptor> value);
+  external JSArray<PublicKeyCredentialDescriptor> get allowCredentials;
   external set userVerification(String value);
   external String get userVerification;
-  external set hints(JSArray value);
-  external JSArray get hints;
+  external set hints(JSArray<JSString> value);
+  external JSArray<JSString> get hints;
   external set attestation(String value);
   external String get attestation;
-  external set attestationFormats(JSArray value);
-  external JSArray get attestationFormats;
+  external set attestationFormats(JSArray<JSString> value);
+  external JSArray<JSString> get attestationFormats;
   external set extensions(AuthenticationExtensionsClientInputs value);
   external AuthenticationExtensionsClientInputs get extensions;
 }
@@ -509,15 +513,15 @@ extension type PublicKeyCredentialDescriptor._(JSObject _) implements JSObject {
   external factory PublicKeyCredentialDescriptor({
     required String type,
     required BufferSource id,
-    JSArray transports,
+    JSArray<JSString> transports,
   });
 
   external set type(String value);
   external String get type;
   external set id(BufferSource value);
   external BufferSource get id;
-  external set transports(JSArray value);
-  external JSArray get transports;
+  external set transports(JSArray<JSString> value);
+  external JSArray<JSString> get transports;
 }
 extension type CredentialPropertiesOutput._(JSObject _) implements JSObject {
   external factory CredentialPropertiesOutput({bool rk});
@@ -595,13 +599,13 @@ extension type AuthenticationExtensionsDevicePublicKeyInputs._(JSObject _)
     implements JSObject {
   external factory AuthenticationExtensionsDevicePublicKeyInputs({
     String attestation,
-    JSArray attestationFormats,
+    JSArray<JSString> attestationFormats,
   });
 
   external set attestation(String value);
   external String get attestation;
-  external set attestationFormats(JSArray value);
-  external JSArray get attestationFormats;
+  external set attestationFormats(JSArray<JSString> value);
+  external JSArray<JSString> get attestationFormats;
 }
 extension type AuthenticationExtensionsDevicePublicKeyOutputs._(JSObject _)
     implements JSObject {

--- a/lib/src/dom/webcodecs.dart
+++ b/lib/src/dom/webcodecs.dart
@@ -40,10 +40,11 @@ typedef VideoMatrixCoefficients = String;
 extension type AudioDecoder._(JSObject _) implements EventTarget, JSObject {
   external factory AudioDecoder(AudioDecoderInit init);
 
-  external static JSPromise isConfigSupported(AudioDecoderConfig config);
+  external static JSPromise<AudioDecoderSupport> isConfigSupported(
+      AudioDecoderConfig config);
   external void configure(AudioDecoderConfig config);
   external void decode(EncodedAudioChunk chunk);
-  external JSPromise flush();
+  external JSPromise<JSAny?> flush();
   external void reset();
   external void close();
   external CodecState get state;
@@ -65,10 +66,11 @@ extension type AudioDecoderInit._(JSObject _) implements JSObject {
 extension type VideoDecoder._(JSObject _) implements EventTarget, JSObject {
   external factory VideoDecoder(VideoDecoderInit init);
 
-  external static JSPromise isConfigSupported(VideoDecoderConfig config);
+  external static JSPromise<VideoDecoderSupport> isConfigSupported(
+      VideoDecoderConfig config);
   external void configure(VideoDecoderConfig config);
   external void decode(EncodedVideoChunk chunk);
-  external JSPromise flush();
+  external JSPromise<JSAny?> flush();
   external void reset();
   external void close();
   external CodecState get state;
@@ -90,10 +92,11 @@ extension type VideoDecoderInit._(JSObject _) implements JSObject {
 extension type AudioEncoder._(JSObject _) implements EventTarget, JSObject {
   external factory AudioEncoder(AudioEncoderInit init);
 
-  external static JSPromise isConfigSupported(AudioEncoderConfig config);
+  external static JSPromise<AudioEncoderSupport> isConfigSupported(
+      AudioEncoderConfig config);
   external void configure(AudioEncoderConfig config);
   external void encode(AudioData data);
-  external JSPromise flush();
+  external JSPromise<JSAny?> flush();
   external void reset();
   external void close();
   external CodecState get state;
@@ -122,13 +125,14 @@ extension type EncodedAudioChunkMetadata._(JSObject _) implements JSObject {
 extension type VideoEncoder._(JSObject _) implements EventTarget, JSObject {
   external factory VideoEncoder(VideoEncoderInit init);
 
-  external static JSPromise isConfigSupported(VideoEncoderConfig config);
+  external static JSPromise<VideoEncoderSupport> isConfigSupported(
+      VideoEncoderConfig config);
   external void configure(VideoEncoderConfig config);
   external void encode(
     VideoFrame frame, [
     VideoEncoderEncodeOptions options,
   ]);
-  external JSPromise flush();
+  external JSPromise<JSAny?> flush();
   external void reset();
   external void close();
   external CodecState get state;
@@ -436,7 +440,7 @@ extension type AudioDataInit._(JSObject _) implements JSObject {
     required int numberOfChannels,
     required int timestamp,
     required BufferSource data,
-    JSArray transfer,
+    JSArray<JSArrayBuffer> transfer,
   });
 
   external set format(AudioSampleFormat value);
@@ -451,8 +455,8 @@ extension type AudioDataInit._(JSObject _) implements JSObject {
   external int get timestamp;
   external set data(BufferSource value);
   external BufferSource get data;
-  external set transfer(JSArray value);
-  external JSArray get transfer;
+  external set transfer(JSArray<JSArrayBuffer> value);
+  external JSArray<JSArrayBuffer> get transfer;
 }
 extension type AudioDataCopyToOptions._(JSObject _) implements JSObject {
   external factory AudioDataCopyToOptions({
@@ -479,7 +483,7 @@ extension type VideoFrame._(JSObject _) implements JSObject {
 
   external VideoFrameMetadata metadata();
   external int allocationSize([VideoFrameCopyToOptions options]);
-  external JSPromise copyTo(
+  external JSPromise<JSArray<PlaneLayout>> copyTo(
     AllowSharedBufferSource destination, [
     VideoFrameCopyToOptions options,
   ]);
@@ -529,12 +533,12 @@ extension type VideoFrameBufferInit._(JSObject _) implements JSObject {
     required int codedHeight,
     required int timestamp,
     int duration,
-    JSArray layout,
+    JSArray<PlaneLayout> layout,
     DOMRectInit visibleRect,
     int displayWidth,
     int displayHeight,
     VideoColorSpaceInit colorSpace,
-    JSArray transfer,
+    JSArray<JSArrayBuffer> transfer,
   });
 
   external set format(VideoPixelFormat value);
@@ -547,8 +551,8 @@ extension type VideoFrameBufferInit._(JSObject _) implements JSObject {
   external int get timestamp;
   external set duration(int value);
   external int get duration;
-  external set layout(JSArray value);
-  external JSArray get layout;
+  external set layout(JSArray<PlaneLayout> value);
+  external JSArray<PlaneLayout> get layout;
   external set visibleRect(DOMRectInit value);
   external DOMRectInit get visibleRect;
   external set displayWidth(int value);
@@ -557,8 +561,8 @@ extension type VideoFrameBufferInit._(JSObject _) implements JSObject {
   external int get displayHeight;
   external set colorSpace(VideoColorSpaceInit value);
   external VideoColorSpaceInit get colorSpace;
-  external set transfer(JSArray value);
-  external JSArray get transfer;
+  external set transfer(JSArray<JSArrayBuffer> value);
+  external JSArray<JSArrayBuffer> get transfer;
 }
 extension type VideoFrameMetadata._(JSObject _) implements JSObject {
   external factory VideoFrameMetadata();
@@ -566,13 +570,13 @@ extension type VideoFrameMetadata._(JSObject _) implements JSObject {
 extension type VideoFrameCopyToOptions._(JSObject _) implements JSObject {
   external factory VideoFrameCopyToOptions({
     DOMRectInit rect,
-    JSArray layout,
+    JSArray<PlaneLayout> layout,
   });
 
   external set rect(DOMRectInit value);
   external DOMRectInit get rect;
-  external set layout(JSArray value);
-  external JSArray get layout;
+  external set layout(JSArray<PlaneLayout> value);
+  external JSArray<PlaneLayout> get layout;
 }
 extension type PlaneLayout._(JSObject _) implements JSObject {
   external factory PlaneLayout({
@@ -614,13 +618,13 @@ extension type VideoColorSpaceInit._(JSObject _) implements JSObject {
 extension type ImageDecoder._(JSObject _) implements JSObject {
   external factory ImageDecoder(ImageDecoderInit init);
 
-  external static JSPromise isTypeSupported(String type);
-  external JSPromise decode([ImageDecodeOptions options]);
+  external static JSPromise<JSBoolean> isTypeSupported(String type);
+  external JSPromise<ImageDecodeResult> decode([ImageDecodeOptions options]);
   external void reset();
   external void close();
   external String get type;
   external bool get complete;
-  external JSPromise get completed;
+  external JSPromise<JSAny?> get completed;
   external ImageTrackList get tracks;
 }
 extension type ImageDecoderInit._(JSObject _) implements JSObject {
@@ -631,7 +635,7 @@ extension type ImageDecoderInit._(JSObject _) implements JSObject {
     int desiredWidth,
     int desiredHeight,
     bool preferAnimation,
-    JSArray transfer,
+    JSArray<JSArrayBuffer> transfer,
   });
 
   external set type(String value);
@@ -646,8 +650,8 @@ extension type ImageDecoderInit._(JSObject _) implements JSObject {
   external int get desiredHeight;
   external set preferAnimation(bool value);
   external bool get preferAnimation;
-  external set transfer(JSArray value);
-  external JSArray get transfer;
+  external set transfer(JSArray<JSArrayBuffer> value);
+  external JSArray<JSArrayBuffer> get transfer;
 }
 extension type ImageDecodeOptions._(JSObject _) implements JSObject {
   external factory ImageDecodeOptions({
@@ -672,7 +676,7 @@ extension type ImageDecodeResult._(JSObject _) implements JSObject {
   external bool get complete;
 }
 extension type ImageTrackList._(JSObject _) implements JSObject {
-  external JSPromise get ready;
+  external JSPromise<JSAny?> get ready;
   external int get length;
   external int get selectedIndex;
   external ImageTrack? get selectedTrack;

--- a/lib/src/dom/webcryptoapi.dart
+++ b/lib/src/dom/webcryptoapi.dart
@@ -39,73 +39,73 @@ extension type CryptoKey._(JSObject _) implements JSObject {
   external JSObject get usages;
 }
 extension type SubtleCrypto._(JSObject _) implements JSObject {
-  external JSPromise encrypt(
+  external JSPromise<JSAny?> encrypt(
     AlgorithmIdentifier algorithm,
     CryptoKey key,
     BufferSource data,
   );
-  external JSPromise decrypt(
+  external JSPromise<JSAny?> decrypt(
     AlgorithmIdentifier algorithm,
     CryptoKey key,
     BufferSource data,
   );
-  external JSPromise sign(
+  external JSPromise<JSAny?> sign(
     AlgorithmIdentifier algorithm,
     CryptoKey key,
     BufferSource data,
   );
-  external JSPromise verify(
+  external JSPromise<JSAny?> verify(
     AlgorithmIdentifier algorithm,
     CryptoKey key,
     BufferSource signature,
     BufferSource data,
   );
-  external JSPromise digest(
+  external JSPromise<JSAny?> digest(
     AlgorithmIdentifier algorithm,
     BufferSource data,
   );
-  external JSPromise generateKey(
+  external JSPromise<JSAny?> generateKey(
     AlgorithmIdentifier algorithm,
     bool extractable,
-    JSArray keyUsages,
+    JSArray<JSString> keyUsages,
   );
-  external JSPromise deriveKey(
+  external JSPromise<JSAny?> deriveKey(
     AlgorithmIdentifier algorithm,
     CryptoKey baseKey,
     AlgorithmIdentifier derivedKeyType,
     bool extractable,
-    JSArray keyUsages,
+    JSArray<JSString> keyUsages,
   );
-  external JSPromise deriveBits(
+  external JSPromise<JSArrayBuffer> deriveBits(
     AlgorithmIdentifier algorithm,
     CryptoKey baseKey,
     int length,
   );
-  external JSPromise importKey(
+  external JSPromise<CryptoKey> importKey(
     KeyFormat format,
     JSObject keyData,
     AlgorithmIdentifier algorithm,
     bool extractable,
-    JSArray keyUsages,
+    JSArray<JSString> keyUsages,
   );
-  external JSPromise exportKey(
+  external JSPromise<JSAny?> exportKey(
     KeyFormat format,
     CryptoKey key,
   );
-  external JSPromise wrapKey(
+  external JSPromise<JSAny?> wrapKey(
     KeyFormat format,
     CryptoKey key,
     CryptoKey wrappingKey,
     AlgorithmIdentifier wrapAlgorithm,
   );
-  external JSPromise unwrapKey(
+  external JSPromise<CryptoKey> unwrapKey(
     KeyFormat format,
     BufferSource wrappedKey,
     CryptoKey unwrappingKey,
     AlgorithmIdentifier unwrapAlgorithm,
     AlgorithmIdentifier unwrappedKeyAlgorithm,
     bool extractable,
-    JSArray keyUsages,
+    JSArray<JSString> keyUsages,
   );
 }
 extension type RsaOtherPrimesInfo._(JSObject _) implements JSObject {
@@ -126,7 +126,7 @@ extension type JsonWebKey._(JSObject _) implements JSObject {
   external factory JsonWebKey({
     String kty,
     String use,
-    JSArray key_ops,
+    JSArray<JSString> key_ops,
     String alg,
     bool ext,
     String crv,
@@ -140,7 +140,7 @@ extension type JsonWebKey._(JSObject _) implements JSObject {
     String dp,
     String dq,
     String qi,
-    JSArray oth,
+    JSArray<RsaOtherPrimesInfo> oth,
     String k,
   });
 
@@ -148,8 +148,8 @@ extension type JsonWebKey._(JSObject _) implements JSObject {
   external String get kty;
   external set use(String value);
   external String get use;
-  external set key_ops(JSArray value);
-  external JSArray get key_ops;
+  external set key_ops(JSArray<JSString> value);
+  external JSArray<JSString> get key_ops;
   external set alg(String value);
   external String get alg;
   external set ext(bool value);
@@ -176,8 +176,8 @@ extension type JsonWebKey._(JSObject _) implements JSObject {
   external String get dq;
   external set qi(String value);
   external String get qi;
-  external set oth(JSArray value);
-  external JSArray get oth;
+  external set oth(JSArray<RsaOtherPrimesInfo> value);
+  external JSArray<RsaOtherPrimesInfo> get oth;
   external set k(String value);
   external String get k;
 }

--- a/lib/src/dom/webgl1.dart
+++ b/lib/src/dom/webgl1.dart
@@ -382,7 +382,7 @@ extension type WebGLRenderingContext._(JSObject _) implements JSObject {
   external static GLenum get BROWSER_DEFAULT_WEBGL;
   external WebGLContextAttributes? getContextAttributes();
   external bool isContextLost();
-  external JSArray? getSupportedExtensions();
+  external JSArray<JSString>? getSupportedExtensions();
   external JSObject? getExtension(String name);
   external void activeTexture(GLenum texture);
   external void attachShader(
@@ -531,7 +531,7 @@ extension type WebGLRenderingContext._(JSObject _) implements JSObject {
     WebGLProgram program,
     GLuint index,
   );
-  external JSArray? getAttachedShaders(WebGLProgram program);
+  external JSArray<WebGLShader>? getAttachedShaders(WebGLProgram program);
   external GLint getAttribLocation(
     WebGLProgram program,
     String name,
@@ -762,7 +762,7 @@ extension type WebGLRenderingContext._(JSObject _) implements JSObject {
     GLsizei width,
     GLsizei height,
   );
-  external JSPromise makeXRCompatible();
+  external JSPromise<JSAny?> makeXRCompatible();
   external void bufferData(
     GLenum target,
     JSAny dataOrSize,

--- a/lib/src/dom/webgl2.dart
+++ b/lib/src/dom/webgl2.dart
@@ -582,7 +582,7 @@ extension type WebGL2RenderingContext._(JSObject _) implements JSObject {
   external static GLenum get MAX_CLIENT_WAIT_TIMEOUT_WEBGL;
   external WebGLContextAttributes? getContextAttributes();
   external bool isContextLost();
-  external JSArray? getSupportedExtensions();
+  external JSArray<JSString>? getSupportedExtensions();
   external JSObject? getExtension(String name);
   external void activeTexture(GLenum texture);
   external void attachShader(
@@ -731,7 +731,7 @@ extension type WebGL2RenderingContext._(JSObject _) implements JSObject {
     WebGLProgram program,
     GLuint index,
   );
-  external JSArray? getAttachedShaders(WebGLProgram program);
+  external JSArray<WebGLShader>? getAttachedShaders(WebGLProgram program);
   external GLint getAttribLocation(
     WebGLProgram program,
     String name,
@@ -962,7 +962,7 @@ extension type WebGL2RenderingContext._(JSObject _) implements JSObject {
     GLsizei width,
     GLsizei height,
   );
-  external JSPromise makeXRCompatible();
+  external JSPromise<JSAny?> makeXRCompatible();
   external void copyBufferSubData(
     GLenum readTarget,
     GLenum writeTarget,
@@ -998,11 +998,11 @@ extension type WebGL2RenderingContext._(JSObject _) implements JSObject {
   );
   external void invalidateFramebuffer(
     GLenum target,
-    JSArray attachments,
+    JSArray<JSNumber> attachments,
   );
   external void invalidateSubFramebuffer(
     GLenum target,
-    JSArray attachments,
+    JSArray<JSNumber> attachments,
     GLint x,
     GLint y,
     GLsizei width,
@@ -1246,7 +1246,7 @@ extension type WebGL2RenderingContext._(JSObject _) implements JSObject {
     GLenum type,
     GLintptr offset,
   );
-  external void drawBuffers(JSArray buffers);
+  external void drawBuffers(JSArray<JSNumber> buffers);
   external void clearBufferfv(
     GLenum buffer,
     GLint drawbuffer,
@@ -1339,7 +1339,7 @@ extension type WebGL2RenderingContext._(JSObject _) implements JSObject {
   external void endTransformFeedback();
   external void transformFeedbackVaryings(
     WebGLProgram program,
-    JSArray varyings,
+    JSArray<JSString> varyings,
     GLenum bufferMode,
   );
   external WebGLActiveInfo? getTransformFeedbackVarying(
@@ -1364,13 +1364,13 @@ extension type WebGL2RenderingContext._(JSObject _) implements JSObject {
     GLenum target,
     GLuint index,
   );
-  external JSArray? getUniformIndices(
+  external JSArray<JSNumber>? getUniformIndices(
     WebGLProgram program,
-    JSArray uniformNames,
+    JSArray<JSString> uniformNames,
   );
   external JSAny? getActiveUniforms(
     WebGLProgram program,
-    JSArray uniformIndices,
+    JSArray<JSNumber> uniformIndices,
     GLenum pname,
   );
   external GLuint getUniformBlockIndex(

--- a/lib/src/dom/webgl_compressed_texture_astc.dart
+++ b/lib/src/dom/webgl_compressed_texture_astc.dart
@@ -37,5 +37,5 @@ extension type WEBGL_compressed_texture_astc._(JSObject _) implements JSObject {
   external static GLenum get COMPRESSED_SRGB8_ALPHA8_ASTC_10x10_KHR;
   external static GLenum get COMPRESSED_SRGB8_ALPHA8_ASTC_12x10_KHR;
   external static GLenum get COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR;
-  external JSArray getSupportedProfiles();
+  external JSArray<JSString> getSupportedProfiles();
 }

--- a/lib/src/dom/webgl_draw_buffers.dart
+++ b/lib/src/dom/webgl_draw_buffers.dart
@@ -43,5 +43,5 @@ extension type WEBGL_draw_buffers._(JSObject _) implements JSObject {
   external static GLenum get DRAW_BUFFER15_WEBGL;
   external static GLenum get MAX_COLOR_ATTACHMENTS_WEBGL;
   external static GLenum get MAX_DRAW_BUFFERS_WEBGL;
-  external void drawBuffersWEBGL(JSArray buffers);
+  external void drawBuffersWEBGL(JSArray<JSNumber> buffers);
 }

--- a/lib/src/dom/webgpu.dart
+++ b/lib/src/dom/webgpu.dart
@@ -117,7 +117,8 @@ extension type GPUAdapterInfo._(JSObject _) implements JSObject {
   external String get description;
 }
 extension type GPU._(JSObject _) implements JSObject {
-  external JSPromise requestAdapter([GPURequestAdapterOptions options]);
+  external JSPromise<GPUAdapter?> requestAdapter(
+      [GPURequestAdapterOptions options]);
   external GPUTextureFormat getPreferredCanvasFormat();
   external WGSLLanguageFeatures get wgslLanguageFeatures;
 }
@@ -133,8 +134,9 @@ extension type GPURequestAdapterOptions._(JSObject _) implements JSObject {
   external bool get forceFallbackAdapter;
 }
 extension type GPUAdapter._(JSObject _) implements JSObject {
-  external JSPromise requestDevice([GPUDeviceDescriptor descriptor]);
-  external JSPromise requestAdapterInfo([JSArray unmaskHints]);
+  external JSPromise<GPUDevice> requestDevice([GPUDeviceDescriptor descriptor]);
+  external JSPromise<GPUAdapterInfo> requestAdapterInfo(
+      [JSArray<JSString> unmaskHints]);
   external GPUSupportedFeatures get features;
   external GPUSupportedLimits get limits;
   external bool get isFallbackAdapter;
@@ -142,13 +144,13 @@ extension type GPUAdapter._(JSObject _) implements JSObject {
 extension type GPUDeviceDescriptor._(JSObject _)
     implements GPUObjectDescriptorBase, JSObject {
   external factory GPUDeviceDescriptor({
-    JSArray requiredFeatures,
+    JSArray<JSString> requiredFeatures,
     JSAny requiredLimits,
     GPUQueueDescriptor defaultQueue,
   });
 
-  external set requiredFeatures(JSArray value);
-  external JSArray get requiredFeatures;
+  external set requiredFeatures(JSArray<JSString> value);
+  external JSArray<JSString> get requiredFeatures;
   external set requiredLimits(JSAny value);
   external JSAny get requiredLimits;
   external set defaultQueue(GPUQueueDescriptor value);
@@ -172,9 +174,9 @@ extension type GPUDevice._(JSObject _) implements EventTarget, JSObject {
       GPUComputePipelineDescriptor descriptor);
   external GPURenderPipeline createRenderPipeline(
       GPURenderPipelineDescriptor descriptor);
-  external JSPromise createComputePipelineAsync(
+  external JSPromise<GPUComputePipeline> createComputePipelineAsync(
       GPUComputePipelineDescriptor descriptor);
-  external JSPromise createRenderPipelineAsync(
+  external JSPromise<GPURenderPipeline> createRenderPipelineAsync(
       GPURenderPipelineDescriptor descriptor);
   external GPUCommandEncoder createCommandEncoder(
       [GPUCommandEncoderDescriptor descriptor]);
@@ -182,18 +184,18 @@ extension type GPUDevice._(JSObject _) implements EventTarget, JSObject {
       GPURenderBundleEncoderDescriptor descriptor);
   external GPUQuerySet createQuerySet(GPUQuerySetDescriptor descriptor);
   external void pushErrorScope(GPUErrorFilter filter);
-  external JSPromise popErrorScope();
+  external JSPromise<GPUError?> popErrorScope();
   external GPUSupportedFeatures get features;
   external GPUSupportedLimits get limits;
   external GPUQueue get queue;
-  external JSPromise get lost;
+  external JSPromise<GPUDeviceLostInfo> get lost;
   external set onuncapturederror(EventHandler value);
   external EventHandler get onuncapturederror;
   external set label(String value);
   external String get label;
 }
 extension type GPUBuffer._(JSObject _) implements JSObject {
-  external JSPromise mapAsync(
+  external JSPromise<JSAny?> mapAsync(
     GPUMapModeFlags mode, [
     GPUSize64 offset,
     GPUSize64 size,
@@ -270,7 +272,7 @@ extension type GPUTextureDescriptor._(JSObject _)
     GPUTextureDimension dimension,
     required GPUTextureFormat format,
     required GPUTextureUsageFlags usage,
-    JSArray viewFormats,
+    JSArray<JSString> viewFormats,
   });
 
   external set size(GPUExtent3D value);
@@ -285,8 +287,8 @@ extension type GPUTextureDescriptor._(JSObject _)
   external GPUTextureFormat get format;
   external set usage(GPUTextureUsageFlags value);
   external GPUTextureUsageFlags get usage;
-  external set viewFormats(JSArray value);
-  external JSArray get viewFormats;
+  external set viewFormats(JSArray<JSString> value);
+  external JSArray<JSString> get viewFormats;
 }
 @JS()
 external $GPUTextureUsage get GPUTextureUsage;
@@ -391,10 +393,11 @@ extension type GPUBindGroupLayout._(JSObject _) implements JSObject {
 }
 extension type GPUBindGroupLayoutDescriptor._(JSObject _)
     implements GPUObjectDescriptorBase, JSObject {
-  external factory GPUBindGroupLayoutDescriptor({required JSArray entries});
+  external factory GPUBindGroupLayoutDescriptor(
+      {required JSArray<GPUBindGroupLayoutEntry> entries});
 
-  external set entries(JSArray value);
-  external JSArray get entries;
+  external set entries(JSArray<GPUBindGroupLayoutEntry> value);
+  external JSArray<GPUBindGroupLayoutEntry> get entries;
 }
 extension type GPUBindGroupLayoutEntry._(JSObject _) implements JSObject {
   external factory GPUBindGroupLayoutEntry({
@@ -491,13 +494,13 @@ extension type GPUBindGroupDescriptor._(JSObject _)
     implements GPUObjectDescriptorBase, JSObject {
   external factory GPUBindGroupDescriptor({
     required GPUBindGroupLayout layout,
-    required JSArray entries,
+    required JSArray<GPUBindGroupEntry> entries,
   });
 
   external set layout(GPUBindGroupLayout value);
   external GPUBindGroupLayout get layout;
-  external set entries(JSArray value);
-  external JSArray get entries;
+  external set entries(JSArray<GPUBindGroupEntry> value);
+  external JSArray<GPUBindGroupEntry> get entries;
 }
 extension type GPUBindGroupEntry._(JSObject _) implements JSObject {
   external factory GPUBindGroupEntry({
@@ -531,13 +534,13 @@ extension type GPUPipelineLayout._(JSObject _) implements JSObject {
 extension type GPUPipelineLayoutDescriptor._(JSObject _)
     implements GPUObjectDescriptorBase, JSObject {
   external factory GPUPipelineLayoutDescriptor(
-      {required JSArray bindGroupLayouts});
+      {required JSArray<GPUBindGroupLayout> bindGroupLayouts});
 
-  external set bindGroupLayouts(JSArray value);
-  external JSArray get bindGroupLayouts;
+  external set bindGroupLayouts(JSArray<GPUBindGroupLayout> value);
+  external JSArray<GPUBindGroupLayout> get bindGroupLayouts;
 }
 extension type GPUShaderModule._(JSObject _) implements JSObject {
-  external JSPromise getCompilationInfo();
+  external JSPromise<GPUCompilationInfo> getCompilationInfo();
   external set label(String value);
   external String get label;
 }
@@ -572,7 +575,7 @@ extension type GPUCompilationMessage._(JSObject _) implements JSObject {
   external int get length;
 }
 extension type GPUCompilationInfo._(JSObject _) implements JSObject {
-  external JSArray get messages;
+  external JSArray<GPUCompilationMessage> get messages;
 }
 extension type GPUPipelineError._(JSObject _)
     implements DOMException, JSObject {
@@ -686,10 +689,11 @@ extension type GPUMultisampleState._(JSObject _) implements JSObject {
 }
 extension type GPUFragmentState._(JSObject _)
     implements GPUProgrammableStage, JSObject {
-  external factory GPUFragmentState({required JSArray targets});
+  external factory GPUFragmentState(
+      {required JSArray<GPUColorTargetState?> targets});
 
-  external set targets(JSArray value);
-  external JSArray get targets;
+  external set targets(JSArray<GPUColorTargetState?> value);
+  external JSArray<GPUColorTargetState?> get targets;
 }
 extension type GPUColorTargetState._(JSObject _) implements JSObject {
   external factory GPUColorTargetState({
@@ -794,24 +798,24 @@ extension type GPUStencilFaceState._(JSObject _) implements JSObject {
 }
 extension type GPUVertexState._(JSObject _)
     implements GPUProgrammableStage, JSObject {
-  external factory GPUVertexState({JSArray buffers});
+  external factory GPUVertexState({JSArray<GPUVertexBufferLayout?> buffers});
 
-  external set buffers(JSArray value);
-  external JSArray get buffers;
+  external set buffers(JSArray<GPUVertexBufferLayout?> value);
+  external JSArray<GPUVertexBufferLayout?> get buffers;
 }
 extension type GPUVertexBufferLayout._(JSObject _) implements JSObject {
   external factory GPUVertexBufferLayout({
     required GPUSize64 arrayStride,
     GPUVertexStepMode stepMode,
-    required JSArray attributes,
+    required JSArray<GPUVertexAttribute> attributes,
   });
 
   external set arrayStride(GPUSize64 value);
   external GPUSize64 get arrayStride;
   external set stepMode(GPUVertexStepMode value);
   external GPUVertexStepMode get stepMode;
-  external set attributes(JSArray value);
-  external JSArray get attributes;
+  external set attributes(JSArray<GPUVertexAttribute> value);
+  external JSArray<GPUVertexAttribute> get attributes;
 }
 extension type GPUVertexAttribute._(JSObject _) implements JSObject {
   external factory GPUVertexAttribute({
@@ -1019,7 +1023,7 @@ extension type GPURenderPassEncoder._(JSObject _) implements JSObject {
   external void setStencilReference(GPUStencilValue reference);
   external void beginOcclusionQuery(GPUSize32 queryIndex);
   external void endOcclusionQuery();
-  external void executeBundles(JSArray bundles);
+  external void executeBundles(JSArray<GPURenderBundle> bundles);
   external void end();
   external void pushDebugGroup(String groupLabel);
   external void popDebugGroup();
@@ -1085,15 +1089,15 @@ extension type GPURenderPassTimestampWrites._(JSObject _) implements JSObject {
 extension type GPURenderPassDescriptor._(JSObject _)
     implements GPUObjectDescriptorBase, JSObject {
   external factory GPURenderPassDescriptor({
-    required JSArray colorAttachments,
+    required JSArray<GPURenderPassColorAttachment?> colorAttachments,
     GPURenderPassDepthStencilAttachment depthStencilAttachment,
     GPUQuerySet occlusionQuerySet,
     GPURenderPassTimestampWrites timestampWrites,
     GPUSize64 maxDrawCount,
   });
 
-  external set colorAttachments(JSArray value);
-  external JSArray get colorAttachments;
+  external set colorAttachments(JSArray<GPURenderPassColorAttachment?> value);
+  external JSArray<GPURenderPassColorAttachment?> get colorAttachments;
   external set depthStencilAttachment(
       GPURenderPassDepthStencilAttachment value);
   external GPURenderPassDepthStencilAttachment get depthStencilAttachment;
@@ -1160,13 +1164,13 @@ extension type GPURenderPassDepthStencilAttachment._(JSObject _)
 extension type GPURenderPassLayout._(JSObject _)
     implements GPUObjectDescriptorBase, JSObject {
   external factory GPURenderPassLayout({
-    required JSArray colorFormats,
+    required JSArray<JSString> colorFormats,
     GPUTextureFormat depthStencilFormat,
     GPUSize32 sampleCount,
   });
 
-  external set colorFormats(JSArray value);
-  external JSArray get colorFormats;
+  external set colorFormats(JSArray<JSString> value);
+  external JSArray<JSString> get colorFormats;
   external set depthStencilFormat(GPUTextureFormat value);
   external GPUTextureFormat get depthStencilFormat;
   external set sampleCount(GPUSize32 value);
@@ -1246,8 +1250,8 @@ extension type GPUQueueDescriptor._(JSObject _)
   external factory GPUQueueDescriptor();
 }
 extension type GPUQueue._(JSObject _) implements JSObject {
-  external void submit(JSArray commandBuffers);
-  external JSPromise onSubmittedWorkDone();
+  external void submit(JSArray<GPUCommandBuffer> commandBuffers);
+  external JSPromise<JSAny?> onSubmittedWorkDone();
   external void writeBuffer(
     GPUBuffer buffer,
     GPUSize64 bufferOffset,
@@ -1299,7 +1303,7 @@ extension type GPUCanvasConfiguration._(JSObject _) implements JSObject {
     required GPUDevice device,
     required GPUTextureFormat format,
     GPUTextureUsageFlags usage,
-    JSArray viewFormats,
+    JSArray<JSString> viewFormats,
     PredefinedColorSpace colorSpace,
     GPUCanvasAlphaMode alphaMode,
   });
@@ -1310,8 +1314,8 @@ extension type GPUCanvasConfiguration._(JSObject _) implements JSObject {
   external GPUTextureFormat get format;
   external set usage(GPUTextureUsageFlags value);
   external GPUTextureUsageFlags get usage;
-  external set viewFormats(JSArray value);
-  external JSArray get viewFormats;
+  external set viewFormats(JSArray<JSString> value);
+  external JSArray<JSString> get viewFormats;
   external set colorSpace(PredefinedColorSpace value);
   external PredefinedColorSpace get colorSpace;
   external set alphaMode(GPUCanvasAlphaMode value);

--- a/lib/src/dom/webhid.dart
+++ b/lib/src/dom/webhid.dart
@@ -12,8 +12,9 @@ import 'webidl.dart';
 
 typedef HIDUnitSystem = String;
 extension type HID._(JSObject _) implements EventTarget, JSObject {
-  external JSPromise getDevices();
-  external JSPromise requestDevice(HIDDeviceRequestOptions options);
+  external JSPromise<JSArray<HIDDevice>> getDevices();
+  external JSPromise<JSArray<HIDDevice>> requestDevice(
+      HIDDeviceRequestOptions options);
   external set onconnect(EventHandler value);
   external EventHandler get onconnect;
   external set ondisconnect(EventHandler value);
@@ -21,14 +22,14 @@ extension type HID._(JSObject _) implements EventTarget, JSObject {
 }
 extension type HIDDeviceRequestOptions._(JSObject _) implements JSObject {
   external factory HIDDeviceRequestOptions({
-    required JSArray filters,
-    JSArray exclusionFilters,
+    required JSArray<HIDDeviceFilter> filters,
+    JSArray<HIDDeviceFilter> exclusionFilters,
   });
 
-  external set filters(JSArray value);
-  external JSArray get filters;
-  external set exclusionFilters(JSArray value);
-  external JSArray get exclusionFilters;
+  external set filters(JSArray<HIDDeviceFilter> value);
+  external JSArray<HIDDeviceFilter> get filters;
+  external set exclusionFilters(JSArray<HIDDeviceFilter> value);
+  external JSArray<HIDDeviceFilter> get exclusionFilters;
 }
 extension type HIDDeviceFilter._(JSObject _) implements JSObject {
   external factory HIDDeviceFilter({
@@ -48,25 +49,25 @@ extension type HIDDeviceFilter._(JSObject _) implements JSObject {
   external int get usage;
 }
 extension type HIDDevice._(JSObject _) implements EventTarget, JSObject {
-  external JSPromise open();
-  external JSPromise close();
-  external JSPromise forget();
-  external JSPromise sendReport(
+  external JSPromise<JSAny?> open();
+  external JSPromise<JSAny?> close();
+  external JSPromise<JSAny?> forget();
+  external JSPromise<JSAny?> sendReport(
     int reportId,
     BufferSource data,
   );
-  external JSPromise sendFeatureReport(
+  external JSPromise<JSAny?> sendFeatureReport(
     int reportId,
     BufferSource data,
   );
-  external JSPromise receiveFeatureReport(int reportId);
+  external JSPromise<JSDataView> receiveFeatureReport(int reportId);
   external set oninputreport(EventHandler value);
   external EventHandler get oninputreport;
   external bool get opened;
   external int get vendorId;
   external int get productId;
   external String get productName;
-  external JSArray get collections;
+  external JSArray<HIDCollectionInfo> get collections;
 }
 extension type HIDConnectionEvent._(JSObject _) implements Event, JSObject {
   external factory HIDConnectionEvent(
@@ -113,10 +114,10 @@ extension type HIDCollectionInfo._(JSObject _) implements JSObject {
     int usagePage,
     int usage,
     int type,
-    JSArray children,
-    JSArray inputReports,
-    JSArray outputReports,
-    JSArray featureReports,
+    JSArray<HIDCollectionInfo> children,
+    JSArray<HIDReportInfo> inputReports,
+    JSArray<HIDReportInfo> outputReports,
+    JSArray<HIDReportInfo> featureReports,
   });
 
   external set usagePage(int value);
@@ -125,25 +126,25 @@ extension type HIDCollectionInfo._(JSObject _) implements JSObject {
   external int get usage;
   external set type(int value);
   external int get type;
-  external set children(JSArray value);
-  external JSArray get children;
-  external set inputReports(JSArray value);
-  external JSArray get inputReports;
-  external set outputReports(JSArray value);
-  external JSArray get outputReports;
-  external set featureReports(JSArray value);
-  external JSArray get featureReports;
+  external set children(JSArray<HIDCollectionInfo> value);
+  external JSArray<HIDCollectionInfo> get children;
+  external set inputReports(JSArray<HIDReportInfo> value);
+  external JSArray<HIDReportInfo> get inputReports;
+  external set outputReports(JSArray<HIDReportInfo> value);
+  external JSArray<HIDReportInfo> get outputReports;
+  external set featureReports(JSArray<HIDReportInfo> value);
+  external JSArray<HIDReportInfo> get featureReports;
 }
 extension type HIDReportInfo._(JSObject _) implements JSObject {
   external factory HIDReportInfo({
     int reportId,
-    JSArray items,
+    JSArray<HIDReportItem> items,
   });
 
   external set reportId(int value);
   external int get reportId;
-  external set items(JSArray value);
-  external JSArray get items;
+  external set items(JSArray<HIDReportItem> value);
+  external JSArray<HIDReportItem> get items;
 }
 extension type HIDReportItem._(JSObject _) implements JSObject {
   external factory HIDReportItem({
@@ -157,7 +158,7 @@ extension type HIDReportItem._(JSObject _) implements JSObject {
     bool hasNull,
     bool hasPreferredState,
     bool wrap,
-    JSArray usages,
+    JSArray<JSNumber> usages,
     int usageMinimum,
     int usageMaximum,
     int reportSize,
@@ -174,7 +175,7 @@ extension type HIDReportItem._(JSObject _) implements JSObject {
     int logicalMaximum,
     int physicalMinimum,
     int physicalMaximum,
-    JSArray strings,
+    JSArray<JSString> strings,
   });
 
   external set isAbsolute(bool value);
@@ -197,8 +198,8 @@ extension type HIDReportItem._(JSObject _) implements JSObject {
   external bool get hasPreferredState;
   external set wrap(bool value);
   external bool get wrap;
-  external set usages(JSArray value);
-  external JSArray get usages;
+  external set usages(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get usages;
   external set usageMinimum(int value);
   external int get usageMinimum;
   external set usageMaximum(int value);
@@ -231,6 +232,6 @@ extension type HIDReportItem._(JSObject _) implements JSObject {
   external int get physicalMinimum;
   external set physicalMaximum(int value);
   external int get physicalMaximum;
-  external set strings(JSArray value);
-  external JSArray get strings;
+  external set strings(JSArray<JSString> value);
+  external JSArray<JSString> get strings;
 }

--- a/lib/src/dom/webmidi.dart
+++ b/lib/src/dom/webmidi.dart
@@ -42,8 +42,8 @@ extension type MIDIAccess._(JSObject _) implements EventTarget, JSObject {
   external bool get sysexEnabled;
 }
 extension type MIDIPort._(JSObject _) implements EventTarget, JSObject {
-  external JSPromise open();
-  external JSPromise close();
+  external JSPromise<MIDIPort> open();
+  external JSPromise<MIDIPort> close();
   external String get id;
   external String? get manufacturer;
   external String? get name;
@@ -60,7 +60,7 @@ extension type MIDIInput._(JSObject _) implements MIDIPort, JSObject {
 }
 extension type MIDIOutput._(JSObject _) implements MIDIPort, JSObject {
   external void send(
-    JSArray data, [
+    JSArray<JSNumber> data, [
     DOMHighResTimeStamp timestamp,
   ]);
   external void clear();

--- a/lib/src/dom/webnn.dart
+++ b/lib/src/dom/webnn.dart
@@ -38,20 +38,20 @@ extension type MLContextOptions._(JSObject _) implements JSObject {
   external MLPowerPreference get powerPreference;
 }
 extension type ML._(JSObject _) implements JSObject {
-  external JSPromise createContext([JSObject gpuDeviceOrOptions]);
+  external JSPromise<MLContext> createContext([JSObject gpuDeviceOrOptions]);
   external MLContext createContextSync([JSObject gpuDeviceOrOptions]);
 }
 extension type MLGraph._(JSObject _) implements JSObject {}
 extension type MLOperandDescriptor._(JSObject _) implements JSObject {
   external factory MLOperandDescriptor({
     required MLOperandType type,
-    JSArray dimensions,
+    JSArray<JSNumber> dimensions,
   });
 
   external set type(MLOperandType value);
   external MLOperandType get type;
-  external set dimensions(JSArray value);
-  external JSArray get dimensions;
+  external set dimensions(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get dimensions;
 }
 extension type MLOperand._(JSObject _) implements JSObject {}
 extension type MLActivation._(JSObject _) implements JSObject {}
@@ -61,7 +61,7 @@ extension type MLContext._(JSObject _) implements JSObject {
     MLNamedArrayBufferViews inputs,
     MLNamedArrayBufferViews outputs,
   );
-  external JSPromise compute(
+  external JSPromise<MLComputeResult> compute(
     MLGraph graph,
     MLNamedArrayBufferViews inputs,
     MLNamedArrayBufferViews outputs,
@@ -113,7 +113,7 @@ extension type MLGraphBuilder._(JSObject _) implements JSObject {
     JSAny descriptorOrValue, [
     JSAny bufferViewOrType,
   ]);
-  external JSPromise build(MLNamedOperands outputs);
+  external JSPromise<MLGraph> build(MLNamedOperands outputs);
   external MLGraph buildSync(MLNamedOperands outputs);
   external MLOperand batchNormalization(
     MLOperand input,
@@ -126,7 +126,7 @@ extension type MLGraphBuilder._(JSObject _) implements JSObject {
     MLClampOptions options,
   ]);
   external MLOperand concat(
-    JSArray inputs,
+    JSArray<MLOperand> inputs,
     int axis,
   );
   external MLOperand conv2d(
@@ -185,7 +185,7 @@ extension type MLGraphBuilder._(JSObject _) implements JSObject {
     MLOperand b, [
     MLGemmOptions options,
   ]);
-  external JSArray gru(
+  external JSArray<MLOperand> gru(
     MLOperand input,
     MLOperand weight,
     MLOperand recurrentWeight,
@@ -218,7 +218,7 @@ extension type MLGraphBuilder._(JSObject _) implements JSObject {
     JSObject inputOrOptions,
     MLLinearOptions options,
   ]);
-  external JSArray lstm(
+  external JSArray<MLOperand> lstm(
     MLOperand input,
     MLOperand weight,
     MLOperand recurrentWeight,
@@ -226,7 +226,7 @@ extension type MLGraphBuilder._(JSObject _) implements JSObject {
     int hiddenSize, [
     MLLstmOptions options,
   ]);
-  external JSArray lstmCell(
+  external JSArray<MLOperand> lstmCell(
     MLOperand input,
     MLOperand weight,
     MLOperand recurrentWeight,
@@ -241,8 +241,8 @@ extension type MLGraphBuilder._(JSObject _) implements JSObject {
   );
   external MLOperand pad(
     MLOperand input,
-    JSArray beginningPadding,
-    JSArray endingPadding, [
+    JSArray<JSNumber> beginningPadding,
+    JSArray<JSNumber> endingPadding, [
     MLPadOptions options,
   ]);
   external MLOperand averagePool2d(
@@ -308,13 +308,13 @@ extension type MLGraphBuilder._(JSObject _) implements JSObject {
   ]);
   external MLOperand reshape(
     MLOperand input,
-    JSArray newShape,
+    JSArray<JSNumber?> newShape,
   );
   external JSObject sigmoid([MLOperand input]);
   external MLOperand slice(
     MLOperand input,
-    JSArray starts,
-    JSArray sizes,
+    JSArray<JSNumber> starts,
+    JSArray<JSNumber> sizes,
   );
   external JSObject softmax([MLOperand input]);
   external JSObject softplus([
@@ -322,7 +322,7 @@ extension type MLGraphBuilder._(JSObject _) implements JSObject {
     MLSoftplusOptions options,
   ]);
   external JSObject softsign([MLOperand input]);
-  external JSArray split(
+  external JSArray<MLOperand> split(
     MLOperand input,
     JSAny splits, [
     MLSplitOptions options,
@@ -370,9 +370,9 @@ extension type MLClampOptions._(JSObject _) implements JSObject {
 }
 extension type MLConv2dOptions._(JSObject _) implements JSObject {
   external factory MLConv2dOptions({
-    JSArray padding,
-    JSArray strides,
-    JSArray dilations,
+    JSArray<JSNumber> padding,
+    JSArray<JSNumber> strides,
+    JSArray<JSNumber> dilations,
     MLAutoPad autoPad,
     int groups,
     MLInputOperandLayout inputLayout,
@@ -381,12 +381,12 @@ extension type MLConv2dOptions._(JSObject _) implements JSObject {
     MLActivation activation,
   });
 
-  external set padding(JSArray value);
-  external JSArray get padding;
-  external set strides(JSArray value);
-  external JSArray get strides;
-  external set dilations(JSArray value);
-  external JSArray get dilations;
+  external set padding(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get padding;
+  external set strides(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get strides;
+  external set dilations(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get dilations;
   external set autoPad(MLAutoPad value);
   external MLAutoPad get autoPad;
   external set groups(int value);
@@ -402,11 +402,11 @@ extension type MLConv2dOptions._(JSObject _) implements JSObject {
 }
 extension type MLConvTranspose2dOptions._(JSObject _) implements JSObject {
   external factory MLConvTranspose2dOptions({
-    JSArray padding,
-    JSArray strides,
-    JSArray dilations,
-    JSArray outputPadding,
-    JSArray outputSizes,
+    JSArray<JSNumber> padding,
+    JSArray<JSNumber> strides,
+    JSArray<JSNumber> dilations,
+    JSArray<JSNumber> outputPadding,
+    JSArray<JSNumber> outputSizes,
     MLAutoPad autoPad,
     int groups,
     MLInputOperandLayout inputLayout,
@@ -415,16 +415,16 @@ extension type MLConvTranspose2dOptions._(JSObject _) implements JSObject {
     MLActivation activation,
   });
 
-  external set padding(JSArray value);
-  external JSArray get padding;
-  external set strides(JSArray value);
-  external JSArray get strides;
-  external set dilations(JSArray value);
-  external JSArray get dilations;
-  external set outputPadding(JSArray value);
-  external JSArray get outputPadding;
-  external set outputSizes(JSArray value);
-  external JSArray get outputSizes;
+  external set padding(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get padding;
+  external set strides(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get strides;
+  external set dilations(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get dilations;
+  external set outputPadding(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get outputPadding;
+  external set outputSizes(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get outputSizes;
   external set autoPad(MLAutoPad value);
   external MLAutoPad get autoPad;
   external set groups(int value);
@@ -473,7 +473,7 @@ extension type MLGruOptions._(JSObject _) implements JSObject {
     bool returnSequence,
     MLRecurrentNetworkDirection direction,
     MLGruWeightLayout layout,
-    JSArray activations,
+    JSArray<MLActivation> activations,
   });
 
   external set bias(MLOperand value);
@@ -490,8 +490,8 @@ extension type MLGruOptions._(JSObject _) implements JSObject {
   external MLRecurrentNetworkDirection get direction;
   external set layout(MLGruWeightLayout value);
   external MLGruWeightLayout get layout;
-  external set activations(JSArray value);
-  external JSArray get activations;
+  external set activations(JSArray<MLActivation> value);
+  external JSArray<MLActivation> get activations;
 }
 extension type MLGruCellOptions._(JSObject _) implements JSObject {
   external factory MLGruCellOptions({
@@ -499,7 +499,7 @@ extension type MLGruCellOptions._(JSObject _) implements JSObject {
     MLOperand recurrentBias,
     bool resetAfter,
     MLGruWeightLayout layout,
-    JSArray activations,
+    JSArray<MLActivation> activations,
   });
 
   external set bias(MLOperand value);
@@ -510,8 +510,8 @@ extension type MLGruCellOptions._(JSObject _) implements JSObject {
   external bool get resetAfter;
   external set layout(MLGruWeightLayout value);
   external MLGruWeightLayout get layout;
-  external set activations(JSArray value);
-  external JSArray get activations;
+  external set activations(JSArray<MLActivation> value);
+  external JSArray<MLActivation> get activations;
 }
 extension type MLHardSigmoidOptions._(JSObject _) implements JSObject {
   external factory MLHardSigmoidOptions({
@@ -569,7 +569,7 @@ extension type MLLstmOptions._(JSObject _) implements JSObject {
     bool returnSequence,
     MLRecurrentNetworkDirection direction,
     MLLstmWeightLayout layout,
-    JSArray activations,
+    JSArray<MLActivation> activations,
   });
 
   external set bias(MLOperand value);
@@ -588,8 +588,8 @@ extension type MLLstmOptions._(JSObject _) implements JSObject {
   external MLRecurrentNetworkDirection get direction;
   external set layout(MLLstmWeightLayout value);
   external MLLstmWeightLayout get layout;
-  external set activations(JSArray value);
-  external JSArray get activations;
+  external set activations(JSArray<MLActivation> value);
+  external JSArray<MLActivation> get activations;
 }
 extension type MLLstmCellOptions._(JSObject _) implements JSObject {
   external factory MLLstmCellOptions({
@@ -597,7 +597,7 @@ extension type MLLstmCellOptions._(JSObject _) implements JSObject {
     MLOperand recurrentBias,
     MLOperand peepholeWeight,
     MLLstmWeightLayout layout,
-    JSArray activations,
+    JSArray<MLActivation> activations,
   });
 
   external set bias(MLOperand value);
@@ -608,8 +608,8 @@ extension type MLLstmCellOptions._(JSObject _) implements JSObject {
   external MLOperand get peepholeWeight;
   external set layout(MLLstmWeightLayout value);
   external MLLstmWeightLayout get layout;
-  external set activations(JSArray value);
-  external JSArray get activations;
+  external set activations(JSArray<MLActivation> value);
+  external JSArray<MLActivation> get activations;
 }
 extension type MLPadOptions._(JSObject _) implements JSObject {
   external factory MLPadOptions({
@@ -624,60 +624,60 @@ extension type MLPadOptions._(JSObject _) implements JSObject {
 }
 extension type MLPool2dOptions._(JSObject _) implements JSObject {
   external factory MLPool2dOptions({
-    JSArray windowDimensions,
-    JSArray padding,
-    JSArray strides,
-    JSArray dilations,
+    JSArray<JSNumber> windowDimensions,
+    JSArray<JSNumber> padding,
+    JSArray<JSNumber> strides,
+    JSArray<JSNumber> dilations,
     MLAutoPad autoPad,
     MLInputOperandLayout layout,
     MLRoundingType roundingType,
-    JSArray outputSizes,
+    JSArray<JSNumber> outputSizes,
   });
 
-  external set windowDimensions(JSArray value);
-  external JSArray get windowDimensions;
-  external set padding(JSArray value);
-  external JSArray get padding;
-  external set strides(JSArray value);
-  external JSArray get strides;
-  external set dilations(JSArray value);
-  external JSArray get dilations;
+  external set windowDimensions(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get windowDimensions;
+  external set padding(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get padding;
+  external set strides(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get strides;
+  external set dilations(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get dilations;
   external set autoPad(MLAutoPad value);
   external MLAutoPad get autoPad;
   external set layout(MLInputOperandLayout value);
   external MLInputOperandLayout get layout;
   external set roundingType(MLRoundingType value);
   external MLRoundingType get roundingType;
-  external set outputSizes(JSArray value);
-  external JSArray get outputSizes;
+  external set outputSizes(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get outputSizes;
 }
 extension type MLReduceOptions._(JSObject _) implements JSObject {
   external factory MLReduceOptions({
-    JSArray axes,
+    JSArray<JSNumber> axes,
     bool keepDimensions,
   });
 
-  external set axes(JSArray value);
-  external JSArray get axes;
+  external set axes(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get axes;
   external set keepDimensions(bool value);
   external bool get keepDimensions;
 }
 extension type MLResample2dOptions._(JSObject _) implements JSObject {
   external factory MLResample2dOptions({
     MLInterpolationMode mode,
-    JSArray scales,
-    JSArray sizes,
-    JSArray axes,
+    JSArray<JSNumber> scales,
+    JSArray<JSNumber> sizes,
+    JSArray<JSNumber> axes,
   });
 
   external set mode(MLInterpolationMode value);
   external MLInterpolationMode get mode;
-  external set scales(JSArray value);
-  external JSArray get scales;
-  external set sizes(JSArray value);
-  external JSArray get sizes;
-  external set axes(JSArray value);
-  external JSArray get axes;
+  external set scales(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get scales;
+  external set sizes(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get sizes;
+  external set axes(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get axes;
 }
 extension type MLSoftplusOptions._(JSObject _) implements JSObject {
   external factory MLSoftplusOptions({num steepness});
@@ -692,14 +692,14 @@ extension type MLSplitOptions._(JSObject _) implements JSObject {
   external int get axis;
 }
 extension type MLSqueezeOptions._(JSObject _) implements JSObject {
-  external factory MLSqueezeOptions({JSArray axes});
+  external factory MLSqueezeOptions({JSArray<JSNumber> axes});
 
-  external set axes(JSArray value);
-  external JSArray get axes;
+  external set axes(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get axes;
 }
 extension type MLTransposeOptions._(JSObject _) implements JSObject {
-  external factory MLTransposeOptions({JSArray permutation});
+  external factory MLTransposeOptions({JSArray<JSNumber> permutation});
 
-  external set permutation(JSArray value);
-  external JSArray get permutation;
+  external set permutation(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get permutation;
 }

--- a/lib/src/dom/webrtc.dart
+++ b/lib/src/dom/webrtc.dart
@@ -46,26 +46,26 @@ typedef RTCErrorDetailType = String;
 extension type RTCConfiguration._(JSObject _) implements JSObject {
   external factory RTCConfiguration({
     String peerIdentity,
-    JSArray iceServers,
+    JSArray<RTCIceServer> iceServers,
     RTCIceTransportPolicy iceTransportPolicy,
     RTCBundlePolicy bundlePolicy,
     RTCRtcpMuxPolicy rtcpMuxPolicy,
-    JSArray certificates,
+    JSArray<RTCCertificate> certificates,
     int iceCandidatePoolSize,
   });
 
   external set peerIdentity(String value);
   external String get peerIdentity;
-  external set iceServers(JSArray value);
-  external JSArray get iceServers;
+  external set iceServers(JSArray<RTCIceServer> value);
+  external JSArray<RTCIceServer> get iceServers;
   external set iceTransportPolicy(RTCIceTransportPolicy value);
   external RTCIceTransportPolicy get iceTransportPolicy;
   external set bundlePolicy(RTCBundlePolicy value);
   external RTCBundlePolicy get bundlePolicy;
   external set rtcpMuxPolicy(RTCRtcpMuxPolicy value);
   external RTCRtcpMuxPolicy get rtcpMuxPolicy;
-  external set certificates(JSArray value);
-  external JSArray get certificates;
+  external set certificates(JSArray<RTCCertificate> value);
+  external JSArray<RTCCertificate> get certificates;
   external set iceCandidatePoolSize(int value);
   external int get iceCandidatePoolSize;
 }
@@ -109,33 +109,33 @@ extension type RTCPeerConnection._(JSObject _)
     implements EventTarget, JSObject {
   external factory RTCPeerConnection([RTCConfiguration configuration]);
 
-  external static JSPromise generateCertificate(
+  external static JSPromise<RTCCertificate> generateCertificate(
       AlgorithmIdentifier keygenAlgorithm);
   external void setIdentityProvider(
     String provider, [
     RTCIdentityProviderOptions options,
   ]);
-  external JSPromise getIdentityAssertion();
-  external JSPromise createOffer([
+  external JSPromise<JSString> getIdentityAssertion();
+  external JSPromise<RTCSessionDescriptionInit> createOffer([
     JSObject optionsOrSuccessCallback,
     RTCPeerConnectionErrorCallback failureCallback,
     RTCOfferOptions options,
   ]);
-  external JSPromise createAnswer([
+  external JSPromise<RTCSessionDescriptionInit> createAnswer([
     JSObject optionsOrSuccessCallback,
     RTCPeerConnectionErrorCallback failureCallback,
   ]);
-  external JSPromise setLocalDescription([
+  external JSPromise<JSAny?> setLocalDescription([
     RTCLocalSessionDescriptionInit description,
     VoidFunction successCallback,
     RTCPeerConnectionErrorCallback failureCallback,
   ]);
-  external JSPromise setRemoteDescription(
+  external JSPromise<JSAny?> setRemoteDescription(
     RTCSessionDescriptionInit description, [
     VoidFunction successCallback,
     RTCPeerConnectionErrorCallback failureCallback,
   ]);
-  external JSPromise addIceCandidate([
+  external JSPromise<JSAny?> addIceCandidate([
     RTCIceCandidateInit candidate,
     VoidFunction successCallback,
     RTCPeerConnectionErrorCallback failureCallback,
@@ -144,9 +144,9 @@ extension type RTCPeerConnection._(JSObject _)
   external RTCConfiguration getConfiguration();
   external void setConfiguration([RTCConfiguration configuration]);
   external void close();
-  external JSArray getSenders();
-  external JSArray getReceivers();
-  external JSArray getTransceivers();
+  external JSArray<RTCRtpSender> getSenders();
+  external JSArray<RTCRtpReceiver> getReceivers();
+  external JSArray<RTCRtpTransceiver> getTransceivers();
   external RTCRtpSender addTrack(
     MediaStreamTrack track,
     MediaStream streams,
@@ -160,8 +160,8 @@ extension type RTCPeerConnection._(JSObject _)
     String label, [
     RTCDataChannelInit dataChannelDict,
   ]);
-  external JSPromise getStats([MediaStreamTrack? selector]);
-  external JSPromise get peerIdentity;
+  external JSPromise<RTCStatsReport> getStats([MediaStreamTrack? selector]);
+  external JSPromise<RTCIdentityAssertion> get peerIdentity;
   external String? get idpLoginUrl;
   external String? get idpErrorInfo;
   external RTCSessionDescription? get localDescription;
@@ -327,34 +327,34 @@ extension type RTCCertificateExpiration._(JSObject _) implements JSObject {
   external int get expires;
 }
 extension type RTCCertificate._(JSObject _) implements JSObject {
-  external JSArray getFingerprints();
+  external JSArray<RTCDtlsFingerprint> getFingerprints();
   external EpochTimeStamp get expires;
 }
 extension type RTCRtpTransceiverInit._(JSObject _) implements JSObject {
   external factory RTCRtpTransceiverInit({
     RTCRtpTransceiverDirection direction,
-    JSArray streams,
-    JSArray sendEncodings,
+    JSArray<MediaStream> streams,
+    JSArray<RTCRtpEncodingParameters> sendEncodings,
   });
 
   external set direction(RTCRtpTransceiverDirection value);
   external RTCRtpTransceiverDirection get direction;
-  external set streams(JSArray value);
-  external JSArray get streams;
-  external set sendEncodings(JSArray value);
-  external JSArray get sendEncodings;
+  external set streams(JSArray<MediaStream> value);
+  external JSArray<MediaStream> get streams;
+  external set sendEncodings(JSArray<RTCRtpEncodingParameters> value);
+  external JSArray<RTCRtpEncodingParameters> get sendEncodings;
 }
 extension type RTCRtpSender._(JSObject _) implements JSObject {
   external static RTCRtpCapabilities? getCapabilities(String kind);
-  external JSPromise generateKeyFrame([JSArray rids]);
-  external JSPromise setParameters(
+  external JSPromise<JSAny?> generateKeyFrame([JSArray<JSString> rids]);
+  external JSPromise<JSAny?> setParameters(
     RTCRtpSendParameters parameters, [
     RTCSetParameterOptions setParameterOptions,
   ]);
   external RTCRtpSendParameters getParameters();
-  external JSPromise replaceTrack(MediaStreamTrack? withTrack);
+  external JSPromise<JSAny?> replaceTrack(MediaStreamTrack? withTrack);
   external void setStreams(MediaStream streams);
-  external JSPromise getStats();
+  external JSPromise<RTCStatsReport> getStats();
   external set transform(RTCRtpTransform? value);
   external RTCRtpTransform? get transform;
   external MediaStreamTrack? get track;
@@ -363,32 +363,32 @@ extension type RTCRtpSender._(JSObject _) implements JSObject {
 }
 extension type RTCRtpParameters._(JSObject _) implements JSObject {
   external factory RTCRtpParameters({
-    required JSArray headerExtensions,
+    required JSArray<RTCRtpHeaderExtensionParameters> headerExtensions,
     required RTCRtcpParameters rtcp,
-    required JSArray codecs,
+    required JSArray<RTCRtpCodecParameters> codecs,
   });
 
-  external set headerExtensions(JSArray value);
-  external JSArray get headerExtensions;
+  external set headerExtensions(JSArray<RTCRtpHeaderExtensionParameters> value);
+  external JSArray<RTCRtpHeaderExtensionParameters> get headerExtensions;
   external set rtcp(RTCRtcpParameters value);
   external RTCRtcpParameters get rtcp;
-  external set codecs(JSArray value);
-  external JSArray get codecs;
+  external set codecs(JSArray<RTCRtpCodecParameters> value);
+  external JSArray<RTCRtpCodecParameters> get codecs;
 }
 extension type RTCRtpSendParameters._(JSObject _)
     implements RTCRtpParameters, JSObject {
   external factory RTCRtpSendParameters({
     RTCDegradationPreference degradationPreference,
     required String transactionId,
-    required JSArray encodings,
+    required JSArray<RTCRtpEncodingParameters> encodings,
   });
 
   external set degradationPreference(RTCDegradationPreference value);
   external RTCDegradationPreference get degradationPreference;
   external set transactionId(String value);
   external String get transactionId;
-  external set encodings(JSArray value);
-  external JSArray get encodings;
+  external set encodings(JSArray<RTCRtpEncodingParameters> value);
+  external JSArray<RTCRtpEncodingParameters> get encodings;
 }
 extension type RTCRtpReceiveParameters._(JSObject _)
     implements RTCRtpParameters, JSObject {
@@ -479,14 +479,14 @@ extension type RTCRtpCodecParameters._(JSObject _)
 }
 extension type RTCRtpCapabilities._(JSObject _) implements JSObject {
   external factory RTCRtpCapabilities({
-    required JSArray codecs,
-    required JSArray headerExtensions,
+    required JSArray<RTCRtpCodecCapability> codecs,
+    required JSArray<RTCRtpHeaderExtensionCapability> headerExtensions,
   });
 
-  external set codecs(JSArray value);
-  external JSArray get codecs;
-  external set headerExtensions(JSArray value);
-  external JSArray get headerExtensions;
+  external set codecs(JSArray<RTCRtpCodecCapability> value);
+  external JSArray<RTCRtpCodecCapability> get codecs;
+  external set headerExtensions(JSArray<RTCRtpHeaderExtensionCapability> value);
+  external JSArray<RTCRtpHeaderExtensionCapability> get headerExtensions;
 }
 extension type RTCRtpCodecCapability._(JSObject _)
     implements RTCRtpCodec, JSObject {
@@ -505,9 +505,9 @@ extension type RTCSetParameterOptions._(JSObject _) implements JSObject {
 extension type RTCRtpReceiver._(JSObject _) implements JSObject {
   external static RTCRtpCapabilities? getCapabilities(String kind);
   external RTCRtpReceiveParameters getParameters();
-  external JSArray getContributingSources();
-  external JSArray getSynchronizationSources();
-  external JSPromise getStats();
+  external JSArray<RTCRtpContributingSource> getContributingSources();
+  external JSArray<RTCRtpSynchronizationSource> getSynchronizationSources();
+  external JSPromise<RTCStatsReport> getStats();
   external set transform(RTCRtpTransform? value);
   external RTCRtpTransform? get transform;
   external MediaStreamTrack get track;
@@ -536,7 +536,7 @@ extension type RTCRtpSynchronizationSource._(JSObject _)
 }
 extension type RTCRtpTransceiver._(JSObject _) implements JSObject {
   external void stop();
-  external void setCodecPreferences(JSArray codecs);
+  external void setCodecPreferences(JSArray<RTCRtpCodecCapability> codecs);
   external String? get mid;
   external RTCRtpSender get sender;
   external RTCRtpReceiver get receiver;
@@ -545,7 +545,7 @@ extension type RTCRtpTransceiver._(JSObject _) implements JSObject {
   external RTCRtpTransceiverDirection? get currentDirection;
 }
 extension type RTCDtlsTransport._(JSObject _) implements EventTarget, JSObject {
-  external JSArray getRemoteCertificates();
+  external JSArray<JSArrayBuffer> getRemoteCertificates();
   external RTCIceTransport get iceTransport;
   external RTCDtlsTransportState get state;
   external set onstatechange(EventHandler value);
@@ -574,8 +574,8 @@ extension type RTCIceTransport._(JSObject _) implements EventTarget, JSObject {
   ]);
   external void stop();
   external void addRemoteCandidate([RTCIceCandidateInit remoteCandidate]);
-  external JSArray getLocalCandidates();
-  external JSArray getRemoteCandidates();
+  external JSArray<RTCIceCandidate> getLocalCandidates();
+  external JSArray<RTCIceCandidate> getRemoteCandidates();
   external RTCIceCandidatePair? getSelectedCandidatePair();
   external RTCIceParameters? getLocalParameters();
   external RTCIceParameters? getRemoteParameters();
@@ -627,14 +627,14 @@ extension type RTCTrackEvent._(JSObject _) implements Event, JSObject {
 
   external RTCRtpReceiver get receiver;
   external MediaStreamTrack get track;
-  external JSArray get streams;
+  external JSArray<MediaStream> get streams;
   external RTCRtpTransceiver get transceiver;
 }
 extension type RTCTrackEventInit._(JSObject _) implements EventInit, JSObject {
   external factory RTCTrackEventInit({
     required RTCRtpReceiver receiver,
     required MediaStreamTrack track,
-    JSArray streams,
+    JSArray<MediaStream> streams,
     required RTCRtpTransceiver transceiver,
   });
 
@@ -642,8 +642,8 @@ extension type RTCTrackEventInit._(JSObject _) implements EventInit, JSObject {
   external RTCRtpReceiver get receiver;
   external set track(MediaStreamTrack value);
   external MediaStreamTrack get track;
-  external set streams(JSArray value);
-  external JSArray get streams;
+  external set streams(JSArray<MediaStream> value);
+  external JSArray<MediaStream> get streams;
   external set transceiver(RTCRtpTransceiver value);
   external RTCRtpTransceiver get transceiver;
 }

--- a/lib/src/dom/webrtc_encoded_transform.dart
+++ b/lib/src/dom/webrtc_encoded_transform.dart
@@ -26,7 +26,7 @@ extension type SFrameTransformOptions._(JSObject _) implements JSObject {
 extension type SFrameTransform._(JSObject _) implements EventTarget, JSObject {
   external factory SFrameTransform([SFrameTransformOptions options]);
 
-  external JSPromise setEncryptionKey(
+  external JSPromise<JSAny?> setEncryptionKey(
     CryptoKey key, [
     CryptoKeyID keyID,
   ]);
@@ -64,22 +64,22 @@ extension type SFrameTransformErrorEventInit._(JSObject _)
 extension type RTCEncodedVideoFrameMetadata._(JSObject _) implements JSObject {
   external factory RTCEncodedVideoFrameMetadata({
     int frameId,
-    JSArray dependencies,
+    JSArray<JSNumber> dependencies,
     int width,
     int height,
     int spatialIndex,
     int temporalIndex,
     int synchronizationSource,
     int payloadType,
-    JSArray contributingSources,
+    JSArray<JSNumber> contributingSources,
     int timestamp,
     int rtpTimestamp,
   });
 
   external set frameId(int value);
   external int get frameId;
-  external set dependencies(JSArray value);
-  external JSArray get dependencies;
+  external set dependencies(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get dependencies;
   external set width(int value);
   external int get width;
   external set height(int value);
@@ -92,8 +92,8 @@ extension type RTCEncodedVideoFrameMetadata._(JSObject _) implements JSObject {
   external int get synchronizationSource;
   external set payloadType(int value);
   external int get payloadType;
-  external set contributingSources(JSArray value);
-  external JSArray get contributingSources;
+  external set contributingSources(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get contributingSources;
   external set timestamp(int value);
   external int get timestamp;
   external set rtpTimestamp(int value);
@@ -109,7 +109,7 @@ extension type RTCEncodedAudioFrameMetadata._(JSObject _) implements JSObject {
   external factory RTCEncodedAudioFrameMetadata({
     int synchronizationSource,
     int payloadType,
-    JSArray contributingSources,
+    JSArray<JSNumber> contributingSources,
     int sequenceNumber,
     int rtpTimestamp,
   });
@@ -118,8 +118,8 @@ extension type RTCEncodedAudioFrameMetadata._(JSObject _) implements JSObject {
   external int get synchronizationSource;
   external set payloadType(int value);
   external int get payloadType;
-  external set contributingSources(JSArray value);
-  external JSArray get contributingSources;
+  external set contributingSources(JSArray<JSNumber> value);
+  external JSArray<JSNumber> get contributingSources;
   external set sequenceNumber(int value);
   external int get sequenceNumber;
   external set rtpTimestamp(int value);
@@ -134,8 +134,8 @@ extension type RTCTransformEvent._(JSObject _) implements Event, JSObject {
   external RTCRtpScriptTransformer get transformer;
 }
 extension type RTCRtpScriptTransformer._(JSObject _) implements JSObject {
-  external JSPromise generateKeyFrame([String rid]);
-  external JSPromise sendKeyFrameRequest();
+  external JSPromise<JSNumber> generateKeyFrame([String rid]);
+  external JSPromise<JSAny?> sendKeyFrameRequest();
   external ReadableStream get readable;
   external WritableStream get writable;
   external JSAny? get options;
@@ -144,6 +144,6 @@ extension type RTCRtpScriptTransform._(JSObject _) implements JSObject {
   external factory RTCRtpScriptTransform(
     Worker worker, [
     JSAny? options,
-    JSArray transfer,
+    JSArray<JSObject> transfer,
   ]);
 }

--- a/lib/src/dom/webrtc_ice.dart
+++ b/lib/src/dom/webrtc_ice.dart
@@ -11,11 +11,11 @@ import 'webrtc.dart';
 extension type RTCIceGatherOptions._(JSObject _) implements JSObject {
   external factory RTCIceGatherOptions({
     RTCIceTransportPolicy gatherPolicy,
-    JSArray iceServers,
+    JSArray<RTCIceServer> iceServers,
   });
 
   external set gatherPolicy(RTCIceTransportPolicy value);
   external RTCIceTransportPolicy get gatherPolicy;
-  external set iceServers(JSArray value);
-  external JSArray get iceServers;
+  external set iceServers(JSArray<RTCIceServer> value);
+  external JSArray<RTCIceServer> get iceServers;
 }

--- a/lib/src/dom/webtransport.dart
+++ b/lib/src/dom/webtransport.dart
@@ -33,17 +33,17 @@ extension type WebTransport._(JSObject _) implements JSObject {
     WebTransportOptions options,
   ]);
 
-  external JSPromise getStats();
+  external JSPromise<WebTransportConnectionStats> getStats();
   external void close([WebTransportCloseInfo closeInfo]);
-  external JSPromise createBidirectionalStream(
+  external JSPromise<WebTransportBidirectionalStream> createBidirectionalStream(
       [WebTransportSendStreamOptions options]);
-  external JSPromise createUnidirectionalStream(
+  external JSPromise<WebTransportSendStream> createUnidirectionalStream(
       [WebTransportSendStreamOptions options]);
-  external JSPromise get ready;
+  external JSPromise<JSAny?> get ready;
   external WebTransportReliabilityMode get reliability;
   external WebTransportCongestionControl get congestionControl;
-  external JSPromise get closed;
-  external JSPromise get draining;
+  external JSPromise<WebTransportCloseInfo> get closed;
+  external JSPromise<JSAny?> get draining;
   external WebTransportDatagramDuplexStream get datagrams;
   external ReadableStream get incomingBidirectionalStreams;
   external ReadableStream get incomingUnidirectionalStreams;
@@ -63,7 +63,7 @@ extension type WebTransportOptions._(JSObject _) implements JSObject {
   external factory WebTransportOptions({
     bool allowPooling,
     bool requireUnreliable,
-    JSArray serverCertificateHashes,
+    JSArray<WebTransportHash> serverCertificateHashes,
     WebTransportCongestionControl congestionControl,
   });
 
@@ -71,8 +71,8 @@ extension type WebTransportOptions._(JSObject _) implements JSObject {
   external bool get allowPooling;
   external set requireUnreliable(bool value);
   external bool get requireUnreliable;
-  external set serverCertificateHashes(JSArray value);
-  external JSArray get serverCertificateHashes;
+  external set serverCertificateHashes(JSArray<WebTransportHash> value);
+  external JSArray<WebTransportHash> get serverCertificateHashes;
   external set congestionControl(WebTransportCongestionControl value);
   external WebTransportCongestionControl get congestionControl;
 }
@@ -153,7 +153,7 @@ extension type WebTransportDatagramStats._(JSObject _) implements JSObject {
 }
 extension type WebTransportSendStream._(JSObject _)
     implements WritableStream, JSObject {
-  external JSPromise getStats();
+  external JSPromise<WebTransportSendStreamStats> getStats();
   external set sendOrder(int? value);
   external int? get sendOrder;
 }
@@ -176,7 +176,7 @@ extension type WebTransportSendStreamStats._(JSObject _) implements JSObject {
 }
 extension type WebTransportReceiveStream._(JSObject _)
     implements ReadableStream, JSObject {
-  external JSPromise getStats();
+  external JSPromise<WebTransportReceiveStreamStats> getStats();
 }
 extension type WebTransportReceiveStreamStats._(JSObject _)
     implements JSObject {

--- a/lib/src/dom/webusb.dart
+++ b/lib/src/dom/webusb.dart
@@ -41,18 +41,18 @@ extension type USBDeviceFilter._(JSObject _) implements JSObject {
 }
 extension type USBDeviceRequestOptions._(JSObject _) implements JSObject {
   external factory USBDeviceRequestOptions({
-    required JSArray filters,
-    JSArray exclusionFilters,
+    required JSArray<USBDeviceFilter> filters,
+    JSArray<USBDeviceFilter> exclusionFilters,
   });
 
-  external set filters(JSArray value);
-  external JSArray get filters;
-  external set exclusionFilters(JSArray value);
-  external JSArray get exclusionFilters;
+  external set filters(JSArray<USBDeviceFilter> value);
+  external JSArray<USBDeviceFilter> get filters;
+  external set exclusionFilters(JSArray<USBDeviceFilter> value);
+  external JSArray<USBDeviceFilter> get exclusionFilters;
 }
 extension type USB._(JSObject _) implements EventTarget, JSObject {
-  external JSPromise getDevices();
-  external JSPromise requestDevice(USBDeviceRequestOptions options);
+  external JSPromise<JSArray<USBDevice>> getDevices();
+  external JSPromise<USBDevice> requestDevice(USBDeviceRequestOptions options);
   external set onconnect(EventHandler value);
   external EventHandler get onconnect;
   external set ondisconnect(EventHandler value);
@@ -104,12 +104,12 @@ extension type USBIsochronousInTransferPacket._(JSObject _)
 extension type USBIsochronousInTransferResult._(JSObject _)
     implements JSObject {
   external factory USBIsochronousInTransferResult(
-    JSArray packets, [
+    JSArray<USBIsochronousInTransferPacket> packets, [
     JSDataView? data,
   ]);
 
   external JSDataView? get data;
-  external JSArray get packets;
+  external JSArray<USBIsochronousInTransferPacket> get packets;
 }
 extension type USBIsochronousOutTransferPacket._(JSObject _)
     implements JSObject {
@@ -123,51 +123,52 @@ extension type USBIsochronousOutTransferPacket._(JSObject _)
 }
 extension type USBIsochronousOutTransferResult._(JSObject _)
     implements JSObject {
-  external factory USBIsochronousOutTransferResult(JSArray packets);
+  external factory USBIsochronousOutTransferResult(
+      JSArray<USBIsochronousOutTransferPacket> packets);
 
-  external JSArray get packets;
+  external JSArray<USBIsochronousOutTransferPacket> get packets;
 }
 extension type USBDevice._(JSObject _) implements JSObject {
-  external JSPromise open();
-  external JSPromise close();
-  external JSPromise forget();
-  external JSPromise selectConfiguration(int configurationValue);
-  external JSPromise claimInterface(int interfaceNumber);
-  external JSPromise releaseInterface(int interfaceNumber);
-  external JSPromise selectAlternateInterface(
+  external JSPromise<JSAny?> open();
+  external JSPromise<JSAny?> close();
+  external JSPromise<JSAny?> forget();
+  external JSPromise<JSAny?> selectConfiguration(int configurationValue);
+  external JSPromise<JSAny?> claimInterface(int interfaceNumber);
+  external JSPromise<JSAny?> releaseInterface(int interfaceNumber);
+  external JSPromise<JSAny?> selectAlternateInterface(
     int interfaceNumber,
     int alternateSetting,
   );
-  external JSPromise controlTransferIn(
+  external JSPromise<USBInTransferResult> controlTransferIn(
     USBControlTransferParameters setup,
     int length,
   );
-  external JSPromise controlTransferOut(
+  external JSPromise<USBOutTransferResult> controlTransferOut(
     USBControlTransferParameters setup, [
     BufferSource data,
   ]);
-  external JSPromise clearHalt(
+  external JSPromise<JSAny?> clearHalt(
     USBDirection direction,
     int endpointNumber,
   );
-  external JSPromise transferIn(
+  external JSPromise<USBInTransferResult> transferIn(
     int endpointNumber,
     int length,
   );
-  external JSPromise transferOut(
+  external JSPromise<USBOutTransferResult> transferOut(
     int endpointNumber,
     BufferSource data,
   );
-  external JSPromise isochronousTransferIn(
+  external JSPromise<USBIsochronousInTransferResult> isochronousTransferIn(
     int endpointNumber,
-    JSArray packetLengths,
+    JSArray<JSNumber> packetLengths,
   );
-  external JSPromise isochronousTransferOut(
+  external JSPromise<USBIsochronousOutTransferResult> isochronousTransferOut(
     int endpointNumber,
     BufferSource data,
-    JSArray packetLengths,
+    JSArray<JSNumber> packetLengths,
   );
-  external JSPromise reset();
+  external JSPromise<JSAny?> reset();
   external int get usbVersionMajor;
   external int get usbVersionMinor;
   external int get usbVersionSubminor;
@@ -183,7 +184,7 @@ extension type USBDevice._(JSObject _) implements JSObject {
   external String? get productName;
   external String? get serialNumber;
   external USBConfiguration? get configuration;
-  external JSArray get configurations;
+  external JSArray<USBConfiguration> get configurations;
   external bool get opened;
 }
 extension type USBControlTransferParameters._(JSObject _) implements JSObject {
@@ -214,7 +215,7 @@ extension type USBConfiguration._(JSObject _) implements JSObject {
 
   external int get configurationValue;
   external String? get configurationName;
-  external JSArray get interfaces;
+  external JSArray<USBInterface> get interfaces;
 }
 extension type USBInterface._(JSObject _) implements JSObject {
   external factory USBInterface(
@@ -224,7 +225,7 @@ extension type USBInterface._(JSObject _) implements JSObject {
 
   external int get interfaceNumber;
   external USBAlternateInterface get alternate;
-  external JSArray get alternates;
+  external JSArray<USBAlternateInterface> get alternates;
   external bool get claimed;
 }
 extension type USBAlternateInterface._(JSObject _) implements JSObject {
@@ -238,7 +239,7 @@ extension type USBAlternateInterface._(JSObject _) implements JSObject {
   external int get interfaceSubclass;
   external int get interfaceProtocol;
   external String? get interfaceName;
-  external JSArray get endpoints;
+  external JSArray<USBEndpoint> get endpoints;
 }
 extension type USBEndpoint._(JSObject _) implements JSObject {
   external factory USBEndpoint(
@@ -255,14 +256,14 @@ extension type USBEndpoint._(JSObject _) implements JSObject {
 extension type USBPermissionDescriptor._(JSObject _)
     implements PermissionDescriptor, JSObject {
   external factory USBPermissionDescriptor({
-    JSArray filters,
-    JSArray exclusionFilters,
+    JSArray<USBDeviceFilter> filters,
+    JSArray<USBDeviceFilter> exclusionFilters,
   });
 
-  external set filters(JSArray value);
-  external JSArray get filters;
-  external set exclusionFilters(JSArray value);
-  external JSArray get exclusionFilters;
+  external set filters(JSArray<USBDeviceFilter> value);
+  external JSArray<USBDeviceFilter> get filters;
+  external set exclusionFilters(JSArray<USBDeviceFilter> value);
+  external JSArray<USBDeviceFilter> get exclusionFilters;
 }
 extension type AllowedUSBDevice._(JSObject _) implements JSObject {
   external factory AllowedUSBDevice({
@@ -279,13 +280,14 @@ extension type AllowedUSBDevice._(JSObject _) implements JSObject {
   external String get serialNumber;
 }
 extension type USBPermissionStorage._(JSObject _) implements JSObject {
-  external factory USBPermissionStorage({JSArray allowedDevices});
+  external factory USBPermissionStorage(
+      {JSArray<AllowedUSBDevice> allowedDevices});
 
-  external set allowedDevices(JSArray value);
-  external JSArray get allowedDevices;
+  external set allowedDevices(JSArray<AllowedUSBDevice> value);
+  external JSArray<AllowedUSBDevice> get allowedDevices;
 }
 extension type USBPermissionResult._(JSObject _)
     implements PermissionStatus, JSObject {
-  external set devices(JSArray value);
-  external JSArray get devices;
+  external set devices(JSArray<USBDevice> value);
+  external JSArray<USBDevice> get devices;
 }

--- a/lib/src/dom/webxr.dart
+++ b/lib/src/dom/webxr.dart
@@ -32,8 +32,8 @@ typedef XREye = String;
 typedef XRHandedness = String;
 typedef XRTargetRayMode = String;
 extension type XRSystem._(JSObject _) implements EventTarget, JSObject {
-  external JSPromise isSessionSupported(XRSessionMode mode);
-  external JSPromise requestSession(
+  external JSPromise<JSBoolean> isSessionSupported(XRSessionMode mode);
+  external JSPromise<XRSession> requestSession(
     XRSessionMode mode, [
     XRSessionInit options,
   ]);
@@ -44,33 +44,37 @@ extension type XRSessionInit._(JSObject _) implements JSObject {
   external factory XRSessionInit({
     XRDepthStateInit depthSensing,
     XRDOMOverlayInit? domOverlay,
-    JSArray requiredFeatures,
-    JSArray optionalFeatures,
+    JSArray<JSString> requiredFeatures,
+    JSArray<JSString> optionalFeatures,
   });
 
   external set depthSensing(XRDepthStateInit value);
   external XRDepthStateInit get depthSensing;
   external set domOverlay(XRDOMOverlayInit? value);
   external XRDOMOverlayInit? get domOverlay;
-  external set requiredFeatures(JSArray value);
-  external JSArray get requiredFeatures;
-  external set optionalFeatures(JSArray value);
-  external JSArray get optionalFeatures;
+  external set requiredFeatures(JSArray<JSString> value);
+  external JSArray<JSString> get requiredFeatures;
+  external set optionalFeatures(JSArray<JSString> value);
+  external JSArray<JSString> get optionalFeatures;
 }
 extension type XRSession._(JSObject _) implements EventTarget, JSObject {
-  external JSPromise restorePersistentAnchor(String uuid);
-  external JSPromise deletePersistentAnchor(String uuid);
-  external JSPromise requestHitTestSource(XRHitTestOptionsInit options);
-  external JSPromise requestHitTestSourceForTransientInput(
-      XRTransientInputHitTestOptionsInit options);
-  external JSPromise requestLightProbe([XRLightProbeInit options]);
+  external JSPromise<XRAnchor> restorePersistentAnchor(String uuid);
+  external JSPromise<JSAny?> deletePersistentAnchor(String uuid);
+  external JSPromise<XRHitTestSource> requestHitTestSource(
+      XRHitTestOptionsInit options);
+  external JSPromise<XRTransientInputHitTestSource>
+      requestHitTestSourceForTransientInput(
+          XRTransientInputHitTestOptionsInit options);
+  external JSPromise<XRLightProbe> requestLightProbe(
+      [XRLightProbeInit options]);
   external void updateRenderState([XRRenderStateInit state]);
-  external JSPromise updateTargetFrameRate(num rate);
-  external JSPromise requestReferenceSpace(XRReferenceSpaceType type);
+  external JSPromise<JSAny?> updateTargetFrameRate(num rate);
+  external JSPromise<XRReferenceSpace> requestReferenceSpace(
+      XRReferenceSpaceType type);
   external int requestAnimationFrame(XRFrameRequestCallback callback);
   external void cancelAnimationFrame(int handle);
-  external JSPromise end();
-  external JSArray get persistentAnchors;
+  external JSPromise<JSAny?> end();
+  external JSArray<JSString> get persistentAnchors;
   external XREnvironmentBlendMode get environmentBlendMode;
   external XRInteractionMode get interactionMode;
   external XRDepthUsage get depthUsage;
@@ -82,7 +86,7 @@ extension type XRSession._(JSObject _) implements EventTarget, JSObject {
   external JSFloat32Array? get supportedFrameRates;
   external XRRenderState get renderState;
   external XRInputSourceArray get inputSources;
-  external JSArray get enabledFeatures;
+  external JSArray<JSString> get enabledFeatures;
   external bool get isSystemKeyboardSupported;
   external set onend(EventHandler value);
   external EventHandler get onend;
@@ -111,7 +115,7 @@ extension type XRRenderStateInit._(JSObject _) implements JSObject {
     num depthFar,
     num inlineVerticalFieldOfView,
     XRWebGLLayer? baseLayer,
-    JSArray? layers,
+    JSArray<XRLayer>? layers,
   });
 
   external set depthNear(num value);
@@ -122,18 +126,18 @@ extension type XRRenderStateInit._(JSObject _) implements JSObject {
   external num get inlineVerticalFieldOfView;
   external set baseLayer(XRWebGLLayer? value);
   external XRWebGLLayer? get baseLayer;
-  external set layers(JSArray? value);
-  external JSArray? get layers;
+  external set layers(JSArray<XRLayer>? value);
+  external JSArray<XRLayer>? get layers;
 }
 extension type XRRenderState._(JSObject _) implements JSObject {
   external num get depthNear;
   external num get depthFar;
   external num? get inlineVerticalFieldOfView;
   external XRWebGLLayer? get baseLayer;
-  external JSArray get layers;
+  external JSArray<XRLayer> get layers;
 }
 extension type XRFrame._(JSObject _) implements JSObject {
-  external JSPromise createAnchor(
+  external JSPromise<XRAnchor> createAnchor(
     XRRigidTransform pose,
     XRSpace space,
   );
@@ -143,17 +147,19 @@ extension type XRFrame._(JSObject _) implements JSObject {
     XRSpace baseSpace,
   );
   external bool fillJointRadii(
-    JSArray jointSpaces,
+    JSArray<XRJointSpace> jointSpaces,
     JSFloat32Array radii,
   );
   external bool fillPoses(
-    JSArray spaces,
+    JSArray<XRSpace> spaces,
     XRSpace baseSpace,
     JSFloat32Array transforms,
   );
-  external JSArray getHitTestResults(XRHitTestSource hitTestSource);
-  external JSArray getHitTestResultsForTransientInput(
-      XRTransientInputHitTestSource hitTestSource);
+  external JSArray<XRHitTestResult> getHitTestResults(
+      XRHitTestSource hitTestSource);
+  external JSArray<XRTransientInputHitTestResult>
+      getHitTestResultsForTransientInput(
+          XRTransientInputHitTestSource hitTestSource);
   external XRLightEstimate? getLightEstimate(XRLightProbe lightProbe);
   external XRViewerPose? getViewerPose(XRReferenceSpace referenceSpace);
   external XRPose? getPose(
@@ -174,7 +180,7 @@ extension type XRReferenceSpace._(JSObject _) implements XRSpace, JSObject {
 }
 extension type XRBoundedReferenceSpace._(JSObject _)
     implements XRReferenceSpace, JSObject {
-  external JSArray get boundsGeometry;
+  external JSArray<DOMPointReadOnly> get boundsGeometry;
 }
 extension type XRView._(JSObject _) implements JSObject {
   external void requestViewportScale(num? scale);
@@ -209,7 +215,7 @@ extension type XRPose._(JSObject _) implements JSObject {
   external bool get emulatedPosition;
 }
 extension type XRViewerPose._(JSObject _) implements XRPose, JSObject {
-  external JSArray get views;
+  external JSArray<XRView> get views;
 }
 extension type XRInputSource._(JSObject _) implements JSObject {
   external Gamepad? get gamepad;
@@ -218,7 +224,7 @@ extension type XRInputSource._(JSObject _) implements JSObject {
   external XRTargetRayMode get targetRayMode;
   external XRSpace get targetRaySpace;
   external XRSpace? get gripSpace;
-  external JSArray get profiles;
+  external JSArray<JSString> get profiles;
 }
 extension type XRInputSourceArray._(JSObject _) implements JSObject {
   external int get length;
@@ -307,23 +313,23 @@ extension type XRInputSourcesChangeEvent._(JSObject _)
   );
 
   external XRSession get session;
-  external JSArray get added;
-  external JSArray get removed;
+  external JSArray<XRInputSource> get added;
+  external JSArray<XRInputSource> get removed;
 }
 extension type XRInputSourcesChangeEventInit._(JSObject _)
     implements EventInit, JSObject {
   external factory XRInputSourcesChangeEventInit({
     required XRSession session,
-    required JSArray added,
-    required JSArray removed,
+    required JSArray<XRInputSource> added,
+    required JSArray<XRInputSource> removed,
   });
 
   external set session(XRSession value);
   external XRSession get session;
-  external set added(JSArray value);
-  external JSArray get added;
-  external set removed(JSArray value);
-  external JSArray get removed;
+  external set added(JSArray<XRInputSource> value);
+  external JSArray<XRInputSource> get added;
+  external set removed(JSArray<XRInputSource> value);
+  external JSArray<XRInputSource> get removed;
 }
 extension type XRReferenceSpaceEvent._(JSObject _) implements Event, JSObject {
   external factory XRReferenceSpaceEvent(
@@ -357,19 +363,19 @@ extension type XRPermissionDescriptor._(JSObject _)
     implements PermissionDescriptor, JSObject {
   external factory XRPermissionDescriptor({
     XRSessionMode mode,
-    JSArray requiredFeatures,
-    JSArray optionalFeatures,
+    JSArray<JSString> requiredFeatures,
+    JSArray<JSString> optionalFeatures,
   });
 
   external set mode(XRSessionMode value);
   external XRSessionMode get mode;
-  external set requiredFeatures(JSArray value);
-  external JSArray get requiredFeatures;
-  external set optionalFeatures(JSArray value);
-  external JSArray get optionalFeatures;
+  external set requiredFeatures(JSArray<JSString> value);
+  external JSArray<JSString> get requiredFeatures;
+  external set optionalFeatures(JSArray<JSString> value);
+  external JSArray<JSString> get optionalFeatures;
 }
 extension type XRPermissionStatus._(JSObject _)
     implements PermissionStatus, JSObject {
-  external set granted(JSArray value);
-  external JSArray get granted;
+  external set granted(JSArray<JSString> value);
+  external JSArray<JSString> get granted;
 }

--- a/lib/src/dom/webxr_depth_sensing.dart
+++ b/lib/src/dom/webxr_depth_sensing.dart
@@ -13,14 +13,14 @@ typedef XRDepthUsage = String;
 typedef XRDepthDataFormat = String;
 extension type XRDepthStateInit._(JSObject _) implements JSObject {
   external factory XRDepthStateInit({
-    required JSArray usagePreference,
-    required JSArray dataFormatPreference,
+    required JSArray<JSString> usagePreference,
+    required JSArray<JSString> dataFormatPreference,
   });
 
-  external set usagePreference(JSArray value);
-  external JSArray get usagePreference;
-  external set dataFormatPreference(JSArray value);
-  external JSArray get dataFormatPreference;
+  external set usagePreference(JSArray<JSString> value);
+  external JSArray<JSString> get usagePreference;
+  external set dataFormatPreference(JSArray<JSString> value);
+  external JSArray<JSString> get dataFormatPreference;
 }
 extension type XRDepthInformation._(JSObject _) implements JSObject {
   external int get width;

--- a/lib/src/dom/webxr_hit_test.dart
+++ b/lib/src/dom/webxr_hit_test.dart
@@ -6,6 +6,7 @@
 
 import 'dart:js_interop';
 
+import 'anchors.dart';
 import 'geometry.dart';
 import 'webxr.dart';
 
@@ -13,14 +14,14 @@ typedef XRHitTestTrackableType = String;
 extension type XRHitTestOptionsInit._(JSObject _) implements JSObject {
   external factory XRHitTestOptionsInit({
     required XRSpace space,
-    JSArray entityTypes,
+    JSArray<JSString> entityTypes,
     XRRay offsetRay,
   });
 
   external set space(XRSpace value);
   external XRSpace get space;
-  external set entityTypes(JSArray value);
-  external JSArray get entityTypes;
+  external set entityTypes(JSArray<JSString> value);
+  external JSArray<JSString> get entityTypes;
   external set offsetRay(XRRay value);
   external XRRay get offsetRay;
 }
@@ -28,14 +29,14 @@ extension type XRTransientInputHitTestOptionsInit._(JSObject _)
     implements JSObject {
   external factory XRTransientInputHitTestOptionsInit({
     required String profile,
-    JSArray entityTypes,
+    JSArray<JSString> entityTypes,
     XRRay offsetRay,
   });
 
   external set profile(String value);
   external String get profile;
-  external set entityTypes(JSArray value);
-  external JSArray get entityTypes;
+  external set entityTypes(JSArray<JSString> value);
+  external JSArray<JSString> get entityTypes;
   external set offsetRay(XRRay value);
   external XRRay get offsetRay;
 }
@@ -46,12 +47,12 @@ extension type XRTransientInputHitTestSource._(JSObject _) implements JSObject {
   external void cancel();
 }
 extension type XRHitTestResult._(JSObject _) implements JSObject {
-  external JSPromise createAnchor();
+  external JSPromise<XRAnchor> createAnchor();
   external XRPose? getPose(XRSpace baseSpace);
 }
 extension type XRTransientInputHitTestResult._(JSObject _) implements JSObject {
   external XRInputSource get inputSource;
-  external JSArray get results;
+  external JSArray<XRHitTestResult> get results;
 }
 extension type XRRayDirectionInit._(JSObject _) implements JSObject {
   external factory XRRayDirectionInit({

--- a/lib/src/dom/window_management.dart
+++ b/lib/src/dom/window_management.dart
@@ -11,7 +11,7 @@ import 'dom.dart';
 import 'html.dart';
 
 extension type ScreenDetails._(JSObject _) implements EventTarget, JSObject {
-  external JSArray get screens;
+  external JSArray<ScreenDetailed> get screens;
   external ScreenDetailed get currentScreen;
   external set onscreenschange(EventHandler value);
   external EventHandler get onscreenschange;

--- a/lib/src/dom/xhr.dart
+++ b/lib/src/dom/xhr.dart
@@ -90,7 +90,7 @@ extension type FormData._(JSObject _) implements JSObject {
   ]);
   external void delete(String name);
   external FormDataEntryValue? get(String name);
-  external JSArray getAll(String name);
+  external JSArray<FormDataEntryValue> getAll(String name);
   external bool has(String name);
   external void set(
     String name,

--- a/tool/generator/translator.dart
+++ b/tool/generator/translator.dart
@@ -96,17 +96,51 @@ class _Library {
   }
 }
 
+/// If [rawType] corresponds to an IDL type that we declare as a typedef,
+/// desugars the typedef and returns the JS type equivalent.
+///
+/// Otherwise, returns null.
+_RawType? _getTypedefAsJsType(_RawType rawType) {
+  final decl = Translator.instance!._typeToDeclaration[rawType.type];
+  if (decl != null) {
+    switch (decl.type) {
+      case 'typedef':
+        return _getRawType((decl as idl.Typedef).idlType);
+      case 'callback':
+      case 'callback interface':
+        return _RawType('JSFunction', false);
+      case 'enum':
+        return _RawType('JSString', false);
+      default:
+        return null;
+    }
+  }
+  return null;
+}
+
 _RawType _computeRawTypeUnion(_RawType rawType1, _RawType rawType2) {
   final type1 = rawType1.type;
   final type2 = rawType2.type;
   final nullable1 = rawType1.nullable;
   final nullable2 = rawType2.nullable;
+  final typeParam1 = rawType1.typeParameter;
+  final typeParam2 = rawType2.typeParameter;
+
+  // If either type parameter is null, then the resulting union can never be a
+  // generic type, so return null.
+  _RawType? computeTypeParamUnion(_RawType? typeParam1, _RawType? typeParam2) =>
+      typeParam1 != null && typeParam2 != null
+          ? _computeRawTypeUnion(typeParam1, typeParam2)
+          : null;
 
   // Equality.
-  if (type1 == type2) return _RawType(type1, nullable1 || nullable2);
+  if (type1 == type2) {
+    return _RawType(type1, nullable1 || nullable2,
+        computeTypeParamUnion(typeParam1, typeParam2));
+  }
   // This sentinel is only for nullability.
-  if (type1 == 'JSUndefined') return _RawType(type2, true);
-  if (type2 == 'JSUndefined') return _RawType(type1, true);
+  if (type1 == 'JSUndefined') return _RawType(type2, true, typeParam2);
+  if (type2 == 'JSUndefined') return _RawType(type1, true, typeParam1);
   // If the two types are not equal, we can just use `JSNumber` as the union can
   // never be `JSInteger` or `JSDouble` anyways.
   if (type1 == 'JSInteger' || type1 == 'JSDouble') rawType1.type = 'JSNumber';
@@ -115,8 +149,8 @@ _RawType _computeRawTypeUnion(_RawType rawType1, _RawType rawType2) {
   // In the case of unions, we should try and get a JS type-able type to get a
   // better LUB.
   _RawType getTypeForUnionCalculation(_RawType rawType) {
-    var type = rawType.type;
-    var nullable = rawType.nullable;
+    final type = rawType.type;
+    final nullable = rawType.nullable;
     final decl = Translator.instance!._typeToDeclaration[type];
     if (decl != null) {
       final nodeType = decl.type;
@@ -127,25 +161,15 @@ _RawType _computeRawTypeUnion(_RawType rawType1, _RawType rawType2) {
           // we get a possible interface name instead of `JSObject`), but that
           // might be too much effort for too little reward. This would entail
           // caching the hierarchy of IDL types.
-          type = 'JSObject';
-          break;
-        case 'typedef':
-          final desugared = getTypeForUnionCalculation(
-              _getRawType((decl as idl.Typedef).idlType));
-          type = desugared.type;
-          nullable = desugared.nullable;
-          break;
-        case 'callback':
-          type = 'JSFunction';
-          break;
-        case 'enum':
-          type = 'JSString';
-          break;
+          return _RawType('JSObject', nullable);
         default:
+          final desugaredType = _getTypedefAsJsType(rawType);
+          if (desugaredType != null) return desugaredType;
           throw Exception('Unhandled type $type with node type: $nodeType');
       }
+    } else {
+      return _RawType(type, nullable, rawType.typeParameter);
     }
-    return _RawType(type, nullable);
   }
 
   final unionableType1 = getTypeForUnionCalculation(rawType1);
@@ -154,7 +178,9 @@ _RawType _computeRawTypeUnion(_RawType rawType1, _RawType rawType2) {
   // We choose `JSAny` if they're not both JS types.
   return _RawType(
       computeJsTypeUnion(unionableType1.type, unionableType2.type) ?? 'JSAny',
-      unionableType1.nullable || unionableType2.nullable);
+      unionableType1.nullable || unionableType2.nullable,
+      computeTypeParamUnion(
+          unionableType1.typeParameter, unionableType2.typeParameter));
 }
 
 /// Returns a [_RawType] for the given [idl.IDLType].
@@ -170,6 +196,7 @@ _RawType _getRawType(idl.IDLType idlType) {
   }
   String type;
   var nullable = idlType.nullable;
+  _RawType? typeParameter;
   if (idlType.generic.isNotEmpty) {
     // TODO(srujzs): Once we have a generic `JSArray` and `JSPromise`, we should
     // add these type parameters in. We need to be careful, however, as we
@@ -177,6 +204,13 @@ _RawType _getRawType(idl.IDLType idlType) {
     // either because it is an interface or a typedef. We also need to make sure
     // to convert type aliases that are Dart types back to JS types e.g.
     // `String` should be `JSString`.
+    final types = (idlType.idlType as JSArray).toDart;
+    if (types.length == 1) {
+      typeParameter = _getRawType(types[0] as idl.IDLType);
+    } else if (types.length > 1) {
+      assert(types.length == 2);
+      assert(idlType.generic == 'record');
+    }
     type = idlType.generic;
   } else {
     type = (idlType.idlType as JSString).toDart;
@@ -191,7 +225,8 @@ _RawType _getRawType(idl.IDLType idlType) {
   // `any` is marked non-nullable in the IDL, but since it is a union of
   // `undefined`, it can be nullable for our purposes.
   if (type == 'any') nullable = true;
-  return _RawType(idlOrBuiltinToJsTypeAliases[type] ?? type, nullable);
+  return _RawType(
+      idlOrBuiltinToJsTypeAliases[type] ?? type, nullable, typeParameter);
 }
 
 /// A class representing either a type that corresponds to an IDL declaration or
@@ -202,16 +237,17 @@ _RawType _getRawType(idl.IDLType idlType) {
 class _RawType {
   String type;
   bool nullable;
+  _RawType? typeParameter;
 
-  _RawType(this.type, this.nullable) {
+  _RawType(this.type, this.nullable, [this.typeParameter]) {
     // While the IDL does not define `undefined` as nullable, it is treated as
     // null in interop.
     if (type == 'JSUndefined') nullable = true;
   }
 
   void update(idl.IDLType idlType) {
-    final union =
-        _computeRawTypeUnion(_RawType(type, nullable), _getRawType(idlType));
+    final union = _computeRawTypeUnion(
+        _RawType(type, nullable, typeParameter), _getRawType(idlType));
     type = union.type;
     nullable = union.nullable;
   }
@@ -530,21 +566,53 @@ class Translator {
 
   // Given a raw type, convert it to the Dart type that will be emitted by the
   // translator.
-  code.TypeReference _typeReference(_RawType type) {
+  //
+  // If [onlyEmitInteropTypes] is true, we don't convert to Dart primitives but
+  // rather only emit a valid interop type. This is used for type arguments as
+  // they are bound to `JSAny?`.
+  code.TypeReference _typeReference(_RawType type,
+      {bool onlyEmitInteropTypes = false}) {
     var dartType = type.type;
     var nullable = type.nullable;
+    var typeParameter = type.typeParameter;
+    final typeArguments = <code.TypeReference>[];
 
-    // Convert JS types to primitives.
-    dartType = switch (dartType) {
-      'JSBoolean' => 'bool',
-      'JSString' => 'String',
-      'JSInteger' => 'int',
-      'JSDouble' => 'num',
-      'JSNumber' => 'num',
-      'JSUndefined' => 'void',
-      _ => dartType,
-    };
-    if (dartType == 'void') nullable = false;
+    if (onlyEmitInteropTypes) {
+      // [type] is already an interop type, but we need to handle two cases:
+      // 1. Types that we declare as typedefs. In the case where they are
+      // aliased to a type that we would declare as a Dart primitive, we need to
+      // use the JS type equivalent and not the typedef name.
+      // 2. Sentinels in our type aliases that aren't actually JS types.
+
+      // TODO(srujzs): Some of these typedefs definitions may end up being
+      // unused as they were ever only used in a generic. Should we delete them
+      // or does it provide value to users?
+      final rawType = _getTypedefAsJsType(type);
+      if (rawType != null &&
+          jsTypeToDartPrimitiveAliases.containsKey(rawType.type)) {
+        dartType = rawType.type;
+        nullable = rawType.nullable;
+        typeParameter = rawType.typeParameter;
+      }
+      dartType = switch (dartType) {
+        'JSInteger' => 'JSNumber',
+        'JSDouble' => 'JSNumber',
+        // When the result is `undefined`, we use `JSAny?`. We explicitly
+        // declare `JSUndefined` `_RawType`s to be nullable, so no need to set
+        // nullable.
+        'JSUndefined' => 'JSAny',
+        _ => dartType,
+      };
+    } else {
+      // Convert JS types to primitives.
+      dartType = jsTypeToDartPrimitiveAliases[dartType] ?? dartType;
+      if (dartType == 'void') nullable = false;
+    }
+    if (typeParameter != null &&
+        (dartType == 'JSArray' || dartType == 'JSPromise')) {
+      typeArguments
+          .add(_typeReference(typeParameter, onlyEmitInteropTypes: true));
+    }
     // Unfortunately, `code_builder` doesn't know the url of the library we are
     // emitting, so we have to remove it here to avoid importing ourselves.
     var url = _typeToLibrary[dartType]?.url;
@@ -563,6 +631,7 @@ class Translator {
     return code.TypeReference((b) => b
       ..symbol = dartType
       ..isNullable = nullable
+      ..types.addAll(typeArguments)
       ..url = url);
   }
 
@@ -843,18 +912,21 @@ class Translator {
     ..generatedByComment = generatedFileDisclaimer
     ..body.addAll([
       for (final typedef in library.typedefs)
-        _typedef(typedef.name, _getRawType(typedef.idlType)),
+        _typedef(
+            typedef.name, _getTypedefAsJsType(_RawType(typedef.name, false))!),
       // TODO(joshualitt): We should lower callbacks and callback interfaces to
       // a Dart function that takes a typed Dart function, and returns an
       // JSFunction.
       for (final callback in library.callbacks)
-        _typedef(callback.name, _RawType('JSFunction', false)),
+        _typedef(callback.name,
+            _getTypedefAsJsType(_RawType(callback.name, false))!),
       for (final callbackInterface in library.callbackInterfaces)
-        _typedef(callbackInterface.name, _RawType('JSFunction', false)),
+        _typedef(callbackInterface.name,
+            _getTypedefAsJsType(_RawType(callbackInterface.name, false))!),
       // TODO(joshualitt): Enums in the WebIDL are just strings, but we could
       // make them easier to work with on the Dart side.
       for (final enum_ in library.enums)
-        _typedef(enum_.name, _RawType('String', false)),
+        _typedef(enum_.name, _getTypedefAsJsType(_RawType(enum_.name, false))!),
       for (final interfacelike in library.interfacelikes)
         ..._interfacelike(interfacelike),
     ]));

--- a/tool/generator/type_aliases.dart
+++ b/tool/generator/type_aliases.dart
@@ -5,6 +5,7 @@
 const idlOrBuiltinToJsTypeAliases = <String, String>{
   'any': 'JSAny',
   'bigint': 'JSBigInt',
+  // TODO(srujzs): Records should be JSObject.
   'record': 'JSAny',
   'object': 'JSObject',
   'Promise': 'JSPromise',
@@ -56,4 +57,13 @@ const idlOrBuiltinToJsTypeAliases = <String, String>{
   'USVString': 'JSString',
   'ByteString': 'JSString',
   'CSSOMString': 'JSString',
+};
+
+const jsTypeToDartPrimitiveAliases = <String, String>{
+  'JSBoolean': 'bool',
+  'JSString': 'String',
+  'JSInteger': 'int',
+  'JSDouble': 'num',
+  'JSNumber': 'num',
+  'JSUndefined': 'void',
 };


### PR DESCRIPTION
Adds a "typeParameter" field to _RawType that keeps track of the generic type for union and emission purposes. Also handles typedefs so that the generic type is always a valid interop type and not a Dart primitive type.

The typedef handling comes at the cost of not having a better name for these types when they appear in generics and some typedefs being potentially unused. The alternative is to make all typedefs JS types but that means an increased need for conversions. From a quick analysis, this would affect several hundred APIs. Another alternative is to have two typedefs, one for the generic and one for the non-generic. This has its own visual downsides as we now have two typedefs for every typedef.