### PR TITLE
Require Dart 3.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO(srujzs): Replace with stable when 3.3 is out.
-        sdk: [dev, 3.3]
+        sdk: [dev, 3.4]
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
@@ -46,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        sdk: [dev, 3.3]
+        sdk: [dev, 3.4]
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   dictionaries and typedefs are only emitted if they're used by a generated API.
 - Added `onUnload` event stream to `ElementEventGetters` extension methods.
 - Expose `ElementStream` as a public class.
+- Require Dart `^3.4.0`.
 
 ## 0.5.1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,17 +4,17 @@ description: Lightweight browser API bindings built around JS interop.
 repository: https://github.com/dart-lang/web
 
 environment:
-  sdk: ^3.3.0
+  sdk: ^3.4.0
 
 dev_dependencies:
   analyzer: ^6.3.0
   args: ^2.4.0
-  build_runner: ^2.4.0
-  build_web_compilers: ^4.0.7
+  build_runner: ^2.4.6
+  build_web_compilers: ^4.0.8
   code_builder: ^4.10.0
   collection: ^1.18.0
   dart_flutter_team_lints: ^3.0.0
   dart_style: ^2.3.4
   io: ^1.0.4
   path: ^1.8.3
-  test: ^1.22.2
+  test: ^1.24.4


### PR DESCRIPTION
Allows us to use the latest pkg:test
