### PR TITLE
improve testing of the 'dart fix' data

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -14,6 +14,8 @@ analyzer:
     # necessary
     camel_case_types: ignore
     non_constant_identifier_names: ignore
+    # Consider removing from dart_flutter_team_lints.
+    unreachable_from_main: ignore
 
 linter:
   rules:

--- a/lib/fix_data.yaml
+++ b/lib/fix_data.yaml
@@ -44,15 +44,6 @@ transforms:
     changes:
       - kind: 'rename'
         newName: 'HTMLBaseElement'
-  # BluetoothRemoteGattDescriptor => BluetoothRemoteGATTDescriptor
-  - title: "Rename to 'BluetoothRemoteGATTDescriptor'"
-    date: 2024-01-12
-    element:
-      uris: [ 'package:web/web.dart' ]
-      class: 'BluetoothRemoteGattDescriptor'
-    changes:
-      - kind: 'rename'
-        newName: 'BluetoothRemoteGATTDescriptor'
   # BodyElement => HTMLBodyElement
   - title: "Rename to 'HTMLBodyElement'"
     date: 2024-01-12
@@ -98,15 +89,6 @@ transforms:
     changes:
       - kind: 'rename'
         newName: 'CDATASection'
-  # Css => CSS
-  - title: "Rename to 'CSS'"
-    date: 2024-01-12
-    element:
-      uris: [ 'package:web/web.dart' ]
-      class: 'Css'
-    changes:
-      - kind: 'rename'
-        newName: 'CSS'
   # CssConditionRule => CSSConditionRule
   - title: "Rename to 'CSSConditionRule'"
     date: 2024-01-12
@@ -647,15 +629,6 @@ transforms:
     changes:
       - kind: 'rename'
         newName: 'HTMLHtmlElement'
-  # HtmlHyperlinkElementUtils => HTMLHyperlinkElementUtils
-  - title: "Rename to 'HTMLHyperlinkElementUtils'"
-    date: 2024-01-12
-    element:
-      uris: [ 'package:web/web.dart' ]
-      class: 'HtmlHyperlinkElementUtils'
-    changes:
-      - kind: 'rename'
-        newName: 'HTMLHyperlinkElementUtils'
   # HtmlOptionsCollection => HTMLOptionsCollection
   - title: "Rename to 'HTMLOptionsCollection'"
     date: 2024-01-12
@@ -800,78 +773,6 @@ transforms:
     changes:
       - kind: 'rename'
         newName: 'HTMLMeterElement'
-  # MidiAccess => MIDIAccess
-  - title: "Rename to 'MIDIAccess'"
-    date: 2024-01-12
-    element:
-      uris: [ 'package:web/web.dart' ]
-      class: 'MidiAccess'
-    changes:
-      - kind: 'rename'
-        newName: 'MIDIAccess'
-  # MidiConnectionEvent => MIDIConnectionEvent
-  - title: "Rename to 'MIDIConnectionEvent'"
-    date: 2024-01-12
-    element:
-      uris: [ 'package:web/web.dart' ]
-      class: 'MidiConnectionEvent'
-    changes:
-      - kind: 'rename'
-        newName: 'MIDIConnectionEvent'
-  # MidiInput => MIDIInput
-  - title: "Rename to 'MIDIInput'"
-    date: 2024-01-12
-    element:
-      uris: [ 'package:web/web.dart' ]
-      class: 'MidiInput'
-    changes:
-      - kind: 'rename'
-        newName: 'MIDIInput'
-  # MidiInputMap => MIDIInputMap
-  - title: "Rename to 'MIDIInputMap'"
-    date: 2024-01-12
-    element:
-      uris: [ 'package:web/web.dart' ]
-      class: 'MidiInputMap'
-    changes:
-      - kind: 'rename'
-        newName: 'MIDIInputMap'
-  # MidiMessageEvent => MIDIMessageEvent
-  - title: "Rename to 'MIDIMessageEvent'"
-    date: 2024-01-12
-    element:
-      uris: [ 'package:web/web.dart' ]
-      class: 'MidiMessageEvent'
-    changes:
-      - kind: 'rename'
-        newName: 'MIDIMessageEvent'
-  # MidiOutput => MIDIOutput
-  - title: "Rename to 'MIDIOutput'"
-    date: 2024-01-12
-    element:
-      uris: [ 'package:web/web.dart' ]
-      class: 'MidiOutput'
-    changes:
-      - kind: 'rename'
-        newName: 'MIDIOutput'
-  # MidiOutputMap => MIDIOutputMap
-  - title: "Rename to 'MIDIOutputMap'"
-    date: 2024-01-12
-    element:
-      uris: [ 'package:web/web.dart' ]
-      class: 'MidiOutputMap'
-    changes:
-      - kind: 'rename'
-        newName: 'MIDIOutputMap'
-  # MidiPort => MIDIPort
-  - title: "Rename to 'MIDIPort'"
-    date: 2024-01-12
-    element:
-      uris: [ 'package:web/web.dart' ]
-      class: 'MidiPort'
-    changes:
-      - kind: 'rename'
-        newName: 'MIDIPort'
   # ModElement => HTMLModElement
   - title: "Rename to 'HTMLModElement'"
     date: 2024-01-12
@@ -1277,24 +1178,6 @@ transforms:
     changes:
       - kind: 'rename'
         newName: 'HTMLTrackElement'
-  # TrustedHtml => TrustedHTML
-  - title: "Rename to 'TrustedHTML'"
-    date: 2024-01-12
-    element:
-      uris: [ 'package:web/web.dart' ]
-      class: 'TrustedHtml'
-    changes:
-      - kind: 'rename'
-        newName: 'TrustedHTML'
-  # TrustedScriptUrl => TrustedScriptURL
-  - title: "Rename to 'TrustedScriptURL'"
-    date: 2024-01-12
-    element:
-      uris: [ 'package:web/web.dart' ]
-      class: 'TrustedScriptUrl'
-    changes:
-      - kind: 'rename'
-        newName: 'TrustedScriptURL'
   # UListElement => HTMLUListElement
   - title: "Rename to 'HTMLUListElement'"
     date: 2024-01-12

--- a/test/dart_fix_test.dart
+++ b/test/dart_fix_test.dart
@@ -1,0 +1,98 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+// Used for debugging the test.
+const keepTempDir = false;
+
+void main() {
+  test("'dart fix' integration", () {
+    // create temp dir
+    final tempDir = Directory.systemTemp.createTempSync('test');
+
+    var sdkVersion = Platform.version;
+    if (sdkVersion.contains(' ')) {
+      sdkVersion = sdkVersion.substring(0, sdkVersion.indexOf(' '));
+    }
+
+    try {
+      // set up project
+      writeFile(tempDir, 'pubspec.yaml', '''
+name: test_project
+environment:
+  sdk: '^$sdkVersion'
+dependencies:
+  web:
+    path: ${Directory.current.path}
+''');
+      final sourceFile = File(p.join('test_fixes', 'renames.dart'));
+      writeFile(
+        tempDir,
+        p.join('lib', sourceFile.name),
+        sourceFile.readAsStringSync(),
+      );
+
+      // run pub get
+      pubGet(tempDir);
+
+      // dart fix
+      dartFix(tempDir);
+
+      // verify no analysis issues
+      dartAnalyze(tempDir);
+    } finally {
+      // ignore: dead_code
+      if (keepTempDir) {
+        print('dart fix test temp dir: ${tempDir.path}');
+      } else {
+        tempDir.deleteSync(recursive: true);
+      }
+    }
+  });
+}
+
+void writeFile(Directory dir, String filePath, String contents) {
+  final file = File(p.join(dir.path, filePath));
+  file.parent.createSync();
+  file.writeAsStringSync(contents);
+}
+
+void pubGet(Directory dir) {
+  exec('pub', ['get'], cwd: dir);
+}
+
+void dartFix(Directory dir) {
+  exec('fix', ['--apply'], cwd: dir);
+}
+
+void dartAnalyze(Directory dir) {
+  exec('analyze', [], cwd: dir);
+}
+
+void exec(String command, List<String> args, {required Directory cwd}) {
+  printOnFailure('dart $command ${args.join(', ')}');
+
+  final result = Process.runSync(
+    Platform.resolvedExecutable,
+    [command, ...args],
+    workingDirectory: cwd.path,
+  );
+
+  var out = result.stdout as String;
+  if (out.isNotEmpty) printOnFailure(out);
+  out = result.stderr as String;
+  if (out.isNotEmpty) printOnFailure(out);
+
+  if (result.exitCode != 0) {
+    fail('dart $command: exitCode ${result.exitCode}');
+  }
+}
+
+extension on File {
+  String get name => p.basename(path);
+}

--- a/test/dart_fix_test.dart
+++ b/test/dart_fix_test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@TestOn('vm')
+library;
+
 import 'dart:io';
 
 import 'package:path/path.dart' as p;

--- a/test/scrape_mdn_test.dart
+++ b/test/scrape_mdn_test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@TestOn('vm')
+library;
+
 import 'package:test/test.dart';
 
 import '../tool/scrape_mdn.dart';

--- a/test_fixes/renames.dart
+++ b/test_fixes/renames.dart
@@ -2,21 +2,17 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: unreachable_from_main
-
 import 'package:web/web.dart';
 
 late AnchorElement $0;
 late AreaElement $1;
 late AudioElement $2;
 late BaseElement $3;
-late BluetoothRemoteGattDescriptor $4;
 late BodyElement $5;
 late BRElement $6;
 late ButtonElement $7;
 late CanvasElement $8;
 late CDataSection $9;
-late Css $10;
 late CssConditionRule $11;
 late CssFontFaceRule $12;
 late CssGroupingRule $13;
@@ -77,7 +73,6 @@ late HtmlDocument $67;
 late HtmlElement $68;
 late HtmlFormControlsCollection $69;
 late HtmlHtmlElement $70;
-late HtmlHyperlinkElementUtils $71;
 late HtmlOptionsCollection $72;
 // late HttpRequest/XMLHttpRequest $73;
 late HttpRequestEventTarget $74;
@@ -94,14 +89,6 @@ late MediaElement $84;
 late MenuElement $85;
 late MetaElement $86;
 late MeterElement $87;
-late MidiAccess $88;
-late MidiConnectionEvent $89;
-late MidiInput $90;
-late MidiInputMap $91;
-late MidiMessageEvent $92;
-late MidiOutput $93;
-late MidiOutputMap $94;
-late MidiPort $95;
 late ModElement $96;
 late ObjectElement $97;
 late OListElement $98;
@@ -147,8 +134,6 @@ late TextAreaElement $137;
 late TimeElement $138;
 late TitleElement $139;
 late TrackElement $140;
-late TrustedHtml $141;
-late TrustedScriptUrl $142;
 late UListElement $143;
 late UnderlyingSourceBase $144;
 late UnknownElement $145;

--- a/test_fixes/renames.dart.expect
+++ b/test_fixes/renames.dart.expect
@@ -2,21 +2,17 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: unreachable_from_main
-
 import 'package:web/web.dart';
 
 late HTMLAnchorElement $0;
 late HTMLAreaElement $1;
 late HTMLAudioElement $2;
 late HTMLBaseElement $3;
-late BluetoothRemoteGATTDescriptor $4;
 late HTMLBodyElement $5;
 late HTMLBRElement $6;
 late HTMLButtonElement $7;
 late HTMLCanvasElement $8;
 late CDATASection $9;
-late CSS $10;
 late CSSConditionRule $11;
 late CSSFontFaceRule $12;
 late CSSGroupingRule $13;
@@ -77,7 +73,6 @@ late Document $67;
 late HTMLElement $68;
 late HTMLFormControlsCollection $69;
 late HTMLHtmlElement $70;
-late HTMLHyperlinkElementUtils $71;
 late HTMLOptionsCollection $72;
 // late HttpRequest/XMLHttpRequest $73;
 late XMLHttpRequestEventTarget $74;
@@ -94,14 +89,6 @@ late HTMLMediaElement $84;
 late HTMLMenuElement $85;
 late HTMLMetaElement $86;
 late HTMLMeterElement $87;
-late MIDIAccess $88;
-late MIDIConnectionEvent $89;
-late MIDIInput $90;
-late MIDIInputMap $91;
-late MIDIMessageEvent $92;
-late MIDIOutput $93;
-late MIDIOutputMap $94;
-late MIDIPort $95;
 late HTMLModElement $96;
 late HTMLObjectElement $97;
 late HTMLOListElement $98;
@@ -147,8 +134,6 @@ late HTMLTextAreaElement $137;
 late HTMLTimeElement $138;
 late HTMLTitleElement $139;
 late HTMLTrackElement $140;
-late TrustedHTML $141;
-late TrustedScriptURL $142;
 late HTMLUListElement $143;
 late UnderlyingSource $144;
 late HTMLUnknownElement $145;

--- a/tool/renames.md
+++ b/tool/renames.md
@@ -17,7 +17,6 @@
 | BackgroundFetchFetch          |                               |
 | BackgroundFetchSettledFetch   |                               |
 | BaseElement                   | HTMLBaseElement               |
-| BluetoothRemoteGattDescriptor | BluetoothRemoteGATTDescriptor |
 | BodyElement                   | HTMLBodyElement               |
 | BRElement                     | HTMLBRElement                 |
 | BudgetState                   |                               |
@@ -26,7 +25,6 @@
 | CDataSection                  | CDATASection                  |
 | ContentElement                |                               |
 | Coordinates                   |                               |
-| Css                           | CSS                           |
 | CssCharsetRule                |                               |
 | CssConditionRule              | CSSConditionRule              |
 | CssFontFaceRule               | CSSFontFaceRule               |
@@ -103,7 +101,6 @@
 | HtmlElement                   | HTMLElement                   |
 | HtmlFormControlsCollection    | HTMLFormControlsCollection    |
 | HtmlHtmlElement               | HTMLHtmlElement               |
-| HtmlHyperlinkElementUtils     | HTMLHyperlinkElementUtils     |
 | HtmlOptionsCollection         | HTMLOptionsCollection         |
 | HttpRequest                   | XMLHttpRequest                |
 | HttpRequestEventTarget        | XMLHttpRequestEventTarget     |
@@ -127,14 +124,6 @@
 | Metadata                      |                               |
 | MetaElement                   | HTMLMetaElement               |
 | MeterElement                  | HTMLMeterElement              |
-| MidiAccess                    | MIDIAccess                    |
-| MidiConnectionEvent           | MIDIConnectionEvent           |
-| MidiInput                     | MIDIInput                     |
-| MidiInputMap                  | MIDIInputMap                  |
-| MidiMessageEvent              | MIDIMessageEvent              |
-| MidiOutput                    | MIDIOutput                    |
-| MidiOutputMap                 | MIDIOutputMap                 |
-| MidiPort                      | MIDIPort                      |
 | ModElement                    | HTMLModElement                |
 | NavigatorUserMediaError       |                               |
 | NoncedElement                 |                               |
@@ -193,8 +182,6 @@
 | TrackDefault                  |                               |
 | TrackDefaultList              |                               |
 | TrackElement                  | HTMLTrackElement              |
-| TrustedHtml                   | TrustedHTML                   |
-| TrustedScriptUrl              | TrustedScriptURL              |
 | TrustedUrl                    |                               |
 | UListElement                  | HTMLUListElement              |
 | UnderlyingSourceBase          | UnderlyingSource              |


### PR DESCRIPTION
- improve testing of the 'dart fix' data
- remove fix data references to previous package:web types we no longer generate

When we reduced the number of generated APIs we stopped generating some classes referenced in the `lib/fix_data.yaml` file. Our testing didn't catch this, since the running `dart fix --compare-to-golden` just mechanically confirms that it can transform the file, not whether the resulting file is error free.

This PR creates a new temporary project with the `test_fixes/renames.dart` file - which contains the older dart:html type names - runs `dart fix` on that project, to update the references to the new package:web names, and runs `dart analyze` to make sure the result has no analysis issues.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
