### PR TITLE
Only consider extension types that start with JS as JS types

### DIFF
--- a/tool/update_bindings.dart
+++ b/tool/update_bindings.dart
@@ -181,9 +181,12 @@ Future<void> _generateJsTypeSupertypes() async {
   for (final name in definedNames.keys) {
     final element = definedNames[name];
     if (element is ExtensionTypeElement) {
-      // Only extension types defined in `dart:js_interop` are JS types.
+      // JS types are any extension type that starts with 'JS' in
+      // `dart:js_interop`.
       bool isJSType(InterfaceElement element) =>
-          element is ExtensionTypeElement && element.library == dartJsInterop;
+          element is ExtensionTypeElement &&
+          element.library == dartJsInterop &&
+          element.name.startsWith('JS');
       if (!isJSType(element)) continue;
 
       String? parentJsType;


### PR DESCRIPTION
ExternalDartReference has been added to dart:js_interop but is not a JS type and doesn't belong in the type hierarchy for union calculation. Fixes an assertion failure.