### PR TITLE
Use URI instead of library name

### DIFF
--- a/tool/update_bindings.dart
+++ b/tool/update_bindings.dart
@@ -159,7 +159,8 @@ Future<void> _runProc(
   }
 }
 
-// Creates a supertype hierarchy of the JS types defined in `dart:js_interop`.
+// Generates a map of the JS type hierarchy defined in `dart:js_interop` that is
+// used by the translator to handle IDL types.
 Future<void> _generateJsTypeSupertypes() async {
   // Use a file that uses `dart:js_interop` for analysis.
   final contextCollection = AnalysisContextCollection(includedPaths: [
@@ -176,9 +177,9 @@ Future<void> _generateJsTypeSupertypes() async {
     final element = definedNames[name];
     if (element is ExtensionTypeElement) {
       // Only extension types defined in `dart:js_interop` are JS types.
-      bool _isJSType(InterfaceElement element) =>
+      bool isJSType(InterfaceElement element) =>
           element is ExtensionTypeElement && element.library == dartJsInterop;
-      if (!_isJSType(element)) continue;
+      if (!isJSType(element)) continue;
 
       String? parentJsType;
       final supertype = element.supertype;
@@ -189,7 +190,7 @@ Future<void> _generateJsTypeSupertypes() async {
       // We should have at most one non-trivial supertype.
       assert(immediateSupertypes.length <= 1);
       for (final supertype in immediateSupertypes) {
-        if (_isJSType(supertype.element)) {
+        if (isJSType(supertype.element)) {
           parentJsType = "'${supertype.element.name}'";
         }
       }


### PR DESCRIPTION
When analyzing library elements, we should use their import URIs instead of their library name. This is especially relevant as https://dart-review.googlesource.com/c/sdk/+/352977 is planning to remove the library name from dart:js_interop.

Also fixes an issue where we were returning instead of continuing in the loop that iterates over dart:js_interop and cleans up references to dart:_js_types which aren't needed anymore.