### PR TITLE
Deprecate extension methods returning `Point`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Changed `record` types to be `JSObject` instead of `JSAny`.
 - Reduce the number of DOM APIs we generate code for. Currently, the API needs
   to be standards-track, and be suported by Safari, Chrome, and Firefox.
+- Deprecate the `client` extension methods on `MouseEvent` and `Touch`.
+  Instead, directly use the `clientX` and `clientY` properties.
 
 ## 0.4.2
 

--- a/lib/src/helpers/extensions.dart
+++ b/lib/src/helpers/extensions.dart
@@ -74,10 +74,22 @@ extension NodeGlue on Node {
 }
 
 extension EventGlue on MouseEvent {
+  /// A [Point] representation of the [clientX] and [clientY] properties
+  /// of this [MouseEvent].
+  ///
+  /// **Deprecated:** Prefer directly accessing
+  /// the [clientX] and [clientY] properties on [MouseEvent].
+  @Deprecated('Instead directly access the clientX and clientY properties.')
   Point get client => Point(clientX, clientY);
 }
 
 extension TouchGlue on Touch {
+  /// A [Point] representation of the [clientX] and [clientY] properties
+  /// of this [Touch] event.
+  ///
+  /// **Deprecated:** Prefer directly accessing
+  /// the [clientX] and [clientY] properties on [Touch].
+  @Deprecated('Instead directly access the clientX and clientY properties.')
   Point get client => Point(clientX, clientY);
 }
 


### PR DESCRIPTION
`Point` really shouldn't exist in its current form so we shouldn't encourage or enable its use.

If anyone still thinks these extensions are helpful, maybe we could return a record instead.