### PR TITLE
write bcd info to a markdown file

### DIFF
--- a/tool/bcd.md
+++ b/tool/bcd.md
@@ -1,0 +1,1421 @@
+## ANGLE_instanced_arrays
+
+- ANGLE_instanced_arrays: standards-track (chrome, firefox, safari)
+
+## CSP
+
+- CSPViolationReportBody: standards-track (chrome, safari)
+- SecurityPolicyViolationEvent: standards-track (chrome, firefox, safari)
+- SecurityPolicyViolationEventInit:
+
+## DOM-Parsing
+
+- XMLSerializer: standards-track (chrome, firefox, safari)
+
+## EXT_blend_minmax
+
+- EXT_blend_minmax: standards-track (chrome, firefox, safari)
+
+## EXT_color_buffer_float
+
+- EXT_color_buffer_float: standards-track (chrome, firefox, safari)
+
+## EXT_color_buffer_half_float
+
+- EXT_color_buffer_half_float: standards-track (chrome, firefox, safari)
+
+## EXT_float_blend
+
+- EXT_float_blend: standards-track (chrome, firefox, safari)
+
+## EXT_frag_depth
+
+- EXT_frag_depth: standards-track (chrome, firefox, safari)
+
+## EXT_sRGB
+
+- EXT_sRGB: standards-track (chrome, firefox, safari)
+
+## EXT_shader_texture_lod
+
+- EXT_shader_texture_lod: standards-track (chrome, firefox, safari)
+
+## EXT_texture_compression_bptc
+
+- EXT_texture_compression_bptc: standards-track (chrome, firefox, safari)
+
+## EXT_texture_compression_rgtc
+
+- EXT_texture_compression_rgtc: standards-track (chrome, firefox, safari)
+
+## EXT_texture_filter_anisotropic
+
+- EXT_texture_filter_anisotropic: standards-track (chrome, firefox, safari)
+
+## FileAPI
+
+- Blob: standards-track (chrome, firefox, safari)
+- BlobPropertyBag:
+- File: standards-track (chrome, firefox, safari)
+- FileList: standards-track (chrome, firefox, safari)
+- FilePropertyBag:
+- FileReader: standards-track (chrome, firefox, safari)
+- FileReaderSync: standards-track (chrome, firefox, safari)
+
+## IndexedDB
+
+- IDBCursor: standards-track (chrome, firefox, safari)
+- IDBCursorWithValue: standards-track (chrome, firefox, safari)
+- IDBDatabase: standards-track (chrome, firefox, safari)
+- IDBDatabaseInfo:
+- IDBFactory: standards-track (chrome, firefox, safari)
+- IDBIndex: standards-track (chrome, firefox, safari)
+- IDBIndexParameters:
+- IDBKeyRange: standards-track (chrome, firefox, safari)
+- IDBObjectStore: standards-track (chrome, firefox, safari)
+- IDBObjectStoreParameters:
+- IDBOpenDBRequest: standards-track (chrome, firefox, safari)
+- IDBRequest: standards-track (chrome, firefox, safari)
+- IDBTransaction: standards-track (chrome, firefox, safari)
+- IDBTransactionOptions:
+- IDBVersionChangeEvent: standards-track (chrome, firefox, safari)
+- IDBVersionChangeEventInit:
+
+## OES_draw_buffers_indexed
+
+- OES_draw_buffers_indexed: standards-track (chrome, firefox, safari)
+
+## OES_element_index_uint
+
+- OES_element_index_uint: standards-track (chrome, firefox, safari)
+
+## OES_fbo_render_mipmap
+
+- OES_fbo_render_mipmap: standards-track (chrome, firefox, safari)
+
+## OES_standard_derivatives
+
+- OES_standard_derivatives: standards-track (chrome, firefox, safari)
+
+## OES_texture_float
+
+- OES_texture_float: standards-track (chrome, firefox, safari)
+
+## OES_texture_float_linear
+
+- OES_texture_float_linear: standards-track (chrome, firefox, safari)
+
+## OES_texture_half_float
+
+- OES_texture_half_float: standards-track (chrome, firefox, safari)
+
+## OES_texture_half_float_linear
+
+- OES_texture_half_float_linear: standards-track (chrome, firefox, safari)
+
+## OES_vertex_array_object
+
+- OES_vertex_array_object: standards-track (chrome, firefox, safari)
+- WebGLVertexArrayObjectOES: standards-track (chrome, firefox, safari)
+
+## SVG
+
+- SVGAElement: standards-track (chrome, firefox, safari)
+- SVGAngle: standards-track (chrome, firefox, safari)
+- SVGAnimatedAngle: standards-track (chrome, firefox, safari)
+- SVGAnimatedBoolean: standards-track (chrome, firefox, safari)
+- SVGAnimatedEnumeration: standards-track (chrome, firefox, safari)
+- SVGAnimatedInteger: standards-track (chrome, firefox, safari)
+- SVGAnimatedLength: standards-track (chrome, firefox, safari)
+- SVGAnimatedLengthList: standards-track (chrome, firefox, safari)
+- SVGAnimatedNumber: standards-track (chrome, firefox, safari)
+- SVGAnimatedNumberList: standards-track (chrome, firefox, safari)
+- SVGAnimatedPreserveAspectRatio: standards-track (chrome, firefox, safari)
+- SVGAnimatedRect: standards-track (chrome, firefox, safari)
+- SVGAnimatedString: standards-track (chrome, firefox, safari)
+- SVGAnimatedTransformList: standards-track (chrome, firefox, safari)
+- SVGBoundingBoxOptions:
+- SVGCircleElement: standards-track (chrome, firefox, safari)
+- SVGDefsElement: standards-track (chrome, firefox, safari)
+- SVGDescElement: standards-track (chrome, firefox, safari)
+- SVGElement: standards-track (chrome, firefox, safari)
+- SVGEllipseElement: standards-track (chrome, firefox, safari)
+- SVGForeignObjectElement: standards-track (chrome, firefox, safari)
+- SVGGElement: standards-track (chrome, firefox, safari)
+- SVGGeometryElement: standards-track (chrome, firefox, safari)
+- SVGGradientElement: standards-track (chrome, firefox, safari)
+- SVGGraphicsElement: standards-track (chrome, firefox, safari)
+- SVGImageElement: standards-track (chrome, firefox, safari)
+- SVGLength: standards-track (chrome, firefox, safari)
+- SVGLengthList: standards-track (chrome, firefox, safari)
+- SVGLineElement: standards-track (chrome, firefox, safari)
+- SVGLinearGradientElement: standards-track (chrome, firefox, safari)
+- SVGMarkerElement: standards-track (chrome, firefox, safari)
+- SVGMetadataElement: standards-track (chrome, firefox, safari)
+- SVGNumber: standards-track (chrome, firefox, safari)
+- SVGNumberList: standards-track (chrome, firefox, safari)
+- SVGPathElement: standards-track (chrome, firefox, safari)
+- SVGPatternElement: standards-track (chrome, firefox, safari)
+- SVGPointList: standards-track (chrome, firefox, safari)
+- SVGPolygonElement: standards-track (chrome, firefox, safari)
+- SVGPolylineElement: standards-track (chrome, firefox, safari)
+- SVGPreserveAspectRatio: standards-track (chrome, firefox, safari)
+- SVGRadialGradientElement: standards-track (chrome, firefox, safari)
+- SVGRectElement: standards-track (chrome, firefox, safari)
+- SVGSVGElement: standards-track (chrome, firefox, safari)
+- SVGScriptElement: standards-track (chrome, firefox, safari)
+- SVGStopElement: standards-track (chrome, firefox, safari)
+- SVGStringList: standards-track (chrome, firefox, safari)
+- SVGStyleElement: standards-track (chrome, firefox, safari)
+- SVGSwitchElement: standards-track (chrome, firefox, safari)
+- SVGSymbolElement: standards-track (chrome, firefox, safari)
+- SVGTSpanElement: standards-track (chrome, firefox, safari)
+- SVGTextContentElement: standards-track (chrome, firefox, safari)
+- SVGTextElement: standards-track (chrome, firefox, safari)
+- SVGTextPathElement: standards-track (chrome, firefox, safari)
+- SVGTextPositioningElement: standards-track (chrome, firefox, safari)
+- SVGTitleElement: standards-track (chrome, firefox, safari)
+- SVGTransform: standards-track (chrome, firefox, safari)
+- SVGTransformList: standards-track (chrome, firefox, safari)
+- SVGUnitTypes: standards-track (chrome, firefox, safari)
+- SVGUseElement: standards-track (chrome, firefox, safari)
+- SVGUseElementShadowRoot:
+- SVGViewElement: standards-track (chrome, firefox, safari)
+- ShadowAnimation:
+
+## WEBGL_color_buffer_float
+
+- WEBGL_color_buffer_float: standards-track (chrome, firefox, safari)
+
+## WEBGL_compressed_texture_astc
+
+- WEBGL_compressed_texture_astc: standards-track (chrome, firefox, safari)
+
+## WEBGL_compressed_texture_s3tc
+
+- WEBGL_compressed_texture_s3tc: standards-track (chrome, firefox, safari)
+
+## WEBGL_compressed_texture_s3tc_srgb
+
+- WEBGL_compressed_texture_s3tc_srgb: standards-track (chrome, firefox, safari)
+
+## WEBGL_debug_renderer_info
+
+- WEBGL_debug_renderer_info: standards-track (chrome, firefox, safari)
+
+## WEBGL_debug_shaders
+
+- WEBGL_debug_shaders: standards-track (chrome, firefox, safari)
+
+## WEBGL_depth_texture
+
+- WEBGL_depth_texture: standards-track (chrome, firefox, safari)
+
+## WEBGL_draw_buffers
+
+- WEBGL_draw_buffers: standards-track (chrome, firefox, safari)
+
+## WEBGL_lose_context
+
+- WEBGL_lose_context: standards-track (chrome, firefox, safari)
+
+## WebCryptoAPI
+
+- AesCbcParams:
+- AesCtrParams:
+- AesDerivedKeyParams:
+- AesGcmParams:
+- AesKeyAlgorithm:
+- AesKeyGenParams:
+- Algorithm:
+- Crypto: standards-track (chrome, firefox, safari)
+- CryptoKey: standards-track (chrome, firefox, safari)
+- CryptoKeyPair:
+- EcKeyAlgorithm:
+- EcKeyGenParams:
+- EcKeyImportParams:
+- EcdhKeyDeriveParams:
+- EcdsaParams:
+- HkdfParams:
+- HmacImportParams:
+- HmacKeyAlgorithm:
+- HmacKeyGenParams:
+- JsonWebKey:
+- KeyAlgorithm:
+- Pbkdf2Params:
+- RsaHashedImportParams:
+- RsaHashedKeyAlgorithm:
+- RsaHashedKeyGenParams:
+- RsaKeyAlgorithm:
+- RsaKeyGenParams:
+- RsaOaepParams:
+- RsaOtherPrimesInfo:
+- RsaPssParams:
+- SubtleCrypto: standards-track (chrome, firefox, safari)
+
+## clipboard-apis
+
+- Clipboard: standards-track (chrome, firefox, safari)
+- ClipboardEvent: standards-track (chrome, firefox, safari)
+- ClipboardEventInit:
+- ClipboardItem: standards-track (chrome, firefox, safari)
+- ClipboardItemOptions:
+- ClipboardPermissionDescriptor:
+- ClipboardUnsanitizedFormats:
+
+## compression
+
+- CompressionStream: standards-track (chrome, firefox, safari)
+- DecompressionStream: standards-track (chrome, firefox, safari)
+
+## console
+
+- console: standards-track (chrome, firefox, safari)
+
+## credential-management
+
+- Credential: standards-track (chrome, firefox, safari)
+- CredentialCreationOptions:
+- CredentialData:
+- CredentialRequestOptions:
+- CredentialsContainer: standards-track (chrome, firefox, safari)
+- FederatedCredential: standards-track, experimental (chrome)
+- FederatedCredentialInit:
+- FederatedCredentialRequestOptions:
+- PasswordCredential: standards-track, experimental (chrome)
+- PasswordCredentialData:
+
+## css-animations
+
+- AnimationEvent: standards-track (chrome, firefox, safari)
+- AnimationEventInit:
+- CSSKeyframeRule: standards-track (chrome, firefox, safari)
+- CSSKeyframesRule: standards-track (chrome, firefox, safari)
+
+## css-animations-2
+
+- CSSAnimation: standards-track (chrome, firefox, safari)
+
+## css-cascade
+
+- CSSLayerBlockRule: standards-track (chrome, firefox, safari)
+- CSSLayerStatementRule: standards-track (chrome, firefox, safari)
+
+## css-conditional
+
+- CSSConditionRule: standards-track (chrome, firefox, safari)
+- CSSMediaRule: standards-track (chrome, firefox, safari)
+- CSSSupportsRule: standards-track (chrome, firefox, safari)
+
+## css-contain-3
+
+- CSSContainerRule: standards-track (chrome, firefox, safari)
+
+## css-counter-styles
+
+- CSSCounterStyleRule: standards-track (chrome, firefox, safari)
+
+## css-font-loading
+
+- FontFace: standards-track (chrome, firefox, safari)
+- FontFaceDescriptors:
+- FontFaceFeatures:
+- FontFacePalette:
+- FontFacePalettes:
+- FontFaceSet: standards-track (chrome, firefox, safari)
+- FontFaceSetLoadEvent: standards-track (chrome, firefox)
+- FontFaceSetLoadEventInit:
+- FontFaceVariationAxis:
+- FontFaceVariations:
+
+## css-fonts
+
+- CSSFontFaceRule: standards-track (chrome, firefox, safari)
+- CSSFontFeatureValuesMap:
+- CSSFontFeatureValuesRule: standards-track (chrome, firefox, safari)
+- CSSFontPaletteValuesRule: standards-track (chrome, firefox, safari)
+
+## css-highlight-api
+
+- Highlight: standards-track (chrome, firefox, safari)
+- HighlightRegistry: standards-track (chrome, firefox, safari)
+
+## css-masking
+
+- SVGClipPathElement: standards-track (chrome, firefox, safari)
+- SVGMaskElement: standards-track (chrome, firefox, safari)
+
+## css-properties-values-api
+
+- CSSPropertyRule: standards-track (chrome, firefox, safari)
+- PropertyDefinition:
+
+## css-transitions
+
+- TransitionEvent: standards-track (chrome, firefox, safari)
+- TransitionEventInit:
+
+## css-transitions-2
+
+- CSSStartingStyleRule: standards-track, experimental (chrome)
+- CSSTransition: standards-track (chrome, firefox, safari)
+
+## css-typed-om
+
+- CSSColor:
+- CSSColorValue:
+- CSSHSL:
+- CSSHWB:
+- CSSImageValue: standards-track (chrome, safari)
+- CSSKeywordValue: standards-track (chrome, safari)
+- CSSLCH:
+- CSSLab:
+- CSSMathClamp: standards-track (chrome, safari)
+- CSSMathInvert: standards-track (chrome, safari)
+- CSSMathMax: standards-track (chrome, safari)
+- CSSMathMin: standards-track (chrome, safari)
+- CSSMathNegate: standards-track (chrome, safari)
+- CSSMathProduct: standards-track (chrome, safari)
+- CSSMathSum: standards-track (chrome, safari)
+- CSSMathValue: standards-track (chrome, safari)
+- CSSMatrixComponent: standards-track (chrome, safari)
+- CSSMatrixComponentOptions:
+- CSSNumericArray: standards-track (chrome, safari)
+- CSSNumericType:
+- CSSNumericValue: standards-track (chrome, safari)
+- CSSOKLCH:
+- CSSOKLab:
+- CSSPerspective: standards-track (chrome, safari)
+- CSSRGB:
+- CSSRotate: standards-track (chrome, safari)
+- CSSScale: standards-track (chrome, safari)
+- CSSSkew: standards-track (chrome, safari)
+- CSSSkewX: standards-track (chrome, safari)
+- CSSSkewY: standards-track (chrome, safari)
+- CSSStyleValue: standards-track (chrome, safari)
+- CSSTransformComponent: standards-track (chrome, safari)
+- CSSTransformValue: standards-track (chrome, safari)
+- CSSTranslate: standards-track (chrome, safari)
+- CSSUnitValue: standards-track (chrome, safari)
+- CSSUnparsedValue: standards-track (chrome, safari)
+- CSSVariableReferenceValue: standards-track (chrome, safari)
+- StylePropertyMap: standards-track (chrome, safari)
+- StylePropertyMapReadOnly: standards-track (chrome, safari)
+
+## css-view-transitions
+
+- ViewTransition: standards-track, experimental (chrome)
+
+## cssom
+
+- CSS: standards-track (chrome, firefox, safari)
+- CSSGroupingRule: standards-track (chrome, firefox, safari)
+- CSSImportRule: standards-track (chrome, firefox, safari)
+- CSSMarginRule:
+- CSSNamespaceRule: standards-track (chrome, firefox, safari)
+- CSSPageRule: standards-track (chrome, firefox, safari)
+- CSSRule: standards-track (chrome, firefox, safari)
+- CSSRuleList: standards-track (chrome, firefox, safari)
+- CSSStyleDeclaration: standards-track (chrome, firefox, safari)
+- CSSStyleRule: standards-track (chrome, firefox, safari)
+- CSSStyleSheet: standards-track (chrome, firefox, safari)
+- CSSStyleSheetInit:
+- MediaList: standards-track (chrome, firefox, safari)
+- StyleSheet: standards-track (chrome, firefox, safari)
+- StyleSheetList: standards-track (chrome, firefox, safari)
+
+## cssom-view
+
+- BoxQuadOptions:
+- CaretPosition: standards-track, experimental (firefox)
+- CheckVisibilityOptions:
+- ConvertCoordinateOptions:
+- MediaQueryList: standards-track (chrome, firefox, safari)
+- MediaQueryListEvent: standards-track (chrome, firefox, safari)
+- MediaQueryListEventInit:
+- Screen: standards-track (chrome, firefox, safari)
+- ScrollIntoViewOptions:
+- ScrollOptions:
+- ScrollToOptions:
+- VisualViewport: standards-track (chrome, firefox, safari)
+
+## dom
+
+- AbortController: standards-track (chrome, firefox, safari)
+- AbortSignal: standards-track (chrome, firefox, safari)
+- AbstractRange: standards-track (chrome, firefox, safari)
+- AddEventListenerOptions:
+- Attr: standards-track (chrome, firefox, safari)
+- CDATASection: standards-track (chrome, firefox, safari)
+- CharacterData: standards-track (chrome, firefox, safari)
+- Comment: standards-track (chrome, firefox, safari)
+- CustomEvent: standards-track (chrome, firefox, safari)
+- CustomEventInit:
+- DOMImplementation: standards-track (chrome, firefox, safari)
+- DOMTokenList: standards-track (chrome, firefox, safari)
+- Document: standards-track (chrome, firefox, safari)
+- DocumentFragment: standards-track (chrome, firefox, safari)
+- DocumentType: standards-track (chrome, firefox, safari)
+- Element: standards-track (chrome, firefox, safari)
+- ElementCreationOptions:
+- Event: standards-track (chrome, firefox, safari)
+- EventInit:
+- EventListenerOptions:
+- EventTarget: standards-track (chrome, firefox, safari)
+- GetRootNodeOptions:
+- HTMLCollection: standards-track (chrome, firefox, safari)
+- MutationObserver: standards-track (chrome, firefox, safari)
+- MutationObserverInit:
+- MutationRecord: standards-track (chrome, firefox, safari)
+- NamedNodeMap: standards-track (chrome, firefox, safari)
+- Node: standards-track (chrome, firefox, safari)
+- NodeIterator: standards-track (chrome, firefox, safari)
+- NodeList: standards-track (chrome, firefox, safari)
+- ProcessingInstruction: standards-track (chrome, firefox, safari)
+- Range: standards-track (chrome, firefox, safari)
+- ShadowRoot: standards-track (chrome, firefox, safari)
+- ShadowRootInit:
+- StaticRange: standards-track (chrome, firefox, safari)
+- StaticRangeInit:
+- Text: standards-track (chrome, firefox, safari)
+- TreeWalker: standards-track (chrome, firefox, safari)
+- XMLDocument: standards-track (chrome, firefox, safari)
+- XPathEvaluator: standards-track (chrome, firefox, safari)
+- XPathExpression: standards-track (chrome, firefox, safari)
+- XPathResult: standards-track (chrome, firefox, safari)
+- XSLTProcessor: standards-track (chrome, firefox, safari)
+
+## encoding
+
+- TextDecodeOptions:
+- TextDecoder: standards-track (chrome, firefox, safari)
+- TextDecoderOptions:
+- TextDecoderStream: standards-track (chrome, firefox, safari)
+- TextEncoder: standards-track (chrome, firefox, safari)
+- TextEncoderEncodeIntoResult:
+- TextEncoderStream: standards-track (chrome, firefox, safari)
+
+## encrypted-media
+
+- MediaEncryptedEvent: standards-track (chrome, firefox, safari)
+- MediaEncryptedEventInit:
+- MediaKeyMessageEvent: standards-track (chrome, firefox, safari)
+- MediaKeyMessageEventInit:
+- MediaKeySession: standards-track (chrome, firefox, safari)
+- MediaKeyStatusMap: standards-track (chrome, firefox, safari)
+- MediaKeySystemAccess: standards-track (chrome, firefox, safari)
+- MediaKeySystemConfiguration:
+- MediaKeySystemMediaCapability:
+- MediaKeys: standards-track (chrome, firefox, safari)
+- MediaKeysPolicy:
+
+## entries-api
+
+- FileSystem: standards-track (chrome, firefox, safari)
+- FileSystemDirectoryEntry: standards-track (chrome, firefox, safari)
+- FileSystemDirectoryReader: standards-track (chrome, firefox, safari)
+- FileSystemEntry: standards-track (chrome, firefox, safari)
+- FileSystemFileEntry: standards-track (chrome, firefox, safari)
+- FileSystemFlags:
+
+## fetch
+
+- Headers: standards-track (chrome, firefox, safari)
+- Request: standards-track (chrome, firefox, safari)
+- RequestInit:
+- Response: standards-track (chrome, firefox, safari)
+- ResponseInit:
+
+## filter-effects
+
+- SVGComponentTransferFunctionElement: standards-track (chrome, firefox, safari)
+- SVGFEBlendElement: standards-track (chrome, firefox, safari)
+- SVGFEColorMatrixElement: standards-track (chrome, firefox, safari)
+- SVGFEComponentTransferElement: standards-track (chrome, firefox, safari)
+- SVGFECompositeElement: standards-track (chrome, firefox, safari)
+- SVGFEConvolveMatrixElement: standards-track (chrome, firefox, safari)
+- SVGFEDiffuseLightingElement: standards-track (chrome, firefox, safari)
+- SVGFEDisplacementMapElement: standards-track (chrome, firefox, safari)
+- SVGFEDistantLightElement: standards-track (chrome, firefox, safari)
+- SVGFEDropShadowElement: standards-track (chrome, firefox, safari)
+- SVGFEFloodElement: standards-track (chrome, firefox, safari)
+- SVGFEFuncAElement: standards-track (chrome, firefox, safari)
+- SVGFEFuncBElement: standards-track (chrome, firefox, safari)
+- SVGFEFuncGElement: standards-track (chrome, firefox, safari)
+- SVGFEFuncRElement: standards-track (chrome, firefox, safari)
+- SVGFEGaussianBlurElement: standards-track (chrome, firefox, safari)
+- SVGFEImageElement: standards-track (chrome, firefox, safari)
+- SVGFEMergeElement: standards-track (chrome, firefox, safari)
+- SVGFEMergeNodeElement: standards-track (chrome, firefox, safari)
+- SVGFEMorphologyElement: standards-track (chrome, firefox, safari)
+- SVGFEOffsetElement: standards-track (chrome, firefox, safari)
+- SVGFEPointLightElement: standards-track (chrome, firefox, safari)
+- SVGFESpecularLightingElement: standards-track (chrome, firefox, safari)
+- SVGFESpotLightElement: standards-track (chrome, firefox, safari)
+- SVGFETileElement: standards-track (chrome, firefox, safari)
+- SVGFETurbulenceElement: standards-track (chrome, firefox, safari)
+- SVGFilterElement: standards-track (chrome, firefox, safari)
+
+## fs
+
+- FileSystemCreateWritableOptions:
+- FileSystemDirectoryHandle: standards-track (chrome, firefox, safari)
+- FileSystemFileHandle: standards-track (chrome, firefox, safari)
+- FileSystemGetDirectoryOptions:
+- FileSystemGetFileOptions:
+- FileSystemHandle: standards-track (chrome, firefox, safari)
+- FileSystemReadWriteOptions:
+- FileSystemRemoveOptions:
+- FileSystemSyncAccessHandle: standards-track (chrome, firefox, safari)
+- FileSystemWritableFileStream: standards-track (chrome, firefox)
+- WriteParams:
+
+## gamepad
+
+- Gamepad: standards-track (chrome, firefox, safari)
+- GamepadButton: standards-track (chrome, firefox, safari)
+- GamepadEffectParameters:
+- GamepadEvent: standards-track (chrome, firefox, safari)
+- GamepadEventInit:
+- GamepadHapticActuator: standards-track (chrome, firefox, safari)
+
+## geolocation
+
+- Geolocation: standards-track (chrome, firefox, safari)
+- GeolocationCoordinates: standards-track (chrome, firefox, safari)
+- GeolocationPosition: standards-track (chrome, firefox, safari)
+- GeolocationPositionError: standards-track (chrome, firefox, safari)
+- PositionOptions:
+
+## geometry
+
+- DOMMatrix: standards-track (chrome, firefox, safari)
+- DOMMatrix2DInit:
+- DOMMatrixInit:
+- DOMMatrixReadOnly: standards-track (chrome, firefox, safari)
+- DOMPoint: standards-track (chrome, firefox, safari)
+- DOMPointInit:
+- DOMPointReadOnly: standards-track (chrome, firefox, safari)
+- DOMQuad: standards-track (chrome, firefox, safari)
+- DOMQuadInit:
+- DOMRect: standards-track (chrome, firefox, safari)
+- DOMRectInit:
+- DOMRectList: standards-track (chrome, firefox, safari)
+- DOMRectReadOnly: standards-track (chrome, firefox, safari)
+
+## hr-time
+
+- Performance: standards-track (chrome, firefox, safari)
+
+## html
+
+- AssignedNodesOptions:
+- AudioTrack: standards-track (chrome, firefox)
+- AudioTrackList: standards-track (chrome, firefox, safari)
+- BarProp: standards-track (chrome, firefox, safari)
+- BeforeUnloadEvent: standards-track (chrome, firefox, safari)
+- BroadcastChannel: standards-track (chrome, firefox, safari)
+- CanvasGradient: standards-track (chrome, firefox, safari)
+- CanvasPattern: standards-track (chrome, firefox, safari)
+- CanvasRenderingContext2D: standards-track (chrome, firefox, safari)
+- CanvasRenderingContext2DSettings:
+- CloseWatcher: standards-track, experimental (chrome)
+- CloseWatcherOptions:
+- CustomElementRegistry: standards-track (chrome, firefox, safari)
+- CustomStateSet: standards-track, experimental (chrome, firefox, safari)
+- DOMParser: standards-track (chrome, firefox, safari)
+- DOMStringList: standards-track (chrome, firefox, safari)
+- DOMStringMap: standards-track (chrome, firefox, safari)
+- DataTransfer: standards-track (chrome, firefox, safari)
+- DataTransferItem: standards-track (chrome, firefox, safari)
+- DataTransferItemList: standards-track (chrome, firefox, safari)
+- DedicatedWorkerGlobalScope: standards-track (chrome, firefox, safari)
+- DragEvent: standards-track (chrome, firefox, safari)
+- DragEventInit:
+- ElementDefinitionOptions:
+- ElementInternals: standards-track (chrome, firefox, safari)
+- ErrorEvent: standards-track (chrome, firefox, safari)
+- ErrorEventInit:
+- EventSource: standards-track (chrome, firefox, safari)
+- EventSourceInit:
+- External: standards-track, deprecated (chrome, firefox)
+- FocusOptions:
+- FormDataEvent: standards-track (chrome, firefox, safari)
+- FormDataEventInit:
+- HTMLAllCollection: standards-track (chrome, firefox, safari)
+- HTMLAnchorElement: standards-track (chrome, firefox, safari)
+- HTMLAreaElement: standards-track (chrome, firefox, safari)
+- HTMLAudioElement: standards-track (chrome, firefox, safari)
+- HTMLBRElement: standards-track (chrome, firefox, safari)
+- HTMLBaseElement: standards-track (chrome, firefox, safari)
+- HTMLBodyElement: standards-track (chrome, firefox, safari)
+- HTMLButtonElement: standards-track (chrome, firefox, safari)
+- HTMLCanvasElement: standards-track (chrome, firefox, safari)
+- HTMLDListElement: standards-track (chrome, firefox, safari)
+- HTMLDataElement: standards-track (chrome, firefox, safari)
+- HTMLDataListElement: standards-track (chrome, firefox, safari)
+- HTMLDetailsElement: standards-track (chrome, firefox, safari)
+- HTMLDialogElement: standards-track (chrome, firefox, safari)
+- HTMLDirectoryElement: standards-track, deprecated (chrome, firefox, safari)
+- HTMLDivElement: standards-track (chrome, firefox, safari)
+- HTMLElement: standards-track (chrome, firefox, safari)
+- HTMLEmbedElement: standards-track (chrome, firefox, safari)
+- HTMLFieldSetElement: standards-track (chrome, firefox, safari)
+- HTMLFontElement: standards-track, deprecated (chrome, firefox, safari)
+- HTMLFormControlsCollection: standards-track (chrome, firefox, safari)
+- HTMLFormElement: standards-track (chrome, firefox, safari)
+- HTMLFrameElement: standards-track, deprecated (chrome, firefox, safari)
+- HTMLFrameSetElement: standards-track, deprecated (chrome, firefox, safari)
+- HTMLHRElement: standards-track (chrome, firefox, safari)
+- HTMLHeadElement: standards-track (chrome, firefox, safari)
+- HTMLHeadingElement: standards-track (chrome, firefox, safari)
+- HTMLHtmlElement: standards-track (chrome, firefox, safari)
+- HTMLIFrameElement: standards-track (chrome, firefox, safari)
+- HTMLImageElement: standards-track (chrome, firefox, safari)
+- HTMLInputElement: standards-track (chrome, firefox, safari)
+- HTMLLIElement: standards-track (chrome, firefox, safari)
+- HTMLLabelElement: standards-track (chrome, firefox, safari)
+- HTMLLegendElement: standards-track (chrome, firefox, safari)
+- HTMLLinkElement: standards-track (chrome, firefox, safari)
+- HTMLMapElement: standards-track (chrome, firefox, safari)
+- HTMLMarqueeElement: standards-track, deprecated (chrome, firefox, safari)
+- HTMLMediaElement: standards-track (chrome, firefox, safari)
+- HTMLMenuElement: standards-track (chrome, firefox, safari)
+- HTMLMetaElement: standards-track (chrome, firefox, safari)
+- HTMLMeterElement: standards-track (chrome, firefox, safari)
+- HTMLModElement: standards-track (chrome, firefox, safari)
+- HTMLOListElement: standards-track (chrome, firefox, safari)
+- HTMLObjectElement: standards-track (chrome, firefox, safari)
+- HTMLOptGroupElement: standards-track (chrome, firefox, safari)
+- HTMLOptionElement: standards-track (chrome, firefox, safari)
+- HTMLOptionsCollection: standards-track (chrome, firefox, safari)
+- HTMLOutputElement: standards-track (chrome, firefox, safari)
+- HTMLParagraphElement: standards-track (chrome, firefox, safari)
+- HTMLParamElement: standards-track, deprecated (chrome, firefox, safari)
+- HTMLPictureElement: standards-track (chrome, firefox, safari)
+- HTMLPreElement: standards-track (chrome, firefox, safari)
+- HTMLProgressElement: standards-track (chrome, firefox, safari)
+- HTMLQuoteElement: standards-track (chrome, firefox, safari)
+- HTMLScriptElement: standards-track (chrome, firefox, safari)
+- HTMLSelectElement: standards-track (chrome, firefox, safari)
+- HTMLSlotElement: standards-track (chrome, firefox, safari)
+- HTMLSourceElement: standards-track (chrome, firefox, safari)
+- HTMLSpanElement: standards-track (chrome, firefox, safari)
+- HTMLStyleElement: standards-track (chrome, firefox, safari)
+- HTMLTableCaptionElement: standards-track (chrome, firefox, safari)
+- HTMLTableCellElement: standards-track (chrome, firefox, safari)
+- HTMLTableColElement: standards-track (chrome, firefox, safari)
+- HTMLTableElement: standards-track (chrome, firefox, safari)
+- HTMLTableRowElement: standards-track (chrome, firefox, safari)
+- HTMLTableSectionElement: standards-track (chrome, firefox, safari)
+- HTMLTemplateElement: standards-track (chrome, firefox, safari)
+- HTMLTextAreaElement: standards-track (chrome, firefox, safari)
+- HTMLTimeElement: standards-track (chrome, firefox, safari)
+- HTMLTitleElement: standards-track (chrome, firefox, safari)
+- HTMLTrackElement: standards-track (chrome, firefox, safari)
+- HTMLUListElement: standards-track (chrome, firefox, safari)
+- HTMLUnknownElement: standards-track (chrome, firefox, safari)
+- HTMLVideoElement: standards-track (chrome, firefox, safari)
+- HashChangeEvent: standards-track (chrome, firefox, safari)
+- HashChangeEventInit:
+- History: standards-track (chrome, firefox, safari)
+- ImageBitmap: standards-track (chrome, firefox, safari)
+- ImageBitmapOptions:
+- ImageBitmapRenderingContext: standards-track (chrome, firefox, safari)
+- ImageBitmapRenderingContextSettings:
+- ImageData: standards-track (chrome, firefox, safari)
+- ImageDataSettings:
+- ImageEncodeOptions:
+- Location: standards-track (chrome, firefox, safari)
+- MediaError: standards-track (chrome, firefox, safari)
+- MessageChannel: standards-track (chrome, firefox, safari)
+- MessageEvent: standards-track (chrome, firefox, safari)
+- MessageEventInit:
+- MessagePort: standards-track (chrome, firefox, safari)
+- MimeType: standards-track, deprecated (chrome, firefox, safari)
+- MimeTypeArray: standards-track, deprecated (chrome, firefox, safari)
+- NavigateEvent: standards-track, experimental (chrome)
+- NavigateEventInit:
+- Navigation: standards-track, experimental (chrome)
+- NavigationActivation:
+- NavigationCurrentEntryChangeEvent: standards-track, experimental (chrome)
+- NavigationCurrentEntryChangeEventInit:
+- NavigationDestination: standards-track, experimental (chrome)
+- NavigationHistoryEntry: standards-track, experimental (chrome)
+- NavigationInterceptOptions:
+- NavigationNavigateOptions:
+- NavigationOptions:
+- NavigationReloadOptions:
+- NavigationResult:
+- NavigationTransition: standards-track, experimental (chrome)
+- NavigationUpdateCurrentEntryOptions:
+- Navigator: standards-track (chrome, firefox, safari)
+- OffscreenCanvas: standards-track (chrome, firefox, safari)
+- OffscreenCanvasRenderingContext2D: standards-track (chrome, firefox, safari)
+- PageRevealEvent:
+- PageRevealEventInit:
+- PageTransitionEvent: standards-track (chrome, firefox, safari)
+- PageTransitionEventInit:
+- Path2D: standards-track (chrome, firefox, safari)
+- Plugin: standards-track, deprecated (chrome, firefox, safari)
+- PluginArray: standards-track, deprecated (chrome, firefox, safari)
+- PopStateEvent: standards-track (chrome, firefox, safari)
+- PopStateEventInit:
+- PromiseRejectionEvent: standards-track (chrome, firefox, safari)
+- PromiseRejectionEventInit:
+- RadioNodeList: standards-track (chrome, firefox, safari)
+- SharedWorker: standards-track (chrome, firefox, safari)
+- SharedWorkerGlobalScope: standards-track (chrome, firefox, safari)
+- Storage: standards-track (chrome, firefox, safari)
+- StorageEvent: standards-track (chrome, firefox, safari)
+- StorageEventInit:
+- StructuredSerializeOptions:
+- SubmitEvent: standards-track (chrome, firefox, safari)
+- SubmitEventInit:
+- TextMetrics: standards-track (chrome, firefox, safari)
+- TextTrack: standards-track (chrome, firefox, safari)
+- TextTrackCue: standards-track (chrome, firefox, safari)
+- TextTrackCueList: standards-track (chrome, firefox, safari)
+- TextTrackList: standards-track (chrome, firefox, safari)
+- TimeRanges: standards-track (chrome, firefox, safari)
+- ToggleEvent: standards-track (chrome, firefox, safari)
+- ToggleEventInit:
+- TrackEvent: standards-track (chrome, firefox, safari)
+- TrackEventInit:
+- UserActivation: standards-track (chrome, firefox, safari)
+- ValidityState: standards-track (chrome, firefox, safari)
+- ValidityStateFlags:
+- VideoTrack: standards-track (chrome, firefox, safari)
+- VideoTrackList: standards-track (chrome, firefox, safari)
+- VisibilityStateEntry: standards-track, experimental (chrome)
+- Window: standards-track (chrome, firefox, safari)
+- WindowPostMessageOptions:
+- Worker: standards-track (chrome, firefox, safari)
+- WorkerGlobalScope: standards-track (chrome, firefox, safari)
+- WorkerLocation: standards-track (chrome, firefox, safari)
+- WorkerNavigator: standards-track (chrome, firefox, safari)
+- WorkerOptions:
+- Worklet: standards-track (chrome, firefox, safari)
+- WorkletGlobalScope: standards-track (chrome, firefox, safari)
+- WorkletOptions:
+
+## intersection-observer
+
+- IntersectionObserver: standards-track (chrome, firefox, safari)
+- IntersectionObserverEntry: standards-track (chrome, firefox, safari)
+- IntersectionObserverEntryInit:
+- IntersectionObserverInit:
+
+## mathml-core
+
+- MathMLElement: standards-track (chrome, firefox, safari)
+
+## media-capabilities
+
+- AudioConfiguration:
+- KeySystemTrackConfiguration:
+- MediaCapabilities: standards-track (chrome, firefox, safari)
+- MediaCapabilitiesDecodingInfo:
+- MediaCapabilitiesEncodingInfo:
+- MediaCapabilitiesInfo:
+- MediaCapabilitiesKeySystemConfiguration:
+- MediaConfiguration:
+- MediaDecodingConfiguration:
+- MediaEncodingConfiguration:
+- VideoConfiguration:
+
+## media-playback-quality
+
+- VideoPlaybackQuality: standards-track (chrome, firefox, safari)
+
+## media-source
+
+- BufferedChangeEvent: standards-track, experimental (safari)
+- BufferedChangeEventInit:
+- ManagedMediaSource: standards-track, experimental (safari)
+- ManagedSourceBuffer: standards-track, experimental (safari)
+- MediaSource: standards-track (chrome, firefox, safari)
+- MediaSourceHandle: standards-track, experimental (chrome)
+- SourceBuffer: standards-track (chrome, firefox, safari)
+- SourceBufferList: standards-track (chrome, firefox, safari)
+
+## mediacapture-streams
+
+- CameraDevicePermissionDescriptor:
+- ConstrainBooleanParameters:
+- ConstrainDOMStringParameters:
+- ConstrainDoubleRange:
+- ConstrainULongRange:
+- DoubleRange:
+- InputDeviceInfo: standards-track (chrome, firefox, safari)
+- MediaDeviceInfo: standards-track (chrome, firefox, safari)
+- MediaDevices: standards-track (chrome, firefox, safari)
+- MediaStream: standards-track (chrome, firefox, safari)
+- MediaStreamConstraints:
+- MediaStreamTrack: standards-track (chrome, firefox, safari)
+- MediaStreamTrackEvent: standards-track (chrome, firefox, safari)
+- MediaStreamTrackEventInit:
+- MediaTrackCapabilities:
+- MediaTrackConstraintSet:
+- MediaTrackConstraints: standards-track (chrome, firefox, safari)
+- MediaTrackSettings: standards-track (chrome, firefox, safari)
+- MediaTrackSupportedConstraints: standards-track (chrome, firefox, safari)
+- OverconstrainedError: standards-track (chrome, safari)
+- ULongRange:
+
+## mediasession
+
+- MediaImage:
+- MediaMetadata: standards-track (chrome, firefox, safari)
+- MediaMetadataInit:
+- MediaPositionState:
+- MediaSession: standards-track (chrome, firefox, safari)
+- MediaSessionActionDetails:
+
+## mediastream-recording
+
+- BlobEvent: standards-track (chrome, firefox, safari)
+- BlobEventInit:
+- MediaRecorder: standards-track (chrome, firefox, safari)
+- MediaRecorderOptions:
+
+## navigation-timing
+
+- PerformanceNavigation: standards-track, deprecated (chrome, firefox, safari)
+- PerformanceNavigationTiming: standards-track (chrome, firefox, safari)
+- PerformanceTiming: standards-track, deprecated (chrome, firefox, safari)
+
+## notifications
+
+- GetNotificationOptions:
+- Notification: standards-track (chrome, firefox, safari)
+- NotificationAction:
+- NotificationEvent: standards-track (chrome, firefox, safari)
+- NotificationEventInit:
+- NotificationOptions:
+
+## orientation-event
+
+- DeviceMotionEvent: standards-track (chrome, firefox, safari)
+- DeviceMotionEventAcceleration: standards-track (chrome, firefox)
+- DeviceMotionEventAccelerationInit:
+- DeviceMotionEventInit:
+- DeviceMotionEventRotationRate: standards-track (chrome, firefox)
+- DeviceMotionEventRotationRateInit:
+- DeviceOrientationEvent: standards-track (chrome, firefox, safari)
+- DeviceOrientationEventInit:
+
+## paint-timing
+
+- PerformancePaintTiming: standards-track (chrome, firefox, safari)
+
+## payment-request
+
+- PaymentCompleteDetails:
+- PaymentCurrencyAmount:
+- PaymentDetailsBase:
+- PaymentDetailsInit:
+- PaymentDetailsModifier:
+- PaymentDetailsUpdate:
+- PaymentItem:
+- PaymentMethodChangeEvent: standards-track (chrome, firefox, safari)
+- PaymentMethodChangeEventInit:
+- PaymentMethodData:
+- PaymentRequest: standards-track (chrome, firefox, safari)
+- PaymentRequestUpdateEvent: standards-track (chrome, firefox, safari)
+- PaymentRequestUpdateEventInit:
+- PaymentResponse: standards-track (chrome, firefox, safari)
+- PaymentValidationErrors:
+
+## performance-timeline
+
+- PerformanceEntry: standards-track (chrome, firefox, safari)
+- PerformanceObserver: standards-track (chrome, firefox, safari)
+- PerformanceObserverCallbackOptions:
+- PerformanceObserverEntryList: standards-track (chrome, firefox, safari)
+- PerformanceObserverInit:
+
+## permissions
+
+- PermissionDescriptor:
+- PermissionSetParameters:
+- PermissionStatus: standards-track (chrome, firefox, safari)
+- Permissions: standards-track (chrome, firefox, safari)
+
+## pointerevents
+
+- PointerEvent: standards-track (chrome, firefox, safari)
+- PointerEventInit:
+
+## push-api
+
+- PushEvent: standards-track (chrome, firefox, safari)
+- PushEventInit:
+- PushManager: standards-track (chrome, firefox, safari)
+- PushMessageData: standards-track (chrome, firefox, safari)
+- PushPermissionDescriptor:
+- PushSubscription: standards-track (chrome, firefox, safari)
+- PushSubscriptionChangeEvent: standards-track (safari)
+- PushSubscriptionChangeEventInit:
+- PushSubscriptionJSON:
+- PushSubscriptionOptions: standards-track (chrome, firefox, safari)
+- PushSubscriptionOptionsInit:
+
+## referrer-policy
+
+## reporting
+
+- GenerateTestReportParameters:
+- Report: standards-track (chrome, safari)
+- ReportBody: standards-track (chrome, safari)
+- ReportingObserver: standards-track (chrome, safari)
+- ReportingObserverOptions:
+
+## resize-observer
+
+- ResizeObserver: standards-track (chrome, firefox, safari)
+- ResizeObserverEntry: standards-track (chrome, firefox, safari)
+- ResizeObserverOptions:
+- ResizeObserverSize: standards-track (chrome, firefox, safari)
+
+## resource-timing
+
+- PerformanceResourceTiming: standards-track (chrome, firefox, safari)
+
+## screen-orientation
+
+- ScreenOrientation: standards-track (chrome, firefox, safari)
+
+## screen-wake-lock
+
+- WakeLock: standards-track (chrome, firefox, safari)
+- WakeLockSentinel: standards-track (chrome, firefox, safari)
+
+## selection-api
+
+- Selection: standards-track (chrome, firefox, safari)
+
+## server-timing
+
+- PerformanceServerTiming: standards-track (chrome, firefox, safari)
+
+## service-workers
+
+- Cache: standards-track (chrome, firefox, safari)
+- CacheQueryOptions:
+- CacheStorage: standards-track (chrome, firefox, safari)
+- Client: standards-track (chrome, firefox, safari)
+- ClientQueryOptions:
+- Clients: standards-track (chrome, firefox, safari)
+- ExtendableEvent: standards-track (chrome, firefox, safari)
+- ExtendableEventInit:
+- ExtendableMessageEvent: standards-track (chrome, firefox, safari)
+- ExtendableMessageEventInit:
+- FetchEvent: standards-track (chrome, firefox, safari)
+- FetchEventInit:
+- MultiCacheQueryOptions:
+- NavigationPreloadManager: standards-track (chrome, firefox, safari)
+- NavigationPreloadState:
+- RegistrationOptions:
+- ServiceWorker: standards-track (chrome, firefox, safari)
+- ServiceWorkerContainer: standards-track (chrome, firefox, safari)
+- ServiceWorkerGlobalScope: standards-track (chrome, firefox, safari)
+- ServiceWorkerRegistration: standards-track (chrome, firefox, safari)
+- WindowClient: standards-track (chrome, firefox, safari)
+
+## speech-api
+
+- SpeechGrammar: standards-track, experimental (chrome, firefox)
+- SpeechGrammarList: standards-track, experimental (chrome)
+- SpeechRecognition: standards-track (chrome, safari)
+- SpeechRecognitionAlternative: standards-track (chrome, safari)
+- SpeechRecognitionErrorEvent: standards-track (chrome, safari)
+- SpeechRecognitionErrorEventInit:
+- SpeechRecognitionEvent: standards-track (chrome, safari)
+- SpeechRecognitionEventInit:
+- SpeechRecognitionResult: standards-track (chrome, safari)
+- SpeechRecognitionResultList: standards-track (chrome, safari)
+- SpeechSynthesis: standards-track (chrome, firefox, safari)
+- SpeechSynthesisErrorEvent: standards-track (chrome, firefox, safari)
+- SpeechSynthesisErrorEventInit:
+- SpeechSynthesisEvent: standards-track (chrome, firefox, safari)
+- SpeechSynthesisEventInit:
+- SpeechSynthesisUtterance: standards-track (chrome, firefox, safari)
+- SpeechSynthesisVoice: standards-track (chrome, firefox, safari)
+
+## storage
+
+- StorageEstimate:
+- StorageManager: standards-track (chrome, firefox, safari)
+
+## streams
+
+- ByteLengthQueuingStrategy: standards-track (chrome, firefox, safari)
+- CountQueuingStrategy: standards-track (chrome, firefox, safari)
+- QueuingStrategy:
+- QueuingStrategyInit:
+- ReadableByteStreamController: standards-track (chrome, firefox)
+- ReadableStream: standards-track (chrome, firefox, safari)
+- ReadableStreamBYOBReader: standards-track (chrome, firefox)
+- ReadableStreamBYOBReaderReadOptions:
+- ReadableStreamBYOBRequest: standards-track (chrome, firefox)
+- ReadableStreamDefaultController: standards-track (chrome, firefox, safari)
+- ReadableStreamDefaultReader: standards-track (chrome, firefox, safari)
+- ReadableStreamGetReaderOptions:
+- ReadableStreamIteratorOptions:
+- ReadableStreamReadResult:
+- ReadableWritablePair:
+- StreamPipeOptions:
+- TransformStream: standards-track (chrome, firefox, safari)
+- TransformStreamDefaultController: standards-track (chrome, firefox, safari)
+- Transformer:
+- UnderlyingSink:
+- UnderlyingSource:
+- WritableStream: standards-track (chrome, firefox, safari)
+- WritableStreamDefaultController: standards-track (chrome, firefox, safari)
+- WritableStreamDefaultWriter: standards-track (chrome, firefox, safari)
+
+## svg-animations
+
+- SVGAnimateElement: standards-track (chrome, firefox, safari)
+- SVGAnimateMotionElement: standards-track (chrome, firefox, safari)
+- SVGAnimateTransformElement: standards-track (chrome, firefox, safari)
+- SVGAnimationElement: standards-track (chrome, firefox, safari)
+- SVGDiscardElement:
+- SVGMPathElement: standards-track (chrome, firefox, safari)
+- SVGSetElement: standards-track (chrome, firefox, safari)
+- TimeEvent: standards-track (firefox)
+
+## touch-events
+
+- Touch: standards-track (chrome, firefox)
+- TouchEvent: standards-track (chrome, firefox)
+- TouchEventInit:
+- TouchInit:
+- TouchList: standards-track (chrome, firefox)
+
+## uievents
+
+- CompositionEvent: standards-track (chrome, firefox, safari)
+- CompositionEventInit:
+- EventModifierInit:
+- FocusEvent: standards-track (chrome, firefox, safari)
+- FocusEventInit:
+- InputEvent: standards-track (chrome, firefox, safari)
+- InputEventInit:
+- KeyboardEvent: standards-track (chrome, firefox, safari)
+- KeyboardEventInit:
+- MouseEvent: standards-track (chrome, firefox, safari)
+- MouseEventInit:
+- MutationEvent: standards-track, deprecated (chrome, firefox, safari)
+- UIEvent: standards-track (chrome, firefox, safari)
+- UIEventInit:
+- WheelEvent: standards-track (chrome, firefox, safari)
+- WheelEventInit:
+
+## url
+
+- URL: standards-track (chrome, firefox, safari)
+- URLSearchParams: standards-track (chrome, firefox, safari)
+
+## user-timing
+
+- PerformanceMark: standards-track (chrome, firefox, safari)
+- PerformanceMarkOptions:
+- PerformanceMeasure: standards-track (chrome, firefox, safari)
+- PerformanceMeasureOptions:
+
+## vibration
+
+## web-animations
+
+- Animation: standards-track (chrome, firefox, safari)
+- AnimationEffect: standards-track (chrome, firefox, safari)
+- AnimationTimeline: standards-track (chrome, firefox, safari)
+- BaseComputedKeyframe:
+- BaseKeyframe:
+- BasePropertyIndexedKeyframe:
+- ComputedEffectTiming:
+- DocumentTimeline: standards-track (chrome, firefox, safari)
+- DocumentTimelineOptions:
+- EffectTiming:
+- GetAnimationsOptions:
+- KeyframeAnimationOptions:
+- KeyframeEffect: standards-track (chrome, firefox, safari)
+- KeyframeEffectOptions:
+- OptionalEffectTiming:
+
+## web-animations-2
+
+- AnimationNodeList:
+- AnimationPlaybackEvent: standards-track (chrome, firefox, safari)
+- AnimationPlaybackEventInit:
+- GroupEffect:
+- SequenceEffect:
+- TimelineRangeOffset:
+
+## web-locks
+
+- Lock: standards-track (chrome, firefox, safari)
+- LockInfo:
+- LockManager: standards-track (chrome, firefox, safari)
+- LockManagerSnapshot:
+- LockOptions:
+
+## webaudio
+
+- AnalyserNode: standards-track (chrome, firefox, safari)
+- AnalyserOptions:
+- AudioBuffer: standards-track (chrome, firefox, safari)
+- AudioBufferOptions:
+- AudioBufferSourceNode: standards-track (chrome, firefox, safari)
+- AudioBufferSourceOptions:
+- AudioContext: standards-track (chrome, firefox, safari)
+- AudioContextOptions:
+- AudioDestinationNode: standards-track (chrome, firefox, safari)
+- AudioListener: standards-track (chrome, firefox, safari)
+- AudioNode: standards-track (chrome, firefox, safari)
+- AudioNodeOptions:
+- AudioParam: standards-track (chrome, firefox, safari)
+- AudioParamDescriptor:
+- AudioParamMap: standards-track (chrome, firefox, safari)
+- AudioProcessingEvent: standards-track, deprecated (chrome, firefox, safari)
+- AudioProcessingEventInit:
+- AudioRenderCapacity:
+- AudioRenderCapacityEvent:
+- AudioRenderCapacityEventInit:
+- AudioRenderCapacityOptions:
+- AudioScheduledSourceNode: standards-track (chrome, firefox, safari)
+- AudioSinkInfo: standards-track, experimental (chrome)
+- AudioSinkOptions:
+- AudioTimestamp:
+- AudioWorklet: standards-track (chrome, firefox, safari)
+- AudioWorkletGlobalScope: standards-track (chrome, firefox, safari)
+- AudioWorkletNode: standards-track (chrome, firefox, safari)
+- AudioWorkletNodeOptions:
+- AudioWorkletProcessor: standards-track (chrome, firefox, safari)
+- BaseAudioContext: standards-track (chrome, firefox, safari)
+- BiquadFilterNode: standards-track (chrome, firefox, safari)
+- BiquadFilterOptions:
+- ChannelMergerNode: standards-track (chrome, firefox, safari)
+- ChannelMergerOptions:
+- ChannelSplitterNode: standards-track (chrome, firefox, safari)
+- ChannelSplitterOptions:
+- ConstantSourceNode: standards-track (chrome, firefox, safari)
+- ConstantSourceOptions:
+- ConvolverNode: standards-track (chrome, firefox, safari)
+- ConvolverOptions:
+- DelayNode: standards-track (chrome, firefox, safari)
+- DelayOptions:
+- DynamicsCompressorNode: standards-track (chrome, firefox, safari)
+- DynamicsCompressorOptions:
+- GainNode: standards-track (chrome, firefox, safari)
+- GainOptions:
+- IIRFilterNode: standards-track (chrome, firefox, safari)
+- IIRFilterOptions:
+- MediaElementAudioSourceNode: standards-track (chrome, firefox, safari)
+- MediaElementAudioSourceOptions:
+- MediaStreamAudioDestinationNode: standards-track (chrome, firefox, safari)
+- MediaStreamAudioSourceNode: standards-track (chrome, firefox, safari)
+- MediaStreamAudioSourceOptions:
+- MediaStreamTrackAudioSourceNode: standards-track (firefox)
+- MediaStreamTrackAudioSourceOptions:
+- OfflineAudioCompletionEvent: standards-track (chrome, firefox, safari)
+- OfflineAudioCompletionEventInit:
+- OfflineAudioContext: standards-track (chrome, firefox, safari)
+- OfflineAudioContextOptions:
+- OscillatorNode: standards-track (chrome, firefox, safari)
+- OscillatorOptions:
+- PannerNode: standards-track (chrome, firefox, safari)
+- PannerOptions:
+- PeriodicWave: standards-track (chrome, firefox, safari)
+- PeriodicWaveConstraints:
+- PeriodicWaveOptions:
+- ScriptProcessorNode: standards-track, deprecated (chrome, firefox, safari)
+- StereoPannerNode: standards-track (chrome, firefox, safari)
+- StereoPannerOptions:
+- WaveShaperNode: standards-track (chrome, firefox, safari)
+- WaveShaperOptions:
+
+## webauthn
+
+- AuthenticationExtensionsClientInputs:
+- AuthenticationExtensionsClientInputsJSON:
+- AuthenticationExtensionsClientOutputs:
+- AuthenticationExtensionsClientOutputsJSON:
+- AuthenticationExtensionsLargeBlobInputs:
+- AuthenticationExtensionsLargeBlobOutputs:
+- AuthenticationExtensionsPRFInputs:
+- AuthenticationExtensionsPRFOutputs:
+- AuthenticationExtensionsPRFValues:
+- AuthenticationExtensionsSupplementalPubKeysInputs:
+- AuthenticationExtensionsSupplementalPubKeysOutputs:
+- AuthenticationResponseJSON:
+- AuthenticatorAssertionResponse: standards-track (chrome, firefox, safari)
+- AuthenticatorAssertionResponseJSON:
+- AuthenticatorAttestationResponse: standards-track (chrome, firefox, safari)
+- AuthenticatorAttestationResponseJSON:
+- AuthenticatorResponse: standards-track (chrome, firefox, safari)
+- AuthenticatorSelectionCriteria:
+- CollectedClientData:
+- CredentialPropertiesOutput:
+- PublicKeyCredential: standards-track (chrome, firefox, safari)
+- PublicKeyCredentialCreationOptions:
+- PublicKeyCredentialCreationOptionsJSON:
+- PublicKeyCredentialDescriptor:
+- PublicKeyCredentialDescriptorJSON:
+- PublicKeyCredentialEntity:
+- PublicKeyCredentialParameters:
+- PublicKeyCredentialRequestOptions:
+- PublicKeyCredentialRequestOptionsJSON:
+- PublicKeyCredentialRpEntity:
+- PublicKeyCredentialUserEntity:
+- PublicKeyCredentialUserEntityJSON:
+- RegistrationResponseJSON:
+- TokenBinding:
+
+## webgl1
+
+- WebGLActiveInfo: standards-track (chrome, firefox, safari)
+- WebGLBuffer: standards-track (chrome, firefox, safari)
+- WebGLContextAttributes:
+- WebGLContextEvent: standards-track (chrome, firefox, safari)
+- WebGLContextEventInit:
+- WebGLFramebuffer: standards-track (chrome, firefox, safari)
+- WebGLObject:
+- WebGLProgram: standards-track (chrome, firefox, safari)
+- WebGLRenderbuffer: standards-track (chrome, firefox, safari)
+- WebGLRenderingContext: standards-track (chrome, firefox, safari)
+- WebGLShader: standards-track (chrome, firefox, safari)
+- WebGLShaderPrecisionFormat: standards-track (chrome, firefox, safari)
+- WebGLTexture: standards-track (chrome, firefox, safari)
+- WebGLUniformLocation: standards-track (chrome, firefox, safari)
+
+## webgl2
+
+- WebGL2RenderingContext: standards-track (chrome, firefox, safari)
+- WebGLQuery: standards-track (chrome, firefox, safari)
+- WebGLSampler: standards-track (chrome, firefox, safari)
+- WebGLSync: standards-track (chrome, firefox, safari)
+- WebGLTransformFeedback: standards-track (chrome, firefox, safari)
+- WebGLVertexArrayObject: standards-track (chrome, firefox, safari)
+
+## webidl
+
+- DOMException: standards-track (chrome, firefox, safari)
+
+## webrtc
+
+- RTCAnswerOptions:
+- RTCCertificate: standards-track (chrome, firefox, safari)
+- RTCCertificateExpiration:
+- RTCConfiguration:
+- RTCDTMFSender: standards-track (chrome, firefox, safari)
+- RTCDTMFToneChangeEvent: standards-track (chrome, firefox, safari)
+- RTCDTMFToneChangeEventInit:
+- RTCDataChannel: standards-track (chrome, firefox, safari)
+- RTCDataChannelEvent: standards-track (chrome, firefox, safari)
+- RTCDataChannelEventInit:
+- RTCDataChannelInit:
+- RTCDtlsFingerprint:
+- RTCDtlsTransport: standards-track (chrome, firefox, safari)
+- RTCError: standards-track (chrome, safari)
+- RTCErrorEvent: standards-track (chrome, safari)
+- RTCErrorEventInit:
+- RTCErrorInit:
+- RTCIceCandidate: standards-track (chrome, firefox, safari)
+- RTCIceCandidateInit:
+- RTCIceCandidatePair:
+- RTCIceParameters:
+- RTCIceServer:
+- RTCIceTransport: standards-track (chrome, safari)
+- RTCLocalSessionDescriptionInit:
+- RTCOfferAnswerOptions:
+- RTCOfferOptions:
+- RTCPeerConnection: standards-track (chrome, firefox, safari)
+- RTCPeerConnectionIceErrorEvent: standards-track (chrome, safari)
+- RTCPeerConnectionIceErrorEventInit:
+- RTCPeerConnectionIceEvent: standards-track (chrome, firefox, safari)
+- RTCPeerConnectionIceEventInit:
+- RTCRtcpParameters:
+- RTCRtpCapabilities:
+- RTCRtpCodec:
+- RTCRtpCodecCapability:
+- RTCRtpCodecParameters:
+- RTCRtpCodingParameters:
+- RTCRtpContributingSource:
+- RTCRtpEncodingParameters:
+- RTCRtpHeaderExtensionCapability:
+- RTCRtpHeaderExtensionParameters:
+- RTCRtpParameters:
+- RTCRtpReceiveParameters:
+- RTCRtpReceiver: standards-track (chrome, firefox, safari)
+- RTCRtpSendParameters:
+- RTCRtpSender: standards-track (chrome, firefox, safari)
+- RTCRtpSynchronizationSource:
+- RTCRtpTransceiver: standards-track (chrome, firefox, safari)
+- RTCRtpTransceiverInit:
+- RTCSctpTransport: standards-track (chrome, firefox, safari)
+- RTCSessionDescription: standards-track (chrome, firefox, safari)
+- RTCSessionDescriptionInit:
+- RTCSetParameterOptions:
+- RTCStats:
+- RTCStatsReport: standards-track (chrome, firefox, safari)
+- RTCTrackEvent: standards-track (chrome, firefox, safari)
+- RTCTrackEventInit:
+
+## webrtc-encoded-transform
+
+- KeyFrameRequestEvent:
+- RTCEncodedAudioFrame: standards-track (chrome, firefox, safari)
+- RTCEncodedAudioFrameMetadata:
+- RTCEncodedVideoFrame: standards-track (chrome, firefox, safari)
+- RTCEncodedVideoFrameMetadata:
+- RTCRtpScriptTransform: standards-track (firefox, safari)
+- RTCRtpScriptTransformer: standards-track (firefox, safari)
+- RTCTransformEvent: standards-track (firefox, safari)
+- SFrameTransform:
+- SFrameTransformErrorEvent:
+- SFrameTransformErrorEventInit:
+- SFrameTransformOptions:
+
+## webrtc-stats
+
+- RTCAudioPlayoutStats:
+- RTCAudioSourceStats:
+- RTCCertificateStats:
+- RTCCodecStats:
+- RTCDataChannelStats:
+- RTCIceCandidatePairStats:
+- RTCIceCandidateStats:
+- RTCInboundRtpStreamStats:
+- RTCMediaSourceStats:
+- RTCOutboundRtpStreamStats:
+- RTCPeerConnectionStats:
+- RTCReceivedRtpStreamStats:
+- RTCRemoteInboundRtpStreamStats:
+- RTCRemoteOutboundRtpStreamStats:
+- RTCRtpStreamStats:
+- RTCSentRtpStreamStats:
+- RTCTransportStats:
+- RTCVideoSourceStats:
+
+## websockets
+
+- CloseEvent: standards-track (chrome, firefox, safari)
+- CloseEventInit:
+- WebSocket: standards-track (chrome, firefox, safari)
+
+## webvtt
+
+- VTTCue: standards-track (chrome, firefox, safari)
+- VTTRegion: standards-track (firefox, safari)
+
+## xhr
+
+- FormData: standards-track (chrome, firefox, safari)
+- ProgressEvent: standards-track (chrome, firefox, safari)
+- ProgressEventInit:
+- XMLHttpRequest: standards-track (chrome, firefox, safari)
+- XMLHttpRequestEventTarget: standards-track (chrome, firefox, safari)
+- XMLHttpRequestUpload: standards-track (chrome, firefox, safari)

--- a/tool/generator/generate_bindings.dart
+++ b/tool/generator/generate_bindings.dart
@@ -57,5 +57,6 @@ Future<TranslationResult> generateBindings(
     translator.collect(shortname, ast);
   }
   translator.setOrUpdateInterfacelikes();
+  translator.emitInterfaceStatusInformation();
   return translator.translate();
 }


### PR DESCRIPTION
- write bcd info to a markdown file

This emits the BCD api status info to a markdown file. The idea being that:

- this might be useful to know when the status of an API changes and that effects the generation status
- gives us some info about why an API is or is not generated
- could be useful if we decide to start segmenting the API surface into separate packages?

After creating this PR I'm not 100% sure that the bcd info => encoded to markdown is useful, but it may not hurt to have it.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
