### PR TITLE
Fix dictionary constructors to accept supertype members and create an empty object when there are no fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.6.0-wip
+
+- Added supertypes' fields to dictionary constructors as dictionaries are
+  allowed to contain those fields.
+- Empty dictionary constructors now create an empty object instead of being
+  treated like non-object literal `external` constructors.
+
 ## 0.5.1
 
 - Add [`TrustedTypes`](https://web.dev/trusted-types) members.

--- a/lib/src/dom/clipboard_apis.dart
+++ b/lib/src/dom/clipboard_apis.dart
@@ -22,7 +22,12 @@ typedef ClipboardItemData = JSPromise<JSAny>;
 typedef ClipboardItems = JSArray<ClipboardItem>;
 typedef PresentationStyle = String;
 extension type ClipboardEventInit._(JSObject _) implements EventInit, JSObject {
-  external factory ClipboardEventInit({DataTransfer? clipboardData});
+  external factory ClipboardEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    DataTransfer? clipboardData,
+  });
 
   external set clipboardData(DataTransfer? value);
   external DataTransfer? get clipboardData;
@@ -136,7 +141,10 @@ extension type ClipboardUnsanitizedFormats._(JSObject _) implements JSObject {
 }
 extension type ClipboardPermissionDescriptor._(JSObject _)
     implements PermissionDescriptor, JSObject {
-  external factory ClipboardPermissionDescriptor({bool allowWithoutGesture});
+  external factory ClipboardPermissionDescriptor({
+    required String name,
+    bool allowWithoutGesture,
+  });
 
   external set allowWithoutGesture(bool value);
   external bool get allowWithoutGesture;

--- a/lib/src/dom/credential_management.dart
+++ b/lib/src/dom/credential_management.dart
@@ -188,6 +188,7 @@ extension type PasswordCredential._(JSObject _)
 extension type PasswordCredentialData._(JSObject _)
     implements CredentialData, JSObject {
   external factory PasswordCredentialData({
+    required String id,
     String name,
     String iconURL,
     required String origin,
@@ -243,6 +244,7 @@ extension type FederatedCredentialRequestOptions._(JSObject _)
 extension type FederatedCredentialInit._(JSObject _)
     implements CredentialData, JSObject {
   external factory FederatedCredentialInit({
+    required String id,
     String name,
     String iconURL,
     required String origin,

--- a/lib/src/dom/csp.dart
+++ b/lib/src/dom/csp.dart
@@ -72,6 +72,9 @@ extension type SecurityPolicyViolationEvent._(JSObject _)
 extension type SecurityPolicyViolationEventInit._(JSObject _)
     implements EventInit, JSObject {
   external factory SecurityPolicyViolationEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     required String documentURI,
     String referrer,
     String blockedURI,

--- a/lib/src/dom/css_animations.dart
+++ b/lib/src/dom/css_animations.dart
@@ -31,6 +31,9 @@ extension type AnimationEvent._(JSObject _) implements Event, JSObject {
 }
 extension type AnimationEventInit._(JSObject _) implements EventInit, JSObject {
   external factory AnimationEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     String animationName,
     num elapsedTime,
     String pseudoElement,

--- a/lib/src/dom/css_font_loading.dart
+++ b/lib/src/dom/css_font_loading.dart
@@ -126,7 +126,12 @@ extension type FontFacePalettes._(JSObject _) implements JSObject {
 }
 extension type FontFaceSetLoadEventInit._(JSObject _)
     implements EventInit, JSObject {
-  external factory FontFaceSetLoadEventInit({JSArray<FontFace> fontfaces});
+  external factory FontFaceSetLoadEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    JSArray<FontFace> fontfaces,
+  });
 
   external set fontfaces(JSArray<FontFace> value);
   external JSArray<FontFace> get fontfaces;

--- a/lib/src/dom/css_transitions.dart
+++ b/lib/src/dom/css_transitions.dart
@@ -31,6 +31,9 @@ extension type TransitionEvent._(JSObject _) implements Event, JSObject {
 extension type TransitionEventInit._(JSObject _)
     implements EventInit, JSObject {
   external factory TransitionEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     String propertyName,
     num elapsedTime,
     String pseudoElement,

--- a/lib/src/dom/cssom_view.dart
+++ b/lib/src/dom/cssom_view.dart
@@ -31,6 +31,7 @@ extension type ScrollOptions._(JSObject _) implements JSObject {
 extension type ScrollToOptions._(JSObject _)
     implements ScrollOptions, JSObject {
   external factory ScrollToOptions({
+    ScrollBehavior behavior,
     num left,
     num top,
   });
@@ -99,6 +100,9 @@ extension type MediaQueryListEvent._(JSObject _) implements Event, JSObject {
 extension type MediaQueryListEventInit._(JSObject _)
     implements EventInit, JSObject {
   external factory MediaQueryListEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     String media,
     bool matches,
   });
@@ -135,6 +139,7 @@ extension type CaretPosition._(JSObject _) implements JSObject {
 extension type ScrollIntoViewOptions._(JSObject _)
     implements ScrollOptions, JSObject {
   external factory ScrollIntoViewOptions({
+    ScrollBehavior behavior,
     ScrollLogicalPosition block,
     ScrollLogicalPosition inline,
   });

--- a/lib/src/dom/dom.dart
+++ b/lib/src/dom/dom.dart
@@ -218,7 +218,12 @@ extension type CustomEvent._(JSObject _) implements Event, JSObject {
   external JSAny? get detail;
 }
 extension type CustomEventInit._(JSObject _) implements EventInit, JSObject {
-  external factory CustomEventInit({JSAny? detail});
+  external factory CustomEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    JSAny? detail,
+  });
 
   external set detail(JSAny? value);
   external JSAny? get detail;
@@ -363,6 +368,7 @@ extension type EventListenerOptions._(JSObject _) implements JSObject {
 extension type AddEventListenerOptions._(JSObject _)
     implements EventListenerOptions, JSObject {
   external factory AddEventListenerOptions({
+    bool capture,
     bool passive,
     bool once,
     AbortSignal signal,

--- a/lib/src/dom/encrypted_media.dart
+++ b/lib/src/dom/encrypted_media.dart
@@ -188,6 +188,9 @@ extension type MediaKeyMessageEvent._(JSObject _) implements Event, JSObject {
 extension type MediaKeyMessageEventInit._(JSObject _)
     implements EventInit, JSObject {
   external factory MediaKeyMessageEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     required MediaKeyMessageType messageType,
     required JSArrayBuffer message,
   });
@@ -215,6 +218,9 @@ extension type MediaEncryptedEvent._(JSObject _) implements Event, JSObject {
 extension type MediaEncryptedEventInit._(JSObject _)
     implements EventInit, JSObject {
   external factory MediaEncryptedEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     String initDataType,
     JSArrayBuffer? initData,
   });

--- a/lib/src/dom/fileapi.dart
+++ b/lib/src/dom/fileapi.dart
@@ -103,7 +103,11 @@ extension type File._(JSObject _) implements Blob, JSObject {
 }
 extension type FilePropertyBag._(JSObject _)
     implements BlobPropertyBag, JSObject {
-  external factory FilePropertyBag({int lastModified});
+  external factory FilePropertyBag({
+    String type,
+    EndingType endings,
+    int lastModified,
+  });
 
   external set lastModified(int value);
   external int get lastModified;

--- a/lib/src/dom/gamepad.dart
+++ b/lib/src/dom/gamepad.dart
@@ -99,7 +99,12 @@ extension type GamepadEvent._(JSObject _) implements Event, JSObject {
   external Gamepad get gamepad;
 }
 extension type GamepadEventInit._(JSObject _) implements EventInit, JSObject {
-  external factory GamepadEventInit({required Gamepad gamepad});
+  external factory GamepadEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    required Gamepad gamepad,
+  });
 
   external set gamepad(Gamepad value);
   external Gamepad get gamepad;

--- a/lib/src/dom/geometry.dart
+++ b/lib/src/dom/geometry.dart
@@ -458,6 +458,18 @@ extension type DOMMatrix2DInit._(JSObject _) implements JSObject {
 extension type DOMMatrixInit._(JSObject _)
     implements DOMMatrix2DInit, JSObject {
   external factory DOMMatrixInit({
+    num a,
+    num b,
+    num c,
+    num d,
+    num e,
+    num f,
+    num m11,
+    num m12,
+    num m21,
+    num m22,
+    num m41,
+    num m42,
     num m13,
     num m14,
     num m23,

--- a/lib/src/dom/html.dart
+++ b/lib/src/dom/html.dart
@@ -1870,7 +1870,12 @@ extension type TrackEvent._(JSObject _) implements Event, JSObject {
   external JSObject? get track;
 }
 extension type TrackEventInit._(JSObject _) implements EventInit, JSObject {
-  external factory TrackEventInit({JSObject? track});
+  external factory TrackEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    JSObject? track,
+  });
 
   external set track(JSObject? value);
   external JSObject? get track;
@@ -3099,7 +3104,12 @@ extension type SubmitEvent._(JSObject _) implements Event, JSObject {
   external HTMLElement? get submitter;
 }
 extension type SubmitEventInit._(JSObject _) implements EventInit, JSObject {
-  external factory SubmitEventInit({HTMLElement? submitter});
+  external factory SubmitEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    HTMLElement? submitter,
+  });
 
   external set submitter(HTMLElement? value);
   external HTMLElement? get submitter;
@@ -3125,7 +3135,12 @@ extension type FormDataEvent._(JSObject _) implements Event, JSObject {
   external FormData get formData;
 }
 extension type FormDataEventInit._(JSObject _) implements EventInit, JSObject {
-  external factory FormDataEventInit({required FormData formData});
+  external factory FormDataEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    required FormData formData,
+  });
 
   external set formData(FormData value);
   external FormData get formData;
@@ -4941,6 +4956,9 @@ extension type ToggleEvent._(JSObject _) implements Event, JSObject {
 }
 extension type ToggleEventInit._(JSObject _) implements EventInit, JSObject {
   external factory ToggleEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     String oldState,
     String newState,
   });
@@ -5159,7 +5177,36 @@ extension type DragEvent._(JSObject _) implements MouseEvent, JSObject {
   external DataTransfer? get dataTransfer;
 }
 extension type DragEventInit._(JSObject _) implements MouseEventInit, JSObject {
-  external factory DragEventInit({DataTransfer? dataTransfer});
+  external factory DragEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    Window? view,
+    int detail,
+    int which,
+    bool ctrlKey,
+    bool shiftKey,
+    bool altKey,
+    bool metaKey,
+    bool modifierAltGraph,
+    bool modifierCapsLock,
+    bool modifierFn,
+    bool modifierFnLock,
+    bool modifierHyper,
+    bool modifierNumLock,
+    bool modifierScrollLock,
+    bool modifierSuper,
+    bool modifierSymbol,
+    bool modifierSymbolLock,
+    int screenX,
+    int screenY,
+    int clientX,
+    int clientY,
+    int button,
+    int buttons,
+    EventTarget? relatedTarget,
+    DataTransfer? dataTransfer,
+  });
 
   external set dataTransfer(DataTransfer? value);
   external DataTransfer? get dataTransfer;
@@ -5776,7 +5823,10 @@ extension type Window._(JSObject _) implements EventTarget, JSObject {
 }
 extension type WindowPostMessageOptions._(JSObject _)
     implements StructuredSerializeOptions, JSObject {
-  external factory WindowPostMessageOptions({String targetOrigin});
+  external factory WindowPostMessageOptions({
+    JSArray<JSObject> transfer,
+    String targetOrigin,
+  });
 
   external set targetOrigin(String value);
   external String get targetOrigin;
@@ -6003,6 +6053,7 @@ extension type NavigationOptions._(JSObject _) implements JSObject {
 extension type NavigationNavigateOptions._(JSObject _)
     implements NavigationOptions, JSObject {
   external factory NavigationNavigateOptions({
+    JSAny? info,
     JSAny? state,
     NavigationHistoryBehavior history,
   });
@@ -6014,7 +6065,10 @@ extension type NavigationNavigateOptions._(JSObject _)
 }
 extension type NavigationReloadOptions._(JSObject _)
     implements NavigationOptions, JSObject {
-  external factory NavigationReloadOptions({JSAny? state});
+  external factory NavigationReloadOptions({
+    JSAny? info,
+    JSAny? state,
+  });
 
   external set state(JSAny? value);
   external JSAny? get state;
@@ -6112,6 +6166,9 @@ extension type NavigateEvent._(JSObject _) implements Event, JSObject {
 }
 extension type NavigateEventInit._(JSObject _) implements EventInit, JSObject {
   external factory NavigateEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     NavigationType navigationType,
     required NavigationDestination destination,
     bool canIntercept,
@@ -6206,6 +6263,9 @@ extension type NavigationCurrentEntryChangeEvent._(JSObject _)
 extension type NavigationCurrentEntryChangeEventInit._(JSObject _)
     implements EventInit, JSObject {
   external factory NavigationCurrentEntryChangeEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     NavigationType? navigationType,
     required NavigationHistoryEntry from,
   });
@@ -6238,6 +6298,9 @@ extension type PopStateEvent._(JSObject _) implements Event, JSObject {
 }
 extension type PopStateEventInit._(JSObject _) implements EventInit, JSObject {
   external factory PopStateEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     JSAny? state,
     bool hasUAVisualTransition,
   });
@@ -6265,6 +6328,9 @@ extension type HashChangeEvent._(JSObject _) implements Event, JSObject {
 extension type HashChangeEventInit._(JSObject _)
     implements EventInit, JSObject {
   external factory HashChangeEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     String oldURL,
     String newURL,
   });
@@ -6284,7 +6350,12 @@ extension type PageRevealEvent._(JSObject _) implements Event, JSObject {
 }
 extension type PageRevealEventInit._(JSObject _)
     implements EventInit, JSObject {
-  external factory PageRevealEventInit({ViewTransition? viewTransition});
+  external factory PageRevealEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    ViewTransition? viewTransition,
+  });
 
   external set viewTransition(ViewTransition? value);
   external ViewTransition? get viewTransition;
@@ -6306,7 +6377,12 @@ extension type PageTransitionEvent._(JSObject _) implements Event, JSObject {
 }
 extension type PageTransitionEventInit._(JSObject _)
     implements EventInit, JSObject {
-  external factory PageTransitionEventInit({bool persisted});
+  external factory PageTransitionEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    bool persisted,
+  });
 
   external set persisted(bool value);
   external bool get persisted;
@@ -6339,6 +6415,9 @@ extension type ErrorEvent._(JSObject _) implements Event, JSObject {
 }
 extension type ErrorEventInit._(JSObject _) implements EventInit, JSObject {
   external factory ErrorEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     String message,
     String filename,
     int lineno,
@@ -6376,6 +6455,9 @@ extension type PromiseRejectionEvent._(JSObject _) implements Event, JSObject {
 extension type PromiseRejectionEventInit._(JSObject _)
     implements EventInit, JSObject {
   external factory PromiseRejectionEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     required JSObject promise,
     JSAny? reason,
   });
@@ -6708,6 +6790,9 @@ extension type MessageEvent._(JSObject _) implements Event, JSObject {
 }
 extension type MessageEventInit._(JSObject _) implements EventInit, JSObject {
   external factory MessageEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     JSAny? data,
     String origin,
     String lastEventId,
@@ -7318,6 +7403,9 @@ extension type StorageEvent._(JSObject _) implements Event, JSObject {
 }
 extension type StorageEventInit._(JSObject _) implements EventInit, JSObject {
   external factory StorageEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     String? key,
     String? oldValue,
     String? newValue,

--- a/lib/src/dom/indexeddb.dart
+++ b/lib/src/dom/indexeddb.dart
@@ -87,6 +87,9 @@ extension type IDBVersionChangeEvent._(JSObject _) implements Event, JSObject {
 extension type IDBVersionChangeEventInit._(JSObject _)
     implements EventInit, JSObject {
   external factory IDBVersionChangeEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     int oldVersion,
     int? newVersion,
   });

--- a/lib/src/dom/media_capabilities.dart
+++ b/lib/src/dom/media_capabilities.dart
@@ -34,6 +34,8 @@ extension type MediaConfiguration._(JSObject _) implements JSObject {
 extension type MediaDecodingConfiguration._(JSObject _)
     implements MediaConfiguration, JSObject {
   external factory MediaDecodingConfiguration({
+    VideoConfiguration video,
+    AudioConfiguration audio,
     required MediaDecodingType type,
     MediaCapabilitiesKeySystemConfiguration keySystemConfiguration,
   });
@@ -46,8 +48,11 @@ extension type MediaDecodingConfiguration._(JSObject _)
 }
 extension type MediaEncodingConfiguration._(JSObject _)
     implements MediaConfiguration, JSObject {
-  external factory MediaEncodingConfiguration(
-      {required MediaEncodingType type});
+  external factory MediaEncodingConfiguration({
+    VideoConfiguration video,
+    AudioConfiguration audio,
+    required MediaEncodingType type,
+  });
 
   external set type(MediaEncodingType value);
   external MediaEncodingType get type;
@@ -165,6 +170,9 @@ extension type MediaCapabilitiesInfo._(JSObject _) implements JSObject {
 extension type MediaCapabilitiesDecodingInfo._(JSObject _)
     implements MediaCapabilitiesInfo, JSObject {
   external factory MediaCapabilitiesDecodingInfo({
+    required bool supported,
+    required bool smooth,
+    required bool powerEfficient,
     required MediaKeySystemAccess keySystemAccess,
     MediaDecodingConfiguration configuration,
   });
@@ -176,8 +184,12 @@ extension type MediaCapabilitiesDecodingInfo._(JSObject _)
 }
 extension type MediaCapabilitiesEncodingInfo._(JSObject _)
     implements MediaCapabilitiesInfo, JSObject {
-  external factory MediaCapabilitiesEncodingInfo(
-      {MediaEncodingConfiguration configuration});
+  external factory MediaCapabilitiesEncodingInfo({
+    required bool supported,
+    required bool smooth,
+    required bool powerEfficient,
+    MediaEncodingConfiguration configuration,
+  });
 
   external set configuration(MediaEncodingConfiguration value);
   external MediaEncodingConfiguration get configuration;

--- a/lib/src/dom/media_source.dart
+++ b/lib/src/dom/media_source.dart
@@ -193,6 +193,9 @@ extension type BufferedChangeEvent._(JSObject _) implements Event, JSObject {
 extension type BufferedChangeEventInit._(JSObject _)
     implements EventInit, JSObject {
   external factory BufferedChangeEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     TimeRanges addedRanges,
     TimeRanges removedRanges,
   });

--- a/lib/src/dom/mediacapture_streams.dart
+++ b/lib/src/dom/mediacapture_streams.dart
@@ -326,8 +326,24 @@ extension type MediaTrackCapabilities._(JSObject _) implements JSObject {
 /// [MediaStreamTrack.getConstraints].
 extension type MediaTrackConstraints._(JSObject _)
     implements MediaTrackConstraintSet, JSObject {
-  external factory MediaTrackConstraints(
-      {JSArray<MediaTrackConstraintSet> advanced});
+  external factory MediaTrackConstraints({
+    ConstrainULong width,
+    ConstrainULong height,
+    ConstrainDouble aspectRatio,
+    ConstrainDouble frameRate,
+    ConstrainDOMString facingMode,
+    ConstrainDOMString resizeMode,
+    ConstrainULong sampleRate,
+    ConstrainULong sampleSize,
+    ConstrainBoolean echoCancellation,
+    ConstrainBoolean autoGainControl,
+    ConstrainBoolean noiseSuppression,
+    ConstrainDouble latency,
+    ConstrainULong channelCount,
+    ConstrainDOMString deviceId,
+    ConstrainDOMString groupId,
+    JSArray<MediaTrackConstraintSet> advanced,
+  });
 
   external set advanced(JSArray<MediaTrackConstraintSet> value);
   external JSArray<MediaTrackConstraintSet> get advanced;
@@ -464,7 +480,12 @@ extension type MediaStreamTrackEvent._(JSObject _) implements Event, JSObject {
 }
 extension type MediaStreamTrackEventInit._(JSObject _)
     implements EventInit, JSObject {
-  external factory MediaStreamTrackEventInit({required MediaStreamTrack track});
+  external factory MediaStreamTrackEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    required MediaStreamTrack track,
+  });
 
   external set track(MediaStreamTrack value);
   external MediaStreamTrack get track;
@@ -591,6 +612,8 @@ extension type DoubleRange._(JSObject _) implements JSObject {
 extension type ConstrainDoubleRange._(JSObject _)
     implements DoubleRange, JSObject {
   external factory ConstrainDoubleRange({
+    num max,
+    num min,
     num exact,
     num ideal,
   });
@@ -614,6 +637,8 @@ extension type ULongRange._(JSObject _) implements JSObject {
 extension type ConstrainULongRange._(JSObject _)
     implements ULongRange, JSObject {
   external factory ConstrainULongRange({
+    int max,
+    int min,
     int exact,
     int ideal,
   });
@@ -647,7 +672,10 @@ extension type ConstrainDOMStringParameters._(JSObject _) implements JSObject {
 }
 extension type CameraDevicePermissionDescriptor._(JSObject _)
     implements PermissionDescriptor, JSObject {
-  external factory CameraDevicePermissionDescriptor({bool panTiltZoom});
+  external factory CameraDevicePermissionDescriptor({
+    required String name,
+    bool panTiltZoom,
+  });
 
   external set panTiltZoom(bool value);
   external bool get panTiltZoom;

--- a/lib/src/dom/notifications.dart
+++ b/lib/src/dom/notifications.dart
@@ -171,6 +171,9 @@ extension type NotificationEvent._(JSObject _)
 extension type NotificationEventInit._(JSObject _)
     implements ExtendableEventInit, JSObject {
   external factory NotificationEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     required Notification notification,
     String action,
   });

--- a/lib/src/dom/orientation_event.dart
+++ b/lib/src/dom/orientation_event.dart
@@ -33,6 +33,9 @@ extension type DeviceOrientationEvent._(JSObject _) implements Event, JSObject {
 extension type DeviceOrientationEventInit._(JSObject _)
     implements EventInit, JSObject {
   external factory DeviceOrientationEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     num? alpha,
     num? beta,
     num? gamma,
@@ -118,6 +121,9 @@ extension type DeviceMotionEventRotationRateInit._(JSObject _)
 extension type DeviceMotionEventInit._(JSObject _)
     implements EventInit, JSObject {
   external factory DeviceMotionEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     DeviceMotionEventAccelerationInit acceleration,
     DeviceMotionEventAccelerationInit accelerationIncludingGravity,
     DeviceMotionEventRotationRateInit rotationRate,

--- a/lib/src/dom/payment_request.dart
+++ b/lib/src/dom/payment_request.dart
@@ -134,6 +134,8 @@ extension type PaymentDetailsBase._(JSObject _) implements JSObject {
 extension type PaymentDetailsInit._(JSObject _)
     implements PaymentDetailsBase, JSObject {
   external factory PaymentDetailsInit({
+    JSArray<PaymentItem> displayItems,
+    JSArray<PaymentDetailsModifier> modifiers,
     String id,
     required PaymentItem total,
   });
@@ -146,6 +148,8 @@ extension type PaymentDetailsInit._(JSObject _)
 extension type PaymentDetailsUpdate._(JSObject _)
     implements PaymentDetailsBase, JSObject {
   external factory PaymentDetailsUpdate({
+    JSArray<PaymentItem> displayItems,
+    JSArray<PaymentDetailsModifier> modifiers,
     PaymentItem total,
     JSObject paymentMethodErrors,
   });
@@ -261,6 +265,9 @@ extension type PaymentMethodChangeEvent._(JSObject _)
 extension type PaymentMethodChangeEventInit._(JSObject _)
     implements PaymentRequestUpdateEventInit, JSObject {
   external factory PaymentMethodChangeEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     String methodName,
     JSObject? methodDetails,
   });
@@ -293,5 +300,9 @@ extension type PaymentRequestUpdateEvent._(JSObject _)
 }
 extension type PaymentRequestUpdateEventInit._(JSObject _)
     implements EventInit, JSObject {
-  external factory PaymentRequestUpdateEventInit();
+  external factory PaymentRequestUpdateEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+  });
 }

--- a/lib/src/dom/pointerevents.dart
+++ b/lib/src/dom/pointerevents.dart
@@ -13,11 +13,40 @@ library;
 
 import 'dart:js_interop';
 
+import 'dom.dart';
+import 'html.dart';
 import 'uievents.dart';
 
 extension type PointerEventInit._(JSObject _)
     implements MouseEventInit, JSObject {
   external factory PointerEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    Window? view,
+    int detail,
+    int which,
+    bool ctrlKey,
+    bool shiftKey,
+    bool altKey,
+    bool metaKey,
+    bool modifierAltGraph,
+    bool modifierCapsLock,
+    bool modifierFn,
+    bool modifierFnLock,
+    bool modifierHyper,
+    bool modifierNumLock,
+    bool modifierScrollLock,
+    bool modifierSuper,
+    bool modifierSymbol,
+    bool modifierSymbolLock,
+    int screenX,
+    int screenY,
+    int clientX,
+    int clientY,
+    int button,
+    int buttons,
+    EventTarget? relatedTarget,
     int pointerId,
     num width,
     num height,

--- a/lib/src/dom/push_api.dart
+++ b/lib/src/dom/push_api.dart
@@ -22,7 +22,10 @@ typedef PushMessageDataInit = JSAny;
 typedef PushEncryptionKeyName = String;
 extension type PushPermissionDescriptor._(JSObject _)
     implements PermissionDescriptor, JSObject {
-  external factory PushPermissionDescriptor({bool userVisibleOnly});
+  external factory PushPermissionDescriptor({
+    required String name,
+    bool userVisibleOnly,
+  });
 
   external set userVisibleOnly(bool value);
   external bool get userVisibleOnly;
@@ -182,7 +185,12 @@ extension type PushEvent._(JSObject _) implements ExtendableEvent, JSObject {
 }
 extension type PushEventInit._(JSObject _)
     implements ExtendableEventInit, JSObject {
-  external factory PushEventInit({PushMessageDataInit data});
+  external factory PushEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    PushMessageDataInit data,
+  });
 
   external set data(PushMessageDataInit value);
   external PushMessageDataInit get data;
@@ -200,6 +208,9 @@ extension type PushSubscriptionChangeEvent._(JSObject _)
 extension type PushSubscriptionChangeEventInit._(JSObject _)
     implements ExtendableEventInit, JSObject {
   external factory PushSubscriptionChangeEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     PushSubscription newSubscription,
     PushSubscription oldSubscription,
   });

--- a/lib/src/dom/service_workers.dart
+++ b/lib/src/dom/service_workers.dart
@@ -510,7 +510,11 @@ extension type ExtendableEvent._(JSObject _) implements Event, JSObject {
 }
 extension type ExtendableEventInit._(JSObject _)
     implements EventInit, JSObject {
-  external factory ExtendableEventInit();
+  external factory ExtendableEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+  });
 }
 
 /// This is the event type for `fetch` events dispatched on the
@@ -598,6 +602,9 @@ extension type FetchEvent._(JSObject _) implements ExtendableEvent, JSObject {
 extension type FetchEventInit._(JSObject _)
     implements ExtendableEventInit, JSObject {
   external factory FetchEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     required Request request,
     JSPromise<JSAny?> preloadResponse,
     String clientId,
@@ -644,6 +651,9 @@ extension type ExtendableMessageEvent._(JSObject _)
 extension type ExtendableMessageEventInit._(JSObject _)
     implements ExtendableEventInit, JSObject {
   external factory ExtendableMessageEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     JSAny? data,
     String origin,
     String lastEventId,
@@ -901,7 +911,12 @@ extension type CacheStorage._(JSObject _) implements JSObject {
 }
 extension type MultiCacheQueryOptions._(JSObject _)
     implements CacheQueryOptions, JSObject {
-  external factory MultiCacheQueryOptions({String cacheName});
+  external factory MultiCacheQueryOptions({
+    bool ignoreSearch,
+    bool ignoreMethod,
+    bool ignoreVary,
+    String cacheName,
+  });
 
   external set cacheName(String value);
   external String get cacheName;

--- a/lib/src/dom/speech_api.dart
+++ b/lib/src/dom/speech_api.dart
@@ -104,6 +104,9 @@ extension type SpeechRecognitionErrorEvent._(JSObject _)
 extension type SpeechRecognitionErrorEventInit._(JSObject _)
     implements EventInit, JSObject {
   external factory SpeechRecognitionErrorEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     required SpeechRecognitionErrorCode error,
     String message,
   });
@@ -168,6 +171,9 @@ extension type SpeechRecognitionEvent._(JSObject _) implements Event, JSObject {
 extension type SpeechRecognitionEventInit._(JSObject _)
     implements EventInit, JSObject {
   external factory SpeechRecognitionEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     int resultIndex,
     required SpeechRecognitionResultList results,
   });
@@ -330,6 +336,9 @@ extension type SpeechSynthesisEvent._(JSObject _) implements Event, JSObject {
 extension type SpeechSynthesisEventInit._(JSObject _)
     implements EventInit, JSObject {
   external factory SpeechSynthesisEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     required SpeechSynthesisUtterance utterance,
     int charIndex,
     int charLength,
@@ -364,8 +373,17 @@ extension type SpeechSynthesisErrorEvent._(JSObject _)
 }
 extension type SpeechSynthesisErrorEventInit._(JSObject _)
     implements SpeechSynthesisEventInit, JSObject {
-  external factory SpeechSynthesisErrorEventInit(
-      {required SpeechSynthesisErrorCode error});
+  external factory SpeechSynthesisErrorEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    required SpeechSynthesisUtterance utterance,
+    int charIndex,
+    int charLength,
+    num elapsedTime,
+    String name,
+    required SpeechSynthesisErrorCode error,
+  });
 
   external set error(SpeechSynthesisErrorCode value);
   external SpeechSynthesisErrorCode get error;

--- a/lib/src/dom/touch_events.dart
+++ b/lib/src/dom/touch_events.dart
@@ -14,6 +14,7 @@ library;
 import 'dart:js_interop';
 
 import 'dom.dart';
+import 'html.dart';
 import 'uievents.dart';
 
 typedef TouchType = String;
@@ -124,6 +125,26 @@ extension type TouchList._(JSObject _) implements JSObject {
 extension type TouchEventInit._(JSObject _)
     implements EventModifierInit, JSObject {
   external factory TouchEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    Window? view,
+    int detail,
+    int which,
+    bool ctrlKey,
+    bool shiftKey,
+    bool altKey,
+    bool metaKey,
+    bool modifierAltGraph,
+    bool modifierCapsLock,
+    bool modifierFn,
+    bool modifierFnLock,
+    bool modifierHyper,
+    bool modifierNumLock,
+    bool modifierScrollLock,
+    bool modifierSuper,
+    bool modifierSymbol,
+    bool modifierSymbolLock,
     JSArray<Touch> touches,
     JSArray<Touch> targetTouches,
     JSArray<Touch> changedTouches,

--- a/lib/src/dom/uievents.dart
+++ b/lib/src/dom/uievents.dart
@@ -58,6 +58,9 @@ extension type UIEvent._(JSObject _) implements Event, JSObject {
 }
 extension type UIEventInit._(JSObject _) implements EventInit, JSObject {
   external factory UIEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     Window? view,
     int detail,
     int which,
@@ -83,7 +86,15 @@ extension type FocusEvent._(JSObject _) implements UIEvent, JSObject {
   external EventTarget? get relatedTarget;
 }
 extension type FocusEventInit._(JSObject _) implements UIEventInit, JSObject {
-  external factory FocusEventInit({EventTarget? relatedTarget});
+  external factory FocusEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    Window? view,
+    int detail,
+    int which,
+    EventTarget? relatedTarget,
+  });
 
   external set relatedTarget(EventTarget? value);
   external EventTarget? get relatedTarget;
@@ -170,6 +181,26 @@ extension type MouseEvent._(JSObject _) implements UIEvent, JSObject {
 extension type MouseEventInit._(JSObject _)
     implements EventModifierInit, JSObject {
   external factory MouseEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    Window? view,
+    int detail,
+    int which,
+    bool ctrlKey,
+    bool shiftKey,
+    bool altKey,
+    bool metaKey,
+    bool modifierAltGraph,
+    bool modifierCapsLock,
+    bool modifierFn,
+    bool modifierFnLock,
+    bool modifierHyper,
+    bool modifierNumLock,
+    bool modifierScrollLock,
+    bool modifierSuper,
+    bool modifierSymbol,
+    bool modifierSymbolLock,
     int screenX,
     int screenY,
     int clientX,
@@ -197,6 +228,12 @@ extension type MouseEventInit._(JSObject _)
 extension type EventModifierInit._(JSObject _)
     implements UIEventInit, JSObject {
   external factory EventModifierInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    Window? view,
+    int detail,
+    int which,
     bool ctrlKey,
     bool shiftKey,
     bool altKey,
@@ -277,6 +314,33 @@ extension type WheelEvent._(JSObject _) implements MouseEvent, JSObject {
 extension type WheelEventInit._(JSObject _)
     implements MouseEventInit, JSObject {
   external factory WheelEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    Window? view,
+    int detail,
+    int which,
+    bool ctrlKey,
+    bool shiftKey,
+    bool altKey,
+    bool metaKey,
+    bool modifierAltGraph,
+    bool modifierCapsLock,
+    bool modifierFn,
+    bool modifierFnLock,
+    bool modifierHyper,
+    bool modifierNumLock,
+    bool modifierScrollLock,
+    bool modifierSuper,
+    bool modifierSymbol,
+    bool modifierSymbolLock,
+    int screenX,
+    int screenY,
+    int clientX,
+    int clientY,
+    int button,
+    int buttons,
+    EventTarget? relatedTarget,
     num deltaX,
     num deltaY,
     num deltaZ,
@@ -307,6 +371,12 @@ extension type InputEvent._(JSObject _) implements UIEvent, JSObject {
 }
 extension type InputEventInit._(JSObject _) implements UIEventInit, JSObject {
   external factory InputEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    Window? view,
+    int detail,
+    int which,
     String? data,
     bool isComposing,
     String inputType,
@@ -384,6 +454,26 @@ extension type KeyboardEvent._(JSObject _) implements UIEvent, JSObject {
 extension type KeyboardEventInit._(JSObject _)
     implements EventModifierInit, JSObject {
   external factory KeyboardEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    Window? view,
+    int detail,
+    int which,
+    bool ctrlKey,
+    bool shiftKey,
+    bool altKey,
+    bool metaKey,
+    bool modifierAltGraph,
+    bool modifierCapsLock,
+    bool modifierFn,
+    bool modifierFnLock,
+    bool modifierHyper,
+    bool modifierNumLock,
+    bool modifierScrollLock,
+    bool modifierSuper,
+    bool modifierSymbol,
+    bool modifierSymbolLock,
     String key,
     String code,
     int location,
@@ -434,7 +524,15 @@ extension type CompositionEvent._(JSObject _) implements UIEvent, JSObject {
 }
 extension type CompositionEventInit._(JSObject _)
     implements UIEventInit, JSObject {
-  external factory CompositionEventInit({String data});
+  external factory CompositionEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    Window? view,
+    int detail,
+    int which,
+    String data,
+  });
 
   external set data(String value);
   external String get data;

--- a/lib/src/dom/web_animations.dart
+++ b/lib/src/dom/web_animations.dart
@@ -294,6 +294,15 @@ extension type OptionalEffectTiming._(JSObject _) implements JSObject {
 extension type ComputedEffectTiming._(JSObject _)
     implements EffectTiming, JSObject {
   external factory ComputedEffectTiming({
+    num delay,
+    num endDelay,
+    num playbackRate,
+    JSAny duration,
+    FillMode fill,
+    num iterationStart,
+    num iterations,
+    PlaybackDirection direction,
+    String easing,
     CSSNumberish startTime,
     CSSNumberish endTime,
     CSSNumberish activeDuration,
@@ -395,6 +404,15 @@ extension type BaseKeyframe._(JSObject _) implements JSObject {
 extension type KeyframeEffectOptions._(JSObject _)
     implements EffectTiming, JSObject {
   external factory KeyframeEffectOptions({
+    num delay,
+    num endDelay,
+    num playbackRate,
+    JSAny duration,
+    FillMode fill,
+    num iterationStart,
+    num iterations,
+    PlaybackDirection direction,
+    String easing,
     IterationCompositeOperation iterationComposite,
     CompositeOperation composite,
     String? pseudoElement,
@@ -410,6 +428,18 @@ extension type KeyframeEffectOptions._(JSObject _)
 extension type KeyframeAnimationOptions._(JSObject _)
     implements KeyframeEffectOptions, JSObject {
   external factory KeyframeAnimationOptions({
+    num delay,
+    num endDelay,
+    num playbackRate,
+    JSAny duration,
+    FillMode fill,
+    num iterationStart,
+    num iterations,
+    PlaybackDirection direction,
+    String easing,
+    IterationCompositeOperation iterationComposite,
+    CompositeOperation composite,
+    String? pseudoElement,
     JSAny rangeStart,
     JSAny rangeEnd,
     String id,

--- a/lib/src/dom/web_animations_2.dart
+++ b/lib/src/dom/web_animations_2.dart
@@ -74,6 +74,9 @@ extension type AnimationPlaybackEvent._(JSObject _) implements Event, JSObject {
 extension type AnimationPlaybackEventInit._(JSObject _)
     implements EventInit, JSObject {
   external factory AnimationPlaybackEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     CSSNumberish? currentTime,
     CSSNumberish? timelineTime,
   });

--- a/lib/src/dom/webaudio.dart
+++ b/lib/src/dom/webaudio.dart
@@ -509,6 +509,9 @@ extension type AudioRenderCapacityEvent._(JSObject _)
 extension type AudioRenderCapacityEventInit._(JSObject _)
     implements EventInit, JSObject {
   external factory AudioRenderCapacityEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     num timestamp,
     num averageLoad,
     num peakLoad,
@@ -622,8 +625,12 @@ extension type OfflineAudioCompletionEvent._(JSObject _)
 }
 extension type OfflineAudioCompletionEventInit._(JSObject _)
     implements EventInit, JSObject {
-  external factory OfflineAudioCompletionEventInit(
-      {required AudioBuffer renderedBuffer});
+  external factory OfflineAudioCompletionEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    required AudioBuffer renderedBuffer,
+  });
 
   external set renderedBuffer(AudioBuffer value);
   external AudioBuffer get renderedBuffer;
@@ -983,6 +990,9 @@ extension type AnalyserNode._(JSObject _) implements AudioNode, JSObject {
 extension type AnalyserOptions._(JSObject _)
     implements AudioNodeOptions, JSObject {
   external factory AnalyserOptions({
+    int channelCount,
+    ChannelCountMode channelCountMode,
+    ChannelInterpretation channelInterpretation,
     int fftSize,
     num maxDecibels,
     num minDecibels,
@@ -1231,6 +1241,9 @@ extension type AudioProcessingEvent._(JSObject _) implements Event, JSObject {
 extension type AudioProcessingEventInit._(JSObject _)
     implements EventInit, JSObject {
   external factory AudioProcessingEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     required num playbackTime,
     required AudioBuffer inputBuffer,
     required AudioBuffer outputBuffer,
@@ -1304,6 +1317,9 @@ extension type BiquadFilterNode._(JSObject _) implements AudioNode, JSObject {
 extension type BiquadFilterOptions._(JSObject _)
     implements AudioNodeOptions, JSObject {
   external factory BiquadFilterOptions({
+    int channelCount,
+    ChannelCountMode channelCountMode,
+    ChannelInterpretation channelInterpretation,
     BiquadFilterType type,
     num Q,
     num detune,
@@ -1374,7 +1390,12 @@ extension type ChannelMergerNode._(JSObject _) implements AudioNode, JSObject {
 }
 extension type ChannelMergerOptions._(JSObject _)
     implements AudioNodeOptions, JSObject {
-  external factory ChannelMergerOptions({int numberOfInputs});
+  external factory ChannelMergerOptions({
+    int channelCount,
+    ChannelCountMode channelCountMode,
+    ChannelInterpretation channelInterpretation,
+    int numberOfInputs,
+  });
 
   external set numberOfInputs(int value);
   external int get numberOfInputs;
@@ -1435,7 +1456,12 @@ extension type ChannelSplitterNode._(JSObject _)
 }
 extension type ChannelSplitterOptions._(JSObject _)
     implements AudioNodeOptions, JSObject {
-  external factory ChannelSplitterOptions({int numberOfOutputs});
+  external factory ChannelSplitterOptions({
+    int channelCount,
+    ChannelCountMode channelCountMode,
+    ChannelInterpretation channelInterpretation,
+    int numberOfOutputs,
+  });
 
   external set numberOfOutputs(int value);
   external int get numberOfOutputs;
@@ -1527,6 +1553,9 @@ extension type ConvolverNode._(JSObject _) implements AudioNode, JSObject {
 extension type ConvolverOptions._(JSObject _)
     implements AudioNodeOptions, JSObject {
   external factory ConvolverOptions({
+    int channelCount,
+    ChannelCountMode channelCountMode,
+    ChannelInterpretation channelInterpretation,
     AudioBuffer? buffer,
     bool disableNormalization,
   });
@@ -1587,6 +1616,9 @@ extension type DelayNode._(JSObject _) implements AudioNode, JSObject {
 extension type DelayOptions._(JSObject _)
     implements AudioNodeOptions, JSObject {
   external factory DelayOptions({
+    int channelCount,
+    ChannelCountMode channelCountMode,
+    ChannelInterpretation channelInterpretation,
     num maxDelayTime,
     num delayTime,
   });
@@ -1645,6 +1677,9 @@ extension type DynamicsCompressorNode._(JSObject _)
 extension type DynamicsCompressorOptions._(JSObject _)
     implements AudioNodeOptions, JSObject {
   external factory DynamicsCompressorOptions({
+    int channelCount,
+    ChannelCountMode channelCountMode,
+    ChannelInterpretation channelInterpretation,
     num attack,
     num knee,
     num ratio,
@@ -1710,7 +1745,12 @@ extension type GainNode._(JSObject _) implements AudioNode, JSObject {
   external AudioParam get gain;
 }
 extension type GainOptions._(JSObject _) implements AudioNodeOptions, JSObject {
-  external factory GainOptions({num gain});
+  external factory GainOptions({
+    int channelCount,
+    ChannelCountMode channelCountMode,
+    ChannelInterpretation channelInterpretation,
+    num gain,
+  });
 
   external set gain(num value);
   external num get gain;
@@ -1793,6 +1833,9 @@ extension type IIRFilterNode._(JSObject _) implements AudioNode, JSObject {
 extension type IIRFilterOptions._(JSObject _)
     implements AudioNodeOptions, JSObject {
   external factory IIRFilterOptions({
+    int channelCount,
+    ChannelCountMode channelCountMode,
+    ChannelInterpretation channelInterpretation,
     required JSArray<JSNumber> feedforward,
     required JSArray<JSNumber> feedback,
   });
@@ -2054,6 +2097,9 @@ extension type OscillatorNode._(JSObject _)
 extension type OscillatorOptions._(JSObject _)
     implements AudioNodeOptions, JSObject {
   external factory OscillatorOptions({
+    int channelCount,
+    ChannelCountMode channelCountMode,
+    ChannelInterpretation channelInterpretation,
     OscillatorType type,
     num frequency,
     num detune,
@@ -2186,6 +2232,9 @@ extension type PannerNode._(JSObject _) implements AudioNode, JSObject {
 extension type PannerOptions._(JSObject _)
     implements AudioNodeOptions, JSObject {
   external factory PannerOptions({
+    int channelCount,
+    ChannelCountMode channelCountMode,
+    ChannelInterpretation channelInterpretation,
     PanningModelType panningModel,
     DistanceModelType distanceModel,
     num positionX,
@@ -2254,6 +2303,7 @@ extension type PeriodicWaveConstraints._(JSObject _) implements JSObject {
 extension type PeriodicWaveOptions._(JSObject _)
     implements PeriodicWaveConstraints, JSObject {
   external factory PeriodicWaveOptions({
+    bool disableNormalization,
     JSArray<JSNumber> real,
     JSArray<JSNumber> imag,
   });
@@ -2375,7 +2425,12 @@ extension type StereoPannerNode._(JSObject _) implements AudioNode, JSObject {
 }
 extension type StereoPannerOptions._(JSObject _)
     implements AudioNodeOptions, JSObject {
-  external factory StereoPannerOptions({num pan});
+  external factory StereoPannerOptions({
+    int channelCount,
+    ChannelCountMode channelCountMode,
+    ChannelInterpretation channelInterpretation,
+    num pan,
+  });
 
   external set pan(num value);
   external num get pan;
@@ -2427,6 +2482,9 @@ extension type WaveShaperNode._(JSObject _) implements AudioNode, JSObject {
 extension type WaveShaperOptions._(JSObject _)
     implements AudioNodeOptions, JSObject {
   external factory WaveShaperOptions({
+    int channelCount,
+    ChannelCountMode channelCountMode,
+    ChannelInterpretation channelInterpretation,
     JSArray<JSNumber> curve,
     OverSampleType oversample,
   });
@@ -2517,6 +2575,9 @@ extension type AudioWorkletNode._(JSObject _) implements AudioNode, JSObject {
 extension type AudioWorkletNodeOptions._(JSObject _)
     implements AudioNodeOptions, JSObject {
   external factory AudioWorkletNodeOptions({
+    int channelCount,
+    ChannelCountMode channelCountMode,
+    ChannelInterpretation channelInterpretation,
     int numberOfInputs,
     int numberOfOutputs,
     JSArray<JSNumber> outputChannelCount,

--- a/lib/src/dom/webauthn.dart
+++ b/lib/src/dom/webauthn.dart
@@ -481,7 +481,10 @@ extension type PublicKeyCredentialEntity._(JSObject _) implements JSObject {
 }
 extension type PublicKeyCredentialRpEntity._(JSObject _)
     implements PublicKeyCredentialEntity, JSObject {
-  external factory PublicKeyCredentialRpEntity({String id});
+  external factory PublicKeyCredentialRpEntity({
+    required String name,
+    String id,
+  });
 
   external set id(String value);
   external String get id;
@@ -489,6 +492,7 @@ extension type PublicKeyCredentialRpEntity._(JSObject _)
 extension type PublicKeyCredentialUserEntity._(JSObject _)
     implements PublicKeyCredentialEntity, JSObject {
   external factory PublicKeyCredentialUserEntity({
+    required String name,
     required BufferSource id,
     required String displayName,
   });

--- a/lib/src/dom/webauthn.dart
+++ b/lib/src/dom/webauthn.dart
@@ -222,7 +222,7 @@ extension type AuthenticatorAssertionResponseJSON._(JSObject _)
 }
 extension type AuthenticationExtensionsClientOutputsJSON._(JSObject _)
     implements JSObject {
-  external factory AuthenticationExtensionsClientOutputsJSON();
+  AuthenticationExtensionsClientOutputsJSON() : _ = JSObject();
 }
 extension type PublicKeyCredentialCreationOptionsJSON._(JSObject _)
     implements JSObject {
@@ -296,7 +296,7 @@ extension type PublicKeyCredentialDescriptorJSON._(JSObject _)
 }
 extension type AuthenticationExtensionsClientInputsJSON._(JSObject _)
     implements JSObject {
-  external factory AuthenticationExtensionsClientInputsJSON();
+  AuthenticationExtensionsClientInputsJSON() : _ = JSObject();
 }
 extension type PublicKeyCredentialRequestOptionsJSON._(JSObject _)
     implements JSObject {

--- a/lib/src/dom/webcryptoapi.dart
+++ b/lib/src/dom/webcryptoapi.dart
@@ -437,6 +437,7 @@ extension type CryptoKeyPair._(JSObject _) implements JSObject {
 }
 extension type RsaKeyGenParams._(JSObject _) implements Algorithm, JSObject {
   external factory RsaKeyGenParams({
+    required String name,
     required int modulusLength,
     required BigInteger publicExponent,
   });
@@ -458,14 +459,19 @@ extension type RsaKeyGenParams._(JSObject _) implements Algorithm, JSObject {
 /// [RSA-OAEP](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/encrypt#rsa-oaep).
 extension type RsaHashedKeyGenParams._(JSObject _)
     implements RsaKeyGenParams, JSObject {
-  external factory RsaHashedKeyGenParams(
-      {required HashAlgorithmIdentifier hash});
+  external factory RsaHashedKeyGenParams({
+    required String name,
+    required int modulusLength,
+    required BigInteger publicExponent,
+    required HashAlgorithmIdentifier hash,
+  });
 
   external set hash(HashAlgorithmIdentifier value);
   external HashAlgorithmIdentifier get hash;
 }
 extension type RsaKeyAlgorithm._(JSObject _) implements KeyAlgorithm, JSObject {
   external factory RsaKeyAlgorithm({
+    required String name,
     required int modulusLength,
     required BigInteger publicExponent,
   });
@@ -477,7 +483,12 @@ extension type RsaKeyAlgorithm._(JSObject _) implements KeyAlgorithm, JSObject {
 }
 extension type RsaHashedKeyAlgorithm._(JSObject _)
     implements RsaKeyAlgorithm, JSObject {
-  external factory RsaHashedKeyAlgorithm({required KeyAlgorithm hash});
+  external factory RsaHashedKeyAlgorithm({
+    required String name,
+    required int modulusLength,
+    required BigInteger publicExponent,
+    required KeyAlgorithm hash,
+  });
 
   external set hash(KeyAlgorithm value);
   external KeyAlgorithm get hash;
@@ -494,8 +505,10 @@ extension type RsaHashedKeyAlgorithm._(JSObject _)
 /// [RSA-OAEP](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/encrypt#rsa-oaep).
 extension type RsaHashedImportParams._(JSObject _)
     implements Algorithm, JSObject {
-  external factory RsaHashedImportParams(
-      {required HashAlgorithmIdentifier hash});
+  external factory RsaHashedImportParams({
+    required String name,
+    required HashAlgorithmIdentifier hash,
+  });
 
   external set hash(HashAlgorithmIdentifier value);
   external HashAlgorithmIdentifier get hash;
@@ -508,7 +521,10 @@ extension type RsaHashedImportParams._(JSObject _)
 /// [RSA-PSS](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/sign#rsa-pss)
 /// algorithm.
 extension type RsaPssParams._(JSObject _) implements Algorithm, JSObject {
-  external factory RsaPssParams({required int saltLength});
+  external factory RsaPssParams({
+    required String name,
+    required int saltLength,
+  });
 
   external set saltLength(int value);
   external int get saltLength;
@@ -522,7 +538,10 @@ extension type RsaPssParams._(JSObject _) implements Algorithm, JSObject {
 /// [RSA_OAEP](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/encrypt#rsa-oaep)
 /// algorithm.
 extension type RsaOaepParams._(JSObject _) implements Algorithm, JSObject {
-  external factory RsaOaepParams({BufferSource label});
+  external factory RsaOaepParams({
+    required String name,
+    BufferSource label,
+  });
 
   external set label(BufferSource value);
   external BufferSource get label;
@@ -535,7 +554,10 @@ extension type RsaOaepParams._(JSObject _) implements Algorithm, JSObject {
 /// [ECDSA](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/sign#ecdsa)
 /// algorithm.
 extension type EcdsaParams._(JSObject _) implements Algorithm, JSObject {
-  external factory EcdsaParams({required HashAlgorithmIdentifier hash});
+  external factory EcdsaParams({
+    required String name,
+    required HashAlgorithmIdentifier hash,
+  });
 
   external set hash(HashAlgorithmIdentifier value);
   external HashAlgorithmIdentifier get hash;
@@ -550,13 +572,19 @@ extension type EcdsaParams._(JSObject _) implements Algorithm, JSObject {
 /// or
 /// [ECDH](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/deriveKey#ecdh).
 extension type EcKeyGenParams._(JSObject _) implements Algorithm, JSObject {
-  external factory EcKeyGenParams({required NamedCurve namedCurve});
+  external factory EcKeyGenParams({
+    required String name,
+    required NamedCurve namedCurve,
+  });
 
   external set namedCurve(NamedCurve value);
   external NamedCurve get namedCurve;
 }
 extension type EcKeyAlgorithm._(JSObject _) implements KeyAlgorithm, JSObject {
-  external factory EcKeyAlgorithm({required NamedCurve namedCurve});
+  external factory EcKeyAlgorithm({
+    required String name,
+    required NamedCurve namedCurve,
+  });
 
   external set namedCurve(NamedCurve value);
   external NamedCurve get namedCurve;
@@ -572,7 +600,10 @@ extension type EcKeyAlgorithm._(JSObject _) implements KeyAlgorithm, JSObject {
 /// or
 /// [ECDH](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/deriveKey#ecdh).
 extension type EcKeyImportParams._(JSObject _) implements Algorithm, JSObject {
-  external factory EcKeyImportParams({required NamedCurve namedCurve});
+  external factory EcKeyImportParams({
+    required String name,
+    required NamedCurve namedCurve,
+  });
 
   external set namedCurve(NamedCurve value);
   external NamedCurve get namedCurve;
@@ -595,7 +626,10 @@ extension type EcKeyImportParams._(JSObject _) implements Algorithm, JSObject {
 /// shared secret.
 extension type EcdhKeyDeriveParams._(JSObject _)
     implements Algorithm, JSObject {
-  external factory EcdhKeyDeriveParams({required CryptoKey public});
+  external factory EcdhKeyDeriveParams({
+    required String name,
+    required CryptoKey public,
+  });
 
   external set public(CryptoKey value);
   external CryptoKey get public;
@@ -642,6 +676,7 @@ extension type EcdhKeyDeriveParams._(JSObject _)
 /// > for more information.
 extension type AesCtrParams._(JSObject _) implements Algorithm, JSObject {
   external factory AesCtrParams({
+    required String name,
     required BufferSource counter,
     required int length,
   });
@@ -652,7 +687,10 @@ extension type AesCtrParams._(JSObject _) implements Algorithm, JSObject {
   external int get length;
 }
 extension type AesKeyAlgorithm._(JSObject _) implements KeyAlgorithm, JSObject {
-  external factory AesKeyAlgorithm({required int length});
+  external factory AesKeyAlgorithm({
+    required String name,
+    required int length,
+  });
 
   external set length(int value);
   external int get length;
@@ -669,14 +707,20 @@ extension type AesKeyAlgorithm._(JSObject _) implements KeyAlgorithm, JSObject {
 /// or
 /// [AES-KW](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/wrapKey#aes-kw).
 extension type AesKeyGenParams._(JSObject _) implements Algorithm, JSObject {
-  external factory AesKeyGenParams({required int length});
+  external factory AesKeyGenParams({
+    required String name,
+    required int length,
+  });
 
   external set length(int value);
   external int get length;
 }
 extension type AesDerivedKeyParams._(JSObject _)
     implements Algorithm, JSObject {
-  external factory AesDerivedKeyParams({required int length});
+  external factory AesDerivedKeyParams({
+    required String name,
+    required int length,
+  });
 
   external set length(int value);
   external int get length;
@@ -690,7 +734,10 @@ extension type AesDerivedKeyParams._(JSObject _)
 /// [AES-CBC](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc)
 /// algorithm.
 extension type AesCbcParams._(JSObject _) implements Algorithm, JSObject {
-  external factory AesCbcParams({required BufferSource iv});
+  external factory AesCbcParams({
+    required String name,
+    required BufferSource iv,
+  });
 
   external set iv(BufferSource value);
   external BufferSource get iv;
@@ -710,6 +757,7 @@ extension type AesCbcParams._(JSObject _) implements Algorithm, JSObject {
 /// in particular section 5.2.1.1 on Input Data.
 extension type AesGcmParams._(JSObject _) implements Algorithm, JSObject {
   external factory AesGcmParams({
+    required String name,
     required BufferSource iv,
     BufferSource additionalData,
     int tagLength,
@@ -732,6 +780,7 @@ extension type AesGcmParams._(JSObject _) implements Algorithm, JSObject {
 /// algorithm.
 extension type HmacImportParams._(JSObject _) implements Algorithm, JSObject {
   external factory HmacImportParams({
+    required String name,
     required HashAlgorithmIdentifier hash,
     int length,
   });
@@ -744,6 +793,7 @@ extension type HmacImportParams._(JSObject _) implements Algorithm, JSObject {
 extension type HmacKeyAlgorithm._(JSObject _)
     implements KeyAlgorithm, JSObject {
   external factory HmacKeyAlgorithm({
+    required String name,
     required KeyAlgorithm hash,
     required int length,
   });
@@ -762,6 +812,7 @@ extension type HmacKeyAlgorithm._(JSObject _)
 /// algorithm.
 extension type HmacKeyGenParams._(JSObject _) implements Algorithm, JSObject {
   external factory HmacKeyGenParams({
+    required String name,
     required HashAlgorithmIdentifier hash,
     int length,
   });
@@ -780,6 +831,7 @@ extension type HmacKeyGenParams._(JSObject _) implements Algorithm, JSObject {
 /// algorithm.
 extension type HkdfParams._(JSObject _) implements Algorithm, JSObject {
   external factory HkdfParams({
+    required String name,
     required HashAlgorithmIdentifier hash,
     required BufferSource salt,
     required BufferSource info,
@@ -801,6 +853,7 @@ extension type HkdfParams._(JSObject _) implements Algorithm, JSObject {
 /// algorithm.
 extension type Pbkdf2Params._(JSObject _) implements Algorithm, JSObject {
   external factory Pbkdf2Params({
+    required String name,
     required BufferSource salt,
     required int iterations,
     required HashAlgorithmIdentifier hash,

--- a/lib/src/dom/webgl1.dart
+++ b/lib/src/dom/webgl1.dart
@@ -1727,7 +1727,12 @@ extension type WebGLContextEvent._(JSObject _) implements Event, JSObject {
 }
 extension type WebGLContextEventInit._(JSObject _)
     implements EventInit, JSObject {
-  external factory WebGLContextEventInit({String statusMessage});
+  external factory WebGLContextEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    String statusMessage,
+  });
 
   external set statusMessage(String value);
   external String get statusMessage;

--- a/lib/src/dom/webrtc.dart
+++ b/lib/src/dom/webrtc.dart
@@ -84,7 +84,7 @@ extension type RTCIceServer._(JSObject _) implements JSObject {
   external String get credential;
 }
 extension type RTCOfferAnswerOptions._(JSObject _) implements JSObject {
-  external factory RTCOfferAnswerOptions();
+  RTCOfferAnswerOptions() : _ = JSObject();
 }
 extension type RTCOfferOptions._(JSObject _)
     implements RTCOfferAnswerOptions, JSObject {
@@ -103,7 +103,7 @@ extension type RTCOfferOptions._(JSObject _)
 }
 extension type RTCAnswerOptions._(JSObject _)
     implements RTCOfferAnswerOptions, JSObject {
-  external factory RTCAnswerOptions();
+  RTCAnswerOptions() : _ = JSObject();
 }
 
 /// The **`RTCPeerConnection`** interface represents a WebRTC connection between
@@ -888,7 +888,7 @@ extension type RTCRtpHeaderExtensionCapability._(JSObject _)
   external String get uri;
 }
 extension type RTCSetParameterOptions._(JSObject _) implements JSObject {
-  external factory RTCSetParameterOptions();
+  RTCSetParameterOptions() : _ = JSObject();
 }
 
 /// The **`RTCRtpReceiver`** interface of the

--- a/lib/src/dom/webrtc.dart
+++ b/lib/src/dom/webrtc.dart
@@ -567,6 +567,9 @@ extension type RTCPeerConnectionIceEvent._(JSObject _)
 extension type RTCPeerConnectionIceEventInit._(JSObject _)
     implements EventInit, JSObject {
   external factory RTCPeerConnectionIceEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     RTCIceCandidate? candidate,
     String? url,
   });
@@ -597,6 +600,9 @@ extension type RTCPeerConnectionIceErrorEvent._(JSObject _)
 extension type RTCPeerConnectionIceErrorEventInit._(JSObject _)
     implements EventInit, JSObject {
   external factory RTCPeerConnectionIceErrorEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     String? address,
     int? port,
     String url,
@@ -739,6 +745,9 @@ extension type RTCRtpParameters._(JSObject _) implements JSObject {
 extension type RTCRtpSendParameters._(JSObject _)
     implements RTCRtpParameters, JSObject {
   external factory RTCRtpSendParameters({
+    required JSArray<RTCRtpHeaderExtensionParameters> headerExtensions,
+    required RTCRtcpParameters rtcp,
+    required JSArray<RTCRtpCodecParameters> codecs,
     required String transactionId,
     required JSArray<RTCRtpEncodingParameters> encodings,
   });
@@ -750,7 +759,11 @@ extension type RTCRtpSendParameters._(JSObject _)
 }
 extension type RTCRtpReceiveParameters._(JSObject _)
     implements RTCRtpParameters, JSObject {
-  external factory RTCRtpReceiveParameters();
+  external factory RTCRtpReceiveParameters({
+    required JSArray<RTCRtpHeaderExtensionParameters> headerExtensions,
+    required RTCRtcpParameters rtcp,
+    required JSArray<RTCRtpCodecParameters> codecs,
+  });
 }
 extension type RTCRtpCodingParameters._(JSObject _) implements JSObject {
   external factory RTCRtpCodingParameters({String rid});
@@ -761,6 +774,7 @@ extension type RTCRtpCodingParameters._(JSObject _) implements JSObject {
 extension type RTCRtpEncodingParameters._(JSObject _)
     implements RTCRtpCodingParameters, JSObject {
   external factory RTCRtpEncodingParameters({
+    String rid,
     bool active,
     int maxBitrate,
     num maxFramerate,
@@ -835,7 +849,13 @@ extension type RTCRtpCodec._(JSObject _) implements JSObject {
 /// the end of this article.
 extension type RTCRtpCodecParameters._(JSObject _)
     implements RTCRtpCodec, JSObject {
-  external factory RTCRtpCodecParameters({required int payloadType});
+  external factory RTCRtpCodecParameters({
+    required String mimeType,
+    required int clockRate,
+    int channels,
+    String sdpFmtpLine,
+    required int payloadType,
+  });
 
   external set payloadType(int value);
   external int get payloadType;
@@ -853,7 +873,12 @@ extension type RTCRtpCapabilities._(JSObject _) implements JSObject {
 }
 extension type RTCRtpCodecCapability._(JSObject _)
     implements RTCRtpCodec, JSObject {
-  external factory RTCRtpCodecCapability();
+  external factory RTCRtpCodecCapability({
+    required String mimeType,
+    required int clockRate,
+    int channels,
+    String sdpFmtpLine,
+  });
 }
 extension type RTCRtpHeaderExtensionCapability._(JSObject _)
     implements JSObject {
@@ -919,7 +944,12 @@ extension type RTCRtpContributingSource._(JSObject _) implements JSObject {
 }
 extension type RTCRtpSynchronizationSource._(JSObject _)
     implements RTCRtpContributingSource, JSObject {
-  external factory RTCRtpSynchronizationSource();
+  external factory RTCRtpSynchronizationSource({
+    required DOMHighResTimeStamp timestamp,
+    required int source,
+    num audioLevel,
+    required int rtpTimestamp,
+  });
 }
 
 /// The WebRTC interface **`RTCRtpTransceiver`** describes a permanent pairing
@@ -1131,6 +1161,9 @@ extension type RTCTrackEvent._(JSObject _) implements Event, JSObject {
 }
 extension type RTCTrackEventInit._(JSObject _) implements EventInit, JSObject {
   external factory RTCTrackEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     required RTCRtpReceiver receiver,
     required MediaStreamTrack track,
     JSArray<MediaStream> streams,
@@ -1301,7 +1334,12 @@ extension type RTCDataChannelEvent._(JSObject _) implements Event, JSObject {
 }
 extension type RTCDataChannelEventInit._(JSObject _)
     implements EventInit, JSObject {
-  external factory RTCDataChannelEventInit({required RTCDataChannel channel});
+  external factory RTCDataChannelEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    required RTCDataChannel channel,
+  });
 
   external set channel(RTCDataChannel value);
   external RTCDataChannel get channel;
@@ -1368,7 +1406,12 @@ extension type RTCDTMFToneChangeEvent._(JSObject _) implements Event, JSObject {
 }
 extension type RTCDTMFToneChangeEventInit._(JSObject _)
     implements EventInit, JSObject {
-  external factory RTCDTMFToneChangeEventInit({String tone});
+  external factory RTCDTMFToneChangeEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    String tone,
+  });
 
   external set tone(String value);
   external String get tone;
@@ -1450,7 +1493,12 @@ extension type RTCErrorEvent._(JSObject _) implements Event, JSObject {
   external RTCError get error;
 }
 extension type RTCErrorEventInit._(JSObject _) implements EventInit, JSObject {
-  external factory RTCErrorEventInit({required RTCError error});
+  external factory RTCErrorEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    required RTCError error,
+  });
 
   external set error(RTCError value);
   external RTCError get error;

--- a/lib/src/dom/webrtc_encoded_transform.dart
+++ b/lib/src/dom/webrtc_encoded_transform.dart
@@ -56,6 +56,9 @@ extension type SFrameTransformErrorEvent._(JSObject _)
 extension type SFrameTransformErrorEventInit._(JSObject _)
     implements EventInit, JSObject {
   external factory SFrameTransformErrorEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     required SFrameTransformErrorEventType errorType,
     required JSAny? frame,
     CryptoKeyID? keyID,

--- a/lib/src/dom/webrtc_stats.dart
+++ b/lib/src/dom/webrtc_stats.dart
@@ -39,6 +39,9 @@ typedef RTCStatsIceCandidatePairState = String;
 /// > and when the name change was implemented in specific browsers.
 extension type RTCRtpStreamStats._(JSObject _) implements RTCStats, JSObject {
   external factory RTCRtpStreamStats({
+    required DOMHighResTimeStamp timestamp,
+    required RTCStatsType type,
+    required String id,
     required int ssrc,
     required String kind,
     String transportId,
@@ -56,6 +59,9 @@ extension type RTCRtpStreamStats._(JSObject _) implements RTCStats, JSObject {
 }
 extension type RTCCodecStats._(JSObject _) implements RTCStats, JSObject {
   external factory RTCCodecStats({
+    required DOMHighResTimeStamp timestamp,
+    required RTCStatsType type,
+    required String id,
     required int payloadType,
     required String transportId,
     required String mimeType,
@@ -80,6 +86,13 @@ extension type RTCCodecStats._(JSObject _) implements RTCStats, JSObject {
 extension type RTCReceivedRtpStreamStats._(JSObject _)
     implements RTCRtpStreamStats, JSObject {
   external factory RTCReceivedRtpStreamStats({
+    required DOMHighResTimeStamp timestamp,
+    required RTCStatsType type,
+    required String id,
+    required int ssrc,
+    required String kind,
+    String transportId,
+    String codecId,
     int packetsReceived,
     int packetsLost,
     num jitter,
@@ -104,6 +117,16 @@ extension type RTCReceivedRtpStreamStats._(JSObject _)
 extension type RTCInboundRtpStreamStats._(JSObject _)
     implements RTCReceivedRtpStreamStats, JSObject {
   external factory RTCInboundRtpStreamStats({
+    required DOMHighResTimeStamp timestamp,
+    required RTCStatsType type,
+    required String id,
+    required int ssrc,
+    required String kind,
+    String transportId,
+    String codecId,
+    int packetsReceived,
+    int packetsLost,
+    num jitter,
     required String trackIdentifier,
     String mid,
     String remoteId,
@@ -269,6 +292,16 @@ extension type RTCInboundRtpStreamStats._(JSObject _)
 extension type RTCRemoteInboundRtpStreamStats._(JSObject _)
     implements RTCReceivedRtpStreamStats, JSObject {
   external factory RTCRemoteInboundRtpStreamStats({
+    required DOMHighResTimeStamp timestamp,
+    required RTCStatsType type,
+    required String id,
+    required int ssrc,
+    required String kind,
+    String transportId,
+    String codecId,
+    int packetsReceived,
+    int packetsLost,
+    num jitter,
     String localId,
     num roundTripTime,
     num totalRoundTripTime,
@@ -290,6 +323,13 @@ extension type RTCRemoteInboundRtpStreamStats._(JSObject _)
 extension type RTCSentRtpStreamStats._(JSObject _)
     implements RTCRtpStreamStats, JSObject {
   external factory RTCSentRtpStreamStats({
+    required DOMHighResTimeStamp timestamp,
+    required RTCStatsType type,
+    required String id,
+    required int ssrc,
+    required String kind,
+    String transportId,
+    String codecId,
     int packetsSent,
     int bytesSent,
   });
@@ -311,6 +351,15 @@ extension type RTCSentRtpStreamStats._(JSObject _)
 extension type RTCOutboundRtpStreamStats._(JSObject _)
     implements RTCSentRtpStreamStats, JSObject {
   external factory RTCOutboundRtpStreamStats({
+    required DOMHighResTimeStamp timestamp,
+    required RTCStatsType type,
+    required String id,
+    required int ssrc,
+    required String kind,
+    String transportId,
+    String codecId,
+    int packetsSent,
+    int bytesSent,
     String mid,
     String mediaSourceId,
     String remoteId,
@@ -417,6 +466,15 @@ extension type RTCOutboundRtpStreamStats._(JSObject _)
 extension type RTCRemoteOutboundRtpStreamStats._(JSObject _)
     implements RTCSentRtpStreamStats, JSObject {
   external factory RTCRemoteOutboundRtpStreamStats({
+    required DOMHighResTimeStamp timestamp,
+    required RTCStatsType type,
+    required String id,
+    required int ssrc,
+    required String kind,
+    String transportId,
+    String codecId,
+    int packetsSent,
+    int bytesSent,
     String localId,
     DOMHighResTimeStamp remoteTimestamp,
     int reportsSent,
@@ -440,6 +498,9 @@ extension type RTCRemoteOutboundRtpStreamStats._(JSObject _)
 }
 extension type RTCMediaSourceStats._(JSObject _) implements RTCStats, JSObject {
   external factory RTCMediaSourceStats({
+    required DOMHighResTimeStamp timestamp,
+    required RTCStatsType type,
+    required String id,
     required String trackIdentifier,
     required String kind,
   });
@@ -465,6 +526,11 @@ extension type RTCMediaSourceStats._(JSObject _) implements RTCStats, JSObject {
 extension type RTCAudioSourceStats._(JSObject _)
     implements RTCMediaSourceStats, JSObject {
   external factory RTCAudioSourceStats({
+    required DOMHighResTimeStamp timestamp,
+    required RTCStatsType type,
+    required String id,
+    required String trackIdentifier,
+    required String kind,
     num audioLevel,
     num totalAudioEnergy,
     num totalSamplesDuration,
@@ -486,6 +552,11 @@ extension type RTCAudioSourceStats._(JSObject _)
 extension type RTCVideoSourceStats._(JSObject _)
     implements RTCMediaSourceStats, JSObject {
   external factory RTCVideoSourceStats({
+    required DOMHighResTimeStamp timestamp,
+    required RTCStatsType type,
+    required String id,
+    required String trackIdentifier,
+    required String kind,
     int width,
     int height,
     int frames,
@@ -504,6 +575,9 @@ extension type RTCVideoSourceStats._(JSObject _)
 extension type RTCAudioPlayoutStats._(JSObject _)
     implements RTCStats, JSObject {
   external factory RTCAudioPlayoutStats({
+    required DOMHighResTimeStamp timestamp,
+    required RTCStatsType type,
+    required String id,
     required String kind,
     num synthesizedSamplesDuration,
     int synthesizedSamplesEvents,
@@ -541,6 +615,9 @@ extension type RTCAudioPlayoutStats._(JSObject _)
 extension type RTCPeerConnectionStats._(JSObject _)
     implements RTCStats, JSObject {
   external factory RTCPeerConnectionStats({
+    required DOMHighResTimeStamp timestamp,
+    required RTCStatsType type,
+    required String id,
     int dataChannelsOpened,
     int dataChannelsClosed,
   });
@@ -552,6 +629,9 @@ extension type RTCPeerConnectionStats._(JSObject _)
 }
 extension type RTCDataChannelStats._(JSObject _) implements RTCStats, JSObject {
   external factory RTCDataChannelStats({
+    required DOMHighResTimeStamp timestamp,
+    required RTCStatsType type,
+    required String id,
     String label,
     String protocol,
     int dataChannelIdentifier,
@@ -602,6 +682,9 @@ extension type RTCDataChannelStats._(JSObject _) implements RTCStats, JSObject {
 /// [`type`](#type) of `transport`.
 extension type RTCTransportStats._(JSObject _) implements RTCStats, JSObject {
   external factory RTCTransportStats({
+    required DOMHighResTimeStamp timestamp,
+    required RTCStatsType type,
+    required String id,
     int packetsSent,
     int packetsReceived,
     int bytesSent,
@@ -664,6 +747,9 @@ extension type RTCTransportStats._(JSObject _) implements RTCStats, JSObject {
 extension type RTCIceCandidateStats._(JSObject _)
     implements RTCStats, JSObject {
   external factory RTCIceCandidateStats({
+    required DOMHighResTimeStamp timestamp,
+    required RTCStatsType type,
+    required String id,
     required String transportId,
     String? address,
     int port,
@@ -719,6 +805,9 @@ extension type RTCIceCandidateStats._(JSObject _)
 extension type RTCIceCandidatePairStats._(JSObject _)
     implements RTCStats, JSObject {
   external factory RTCIceCandidatePairStats({
+    required DOMHighResTimeStamp timestamp,
+    required RTCStatsType type,
+    required String id,
     required String transportId,
     required String localCandidateId,
     required String remoteCandidateId,
@@ -799,6 +888,9 @@ extension type RTCIceCandidatePairStats._(JSObject _)
 /// [`type`](#type) of `certificate`.
 extension type RTCCertificateStats._(JSObject _) implements RTCStats, JSObject {
   external factory RTCCertificateStats({
+    required DOMHighResTimeStamp timestamp,
+    required RTCStatsType type,
+    required String id,
     required String fingerprint,
     required String fingerprintAlgorithm,
     required String base64Certificate,

--- a/lib/src/dom/websockets.dart
+++ b/lib/src/dom/websockets.dart
@@ -95,6 +95,9 @@ extension type CloseEvent._(JSObject _) implements Event, JSObject {
 }
 extension type CloseEventInit._(JSObject _) implements EventInit, JSObject {
   external factory CloseEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     bool wasClean,
     int code,
     String reason,

--- a/lib/src/dom/xhr.dart
+++ b/lib/src/dom/xhr.dart
@@ -297,6 +297,9 @@ extension type ProgressEvent._(JSObject _) implements Event, JSObject {
 }
 extension type ProgressEventInit._(JSObject _) implements EventInit, JSObject {
   external factory ProgressEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
     bool lengthComputable,
     int loaded,
     int total,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: web
-version: 0.5.1
+version: 0.6.0-wip
 description: Lightweight browser API bindings built around JS static interop.
 repository: https://github.com/dart-lang/web
 


### PR DESCRIPTION
Dictionaries can contain their supertypes' members as well and therefore, these constructors should accept them.

https://webidl.spec.whatwg.org/#idl-dictionaries
https://github.com/dart-lang/web/issues/188

We also emit some empty dictionary constructors, but because they are empty, they are treated as named constructors instead of object literal constructors. They should instead call `JSObject()` to create an empty object.

Since some supertype fields are marked `required`, this is technically a breaking change as calling the same dictionary constructor requires those members now. Therefore, bump to 0.6.0-wip.