### PR TITLE
Add Float16Array alias

### DIFF
--- a/tool/generator/type_aliases.dart
+++ b/tool/generator/type_aliases.dart
@@ -26,9 +26,10 @@ const idlOrBuiltinToJsTypeAliases = <String, String>{
   'Uint8ClampedArray': 'JSUint8ClampedArray',
   'Float32Array': 'JSFloat32Array',
   'Float64Array': 'JSFloat64Array',
-  // TODO(srujzs): Change these aliases if we add these two as JS types.
+  // TODO(srujzs): Change these aliases if we add these as JS types.
   'BigInt64Array': 'JSTypedArray',
   'BigUint64Array': 'JSTypedArray',
+  'Float16Array': 'JSTypedArray',
 
   // Array aliases.
   'sequence': 'JSArray',


### PR DESCRIPTION
This is a new typed array in the w3 spec. Since we don't have a specific type for this, we alias it to JSTypedArray.