### PR TITLE
Emit double as return value instead of num

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
   dictionaries and typedefs are only emitted if they're used by a generated API.
 - Added `onUnload` event stream to `ElementEventGetters` extension methods.
 - Expose `ElementStream` as a public class.
+- APIs that return a double value now return `double` instead of `num`. This is
+  to avoid users accidentally downcasting `num`, which has different semantics
+  depending on whether you compile to JS or Wasm. See issue [#57][] for more
+  details.
+
+[#57]: https://github.com/dart-lang/web/issues/57
 
 ## 0.5.1
 

--- a/lib/src/dom/battery_status.dart
+++ b/lib/src/dom/battery_status.dart
@@ -50,7 +50,7 @@ extension type BatteryManager._(JSObject _) implements EventTarget, JSObject {
   /// > **Note:** Even if the time returned is precise to the second,
   /// > browsers round them to a higher interval
   /// > (typically to the closest 15 minutes) for privacy reasons.
-  external num get chargingTime;
+  external double get chargingTime;
 
   /// The **`dischargingTime`** read-only property of the [BatteryManager]
   /// interface indicates the amount of time, in seconds, that remains until the
@@ -63,7 +63,7 @@ extension type BatteryManager._(JSObject _) implements EventTarget, JSObject {
   /// > **Note:** Even if the time returned is precise to the second, browsers
   /// > round them to a higher
   /// > interval (typically to the closest 15 minutes) for privacy reasons.
-  external num get dischargingTime;
+  external double get dischargingTime;
 
   /// The **`level`** read-only property of the [BatteryManager] interface
   /// indicates the current battery charge level as a value between `0.0` and
@@ -74,7 +74,7 @@ extension type BatteryManager._(JSObject _) implements EventTarget, JSObject {
   /// report the battery status information.
   /// When its value changes, the [BatteryManager.levelchange_event] event is
   /// fired.
-  external num get level;
+  external double get level;
   external EventHandler get onchargingchange;
   external set onchargingchange(EventHandler value);
   external EventHandler get onchargingtimechange;

--- a/lib/src/dom/cookie_store.dart
+++ b/lib/src/dom/cookie_store.dart
@@ -94,7 +94,7 @@ extension type CookieInit._(JSObject _) implements JSObject {
   external set name(String value);
   external String get value;
   external set value(String value);
-  external DOMHighResTimeStamp? get expires;
+  external double? get expires;
   external set expires(DOMHighResTimeStamp? value);
   external String? get domain;
   external set domain(String? value);
@@ -142,7 +142,7 @@ extension type CookieListItem._(JSObject _) implements JSObject {
   external set domain(String? value);
   external String get path;
   external set path(String value);
-  external DOMHighResTimeStamp? get expires;
+  external double? get expires;
   external set expires(DOMHighResTimeStamp? value);
   external bool get secure;
   external set secure(bool value);

--- a/lib/src/dom/css_animations.dart
+++ b/lib/src/dom/css_animations.dart
@@ -43,7 +43,7 @@ extension type AnimationEvent._(JSObject _) implements Event, JSObject {
   /// `elapsedTime` is `0.0` unless there was a negative value for
   /// , in which case the event will be fired with
   /// `elapsedTime` containing `(-1 * delay)`.
-  external num get elapsedTime;
+  external double get elapsedTime;
 
   /// The **`AnimationEvent.pseudoElement`** read-only property is a
   /// string, starting with `'::'`, containing the name of the
@@ -65,7 +65,7 @@ extension type AnimationEventInit._(JSObject _) implements EventInit, JSObject {
 
   external String get animationName;
   external set animationName(String value);
-  external num get elapsedTime;
+  external double get elapsedTime;
   external set elapsedTime(num value);
   external String get pseudoElement;
   external set pseudoElement(String value);

--- a/lib/src/dom/css_paint_api.dart
+++ b/lib/src/dom/css_paint_api.dart
@@ -116,7 +116,7 @@ extension type PaintRenderingContext2D._(JSObject _) implements JSObject {
   ]);
   external void setLineDash(JSArray<JSNumber> segments);
   external JSArray<JSNumber> getLineDash();
-  external num get globalAlpha;
+  external double get globalAlpha;
   external set globalAlpha(num value);
   external String get globalCompositeOperation;
   external set globalCompositeOperation(String value);
@@ -128,26 +128,26 @@ extension type PaintRenderingContext2D._(JSObject _) implements JSObject {
   external set strokeStyle(JSAny value);
   external JSAny get fillStyle;
   external set fillStyle(JSAny value);
-  external num get shadowOffsetX;
+  external double get shadowOffsetX;
   external set shadowOffsetX(num value);
-  external num get shadowOffsetY;
+  external double get shadowOffsetY;
   external set shadowOffsetY(num value);
-  external num get shadowBlur;
+  external double get shadowBlur;
   external set shadowBlur(num value);
   external String get shadowColor;
   external set shadowColor(String value);
-  external num get lineWidth;
+  external double get lineWidth;
   external set lineWidth(num value);
   external CanvasLineCap get lineCap;
   external set lineCap(CanvasLineCap value);
   external CanvasLineJoin get lineJoin;
   external set lineJoin(CanvasLineJoin value);
-  external num get miterLimit;
+  external double get miterLimit;
   external set miterLimit(num value);
-  external num get lineDashOffset;
+  external double get lineDashOffset;
   external set lineDashOffset(num value);
 }
 extension type PaintSize._(JSObject _) implements JSObject {
-  external num get width;
-  external num get height;
+  external double get width;
+  external double get height;
 }

--- a/lib/src/dom/css_transitions.dart
+++ b/lib/src/dom/css_transitions.dart
@@ -39,7 +39,7 @@ extension type TransitionEvent._(JSObject _) implements Event, JSObject {
   /// seconds,
   /// when this event fired. This value is not affected by the
   /// property.
-  external num get elapsedTime;
+  external double get elapsedTime;
 
   /// The **`TransitionEvent.pseudoElement`** read-only property is a
   /// string, starting with `'::'`, containing the name of the
@@ -63,7 +63,7 @@ extension type TransitionEventInit._(JSObject _)
 
   external String get propertyName;
   external set propertyName(String value);
-  external num get elapsedTime;
+  external double get elapsedTime;
   external set elapsedTime(num value);
   external String get pseudoElement;
   external set pseudoElement(String value);

--- a/lib/src/dom/css_typed_om.dart
+++ b/lib/src/dom/css_typed_om.dart
@@ -302,7 +302,7 @@ extension type CSSUnitValue._(JSObject _) implements CSSNumericValue, JSObject {
 
   /// The **`CSSUnitValue.value`** property of the
   /// [CSSUnitValue] interface returns a double indicating the number of units.
-  external num get value;
+  external double get value;
   external set value(num value);
 
   /// The **`CSSUnitValue.unit`** read-only property

--- a/lib/src/dom/cssom_view.dart
+++ b/lib/src/dom/cssom_view.dart
@@ -33,9 +33,9 @@ extension type ScrollToOptions._(JSObject _)
     num top,
   });
 
-  external num get left;
+  external double get left;
   external set left(num value);
-  external num get top;
+  external double get top;
   external set top(num value);
 }
 
@@ -248,41 +248,41 @@ extension type VisualViewport._(JSObject _) implements EventTarget, JSObject {
   /// returns the offset of the left edge of the visual viewport from the left
   /// edge of the layout viewport in CSS pixels, or `0` if current document is
   /// not fully active.
-  external num get offsetLeft;
+  external double get offsetLeft;
 
   /// The **`offsetTop`** read-only property of the [VisualViewport] interface
   /// returns the offset of the top edge of the visual viewport from the top
   /// edge of the layout viewport in CSS pixels, or `0` if current document is
   /// not fully active.
-  external num get offsetTop;
+  external double get offsetTop;
 
   /// The **`pageLeft`** read-only property of the [VisualViewport] interface
   /// returns the x coordinate of the left edge of the visual viewport relative
   /// to the initial containing block origin, in CSS pixels, or `0` if current
   /// document is not fully active.
-  external num get pageLeft;
+  external double get pageLeft;
 
   /// The **`pageTop`** read-only property of the [VisualViewport] interface
   /// returns the y coordinate of the top edge of the visual viewport relative
   /// to the initial containing block origin, in CSS pixels, or `0` if current
   /// document is not fully active.
-  external num get pageTop;
+  external double get pageTop;
 
   /// The **`width`** read-only property of the [VisualViewport] interface
   /// returns the width of the visual viewport, in CSS pixels, or `0` if current
   /// document is not fully active.
-  external num get width;
+  external double get width;
 
   /// The **`height`** read-only property of the [VisualViewport] interface
   /// returns the height of the visual viewport, in CSS pixels, or `0` if
   /// current document is not fully active.
-  external num get height;
+  external double get height;
 
   /// The **`scale`** read-only property of the [VisualViewport] interface
   /// returns the pinch-zoom scaling factor applied to the visual viewport, or
   /// `0` if current document is not fully active, or `1` if there is no output
   /// device.
-  external num get scale;
+  external double get scale;
   external EventHandler get onresize;
   external set onresize(EventHandler value);
   external EventHandler get onscroll;

--- a/lib/src/dom/dom.dart
+++ b/lib/src/dom/dom.dart
@@ -19,7 +19,6 @@ import 'cssom.dart';
 import 'cssom_view.dart';
 import 'fullscreen.dart';
 import 'geometry.dart';
-import 'hr_time.dart';
 import 'html.dart';
 import 'selection_api.dart';
 import 'svg.dart';
@@ -286,7 +285,7 @@ extension type Event._(JSObject _) implements JSObject {
 
   /// The **`timeStamp`** read-only property of the [Event] interface returns
   /// the time (in milliseconds) at which the event was created.
-  external DOMHighResTimeStamp get timeStamp;
+  external double get timeStamp;
 }
 extension type EventInit._(JSObject _) implements JSObject {
   external factory EventInit({
@@ -3406,7 +3405,7 @@ extension type Element._(JSObject _) implements Node, JSObject {
   ///
   /// > **Warning:** On systems using display scaling, `scrollTop` may give you
   /// > a decimal value.
-  external num get scrollTop;
+  external double get scrollTop;
   external set scrollTop(num value);
 
   /// The **`Element.scrollLeft`** property gets or sets the number
@@ -3432,7 +3431,7 @@ extension type Element._(JSObject _) implements Node, JSObject {
   /// > **Warning:** On systems using display scaling, `scrollLeft` may give you
   /// > a decimal
   /// > value.
-  external num get scrollLeft;
+  external double get scrollLeft;
   external set scrollLeft(num value);
 
   /// The **`Element.scrollWidth`** read-only property is a
@@ -5253,7 +5252,7 @@ extension type XPathResult._(JSObject _) implements JSObject {
   /// The read-only **`numberValue`** property of the
   /// [XPathResult] interface returns the numeric value of a result with
   /// [XPathResult.resultType] being `NUMBER_TYPE`.
-  external num get numberValue;
+  external double get numberValue;
 
   /// The read-only **`stringValue`** property of the
   /// [XPathResult] interface returns the string value of a result with

--- a/lib/src/dom/encrypted_media.dart
+++ b/lib/src/dom/encrypted_media.dart
@@ -171,7 +171,7 @@ extension type MediaKeySession._(JSObject _) implements EventTarget, JSObject {
   /// measured in milliseconds since January 1, 1970, UTC. This value may change
   /// during a
   /// session lifetime, such as when an action triggers the start of a window.
-  external num get expiration;
+  external double get expiration;
 
   /// The `MediaKeySession.closed` read-only property returns a
   /// `Promise` signaling when a [MediaKeySession] closes. This

--- a/lib/src/dom/event_timing.dart
+++ b/lib/src/dom/event_timing.dart
@@ -14,7 +14,6 @@ library;
 import 'dart:js_interop';
 
 import 'dom.dart';
-import 'hr_time.dart';
 import 'performance_timeline.dart';
 
 /// The `PerformanceEventTiming` interface of the Event Timing API provides
@@ -34,14 +33,14 @@ extension type PerformanceEventTiming._(JSObject _)
   /// The read-only **`processingStart`** property returns the time at which
   /// event dispatch started. This is when event handlers are about to be
   /// executed.
-  external DOMHighResTimeStamp get processingStart;
+  external double get processingStart;
 
   /// The read-only **`processingEnd`** property returns the time the last event
   /// handler finished executing.
   ///
   /// It's equal to [PerformanceEventTiming.processingStart] when there are no
   /// such event handlers.
-  external DOMHighResTimeStamp get processingEnd;
+  external double get processingEnd;
 
   /// The read-only **`cancelable`** property returns the associated event's
   /// [`cancelable`](https://developer.mozilla.org/en-US/docs/Web/API/Event/cancelable)

--- a/lib/src/dom/gamepad.dart
+++ b/lib/src/dom/gamepad.dart
@@ -14,7 +14,6 @@ library;
 import 'dart:js_interop';
 
 import 'dom.dart';
-import 'hr_time.dart';
 
 typedef GamepadMappingType = String;
 
@@ -84,7 +83,7 @@ extension type Gamepad._(JSObject _) implements JSObject {
   /// newer values will always be greater than or equal to older values.
   ///
   /// > **Note:** This property is not currently supported anywhere.
-  external DOMHighResTimeStamp get timestamp;
+  external double get timestamp;
 
   /// The **`Gamepad.mapping`** property of the
   /// [Gamepad] interface returns a string indicating whether the browser has
@@ -166,7 +165,7 @@ extension type GamepadButton._(JSObject _) implements JSObject {
   /// The values are normalized to the range `0.0` — `1.0`, with
   /// `0.0` representing a button that is not pressed, and 1.0 representing a
   /// button that is fully pressed.
-  external num get value;
+  external double get value;
 }
 
 /// The **`GamepadHapticActuator`** interface of the

--- a/lib/src/dom/generic_sensor.dart
+++ b/lib/src/dom/generic_sensor.dart
@@ -14,7 +14,6 @@ library;
 import 'dart:js_interop';
 
 import 'dom.dart';
-import 'hr_time.dart';
 import 'html.dart';
 import 'webidl.dart';
 
@@ -73,7 +72,7 @@ extension type Sensor._(JSObject _) implements EventTarget, JSObject {
   ///
   /// Because [Sensor] is a base class, `timestamp` may only be read
   /// from one of its derived classes.
-  external DOMHighResTimeStamp? get timestamp;
+  external double? get timestamp;
   external EventHandler get onreading;
   external set onreading(EventHandler value);
   external EventHandler get onactivate;
@@ -84,7 +83,7 @@ extension type Sensor._(JSObject _) implements EventTarget, JSObject {
 extension type SensorOptions._(JSObject _) implements JSObject {
   external factory SensorOptions({num frequency});
 
-  external num get frequency;
+  external double get frequency;
   external set frequency(num value);
 }
 

--- a/lib/src/dom/geolocation.dart
+++ b/lib/src/dom/geolocation.dart
@@ -113,12 +113,12 @@ extension type GeolocationCoordinates._(JSObject _) implements JSObject {
   /// interface is a strictly positive `double` representing the accuracy, with
   /// a 95% confidence level, of the [GeolocationCoordinates.latitude] and
   /// [GeolocationCoordinates.longitude] properties expressed in meters.
-  external num get accuracy;
+  external double get accuracy;
 
   /// The **`latitude`** read-only property of the [GeolocationCoordinates]
   /// interface is a `double` representing the latitude of the position in
   /// decimal degrees.
-  external num get latitude;
+  external double get latitude;
 
   /// The **`longitude`** read-only property of the [GeolocationCoordinates]
   /// interface is a number which represents the longitude of a geographical
@@ -127,7 +127,7 @@ extension type GeolocationCoordinates._(JSObject _) implements JSObject {
   /// measurement, the `GeolocationCoordinates` object is part of the
   /// [GeolocationPosition] interface, which is the object type returned by
   /// Geolocation API functions that obtain and return a geographical position.
-  external num get longitude;
+  external double get longitude;
 
   /// The **`altitude`** read-only property of the [GeolocationCoordinates]
   /// interface is a `double` representing the altitude of the position in
@@ -135,14 +135,14 @@ extension type GeolocationCoordinates._(JSObject _) implements JSObject {
   /// [WGS84](https://gis-lab.info/docs/nima-tr8350.2-wgs84fin.pdf) ellipsoid
   /// (which defines the nominal sea level surface). This value is `null` if the
   /// implementation cannot provide this data.
-  external num? get altitude;
+  external double? get altitude;
 
   /// The **`altitudeAccuracy`** read-only property of the
   /// [GeolocationCoordinates] interface is a strictly positive `double`
   /// representing the accuracy, with a 95% confidence level, of the `altitude`
   /// expressed in meters. This value is `null` if the implementation doesn't
   /// support measuring altitude.
-  external num? get altitudeAccuracy;
+  external double? get altitudeAccuracy;
 
   /// The **`heading`** read-only property of the [GeolocationCoordinates]
   /// interface is a `double` representing the direction in which the device is
@@ -152,13 +152,13 @@ extension type GeolocationCoordinates._(JSObject _) implements JSObject {
   /// degrees and west is `270` degrees). If [GeolocationCoordinates.speed] is
   /// `0`, `heading` is `NaN`. If the device is not able to provide heading
   /// information, this value is `null`.
-  external num? get heading;
+  external double? get heading;
 
   /// The **`speed`** read-only property of the [GeolocationCoordinates]
   /// interface is a `double` representing the velocity of the device in meters
   /// per second. This value is `null` if the implementation is not able to
   /// measure it.
-  external num? get speed;
+  external double? get speed;
 }
 
 /// The **`GeolocationPositionError`** interface represents the reason of an

--- a/lib/src/dom/geometry.dart
+++ b/lib/src/dom/geometry.dart
@@ -67,7 +67,7 @@ extension type DOMPointReadOnly._(JSObject _) implements JSObject {
   ///
   /// In general, positive values `x` mean to the right, and negative values of
   /// `x` means to the left, assuming no transforms have resulted in a reversal.
-  external num get x;
+  external double get x;
 
   /// The **`DOMPointReadOnly`** interface's
   /// **`y`** property holds the vertical coordinate, y, for a
@@ -78,7 +78,7 @@ extension type DOMPointReadOnly._(JSObject _) implements JSObject {
   ///
   /// In general, positive values of `y` mean downward, and negative values of
   /// `y` mean upward, assuming no transforms have resulted in a reversal.
-  external num get y;
+  external double get y;
 
   /// The **`DOMPointReadOnly`** interface's
   /// **`z`** property holds the depth coordinate, z, for a
@@ -90,7 +90,7 @@ extension type DOMPointReadOnly._(JSObject _) implements JSObject {
   /// In general, positive values of `z` mean toward the user (out from the
   /// screen), and negative values of `z` mean away from the user (into the
   /// screen), assuming no transforms have resulted in a reversal.
-  external num get z;
+  external double get z;
 
   /// The **`DOMPointReadOnly`** interface's
   /// **`w`** property holds the point's perspective value,
@@ -100,7 +100,7 @@ extension type DOMPointReadOnly._(JSObject _) implements JSObject {
   /// to change the value of this property, you should instead use the
   /// [DOMPoint]
   /// object.
-  external num get w;
+  external double get w;
 }
 
 /// A **`DOMPoint`** object represents a 2D or 3D point in a coordinate system;
@@ -135,7 +135,7 @@ extension type DOMPoint._(JSObject _) implements DOMPointReadOnly, JSObject {
   /// and negative values of `x` means to the left, barring any transforms that
   /// may
   /// have altered the orientation of the axes.
-  external num get x;
+  external double get x;
   external set x(num value);
 
   /// The **`DOMPoint`** interface's
@@ -144,7 +144,7 @@ extension type DOMPoint._(JSObject _) implements DOMPointReadOnly, JSObject {
   ///
   /// Unless transforms have been applied to alter the
   /// orientation, the value of `y` increases downward and decreases upward.
-  external num get y;
+  external double get y;
   external set y(num value);
 
   /// The **`DOMPoint`** interface's
@@ -155,13 +155,13 @@ extension type DOMPoint._(JSObject _) implements DOMPointReadOnly, JSObject {
   /// the plane of the screen, with positive values extending outward toward the
   /// user from the
   /// screen, and negative values receding into the distance behind the screen.
-  external num get z;
+  external double get z;
   external set z(num value);
 
   /// The **`DOMPoint`** interface's
   /// **`w`** property holds the point's perspective value, w, for a
   /// point in space.
-  external num get w;
+  external double get w;
   external set w(num value);
 }
 extension type DOMPointInit._(JSObject _) implements JSObject {
@@ -172,13 +172,13 @@ extension type DOMPointInit._(JSObject _) implements JSObject {
     num w,
   });
 
-  external num get x;
+  external double get x;
   external set x(num value);
-  external num get y;
+  external double get y;
   external set y(num value);
-  external num get z;
+  external double get z;
   external set z(num value);
-  external num get w;
+  external double get w;
   external set w(num value);
 }
 
@@ -202,39 +202,39 @@ extension type DOMRectReadOnly._(JSObject _) implements JSObject {
 
   /// The **`x`** read-only property of the **`DOMRectReadOnly`** interface
   /// represents the x coordinate of the `DOMRect`'s origin.
-  external num get x;
+  external double get x;
 
   /// The **`y`** read-only property of the **`DOMRectReadOnly`** interface
   /// represents the y coordinate of the `DOMRect`'s origin.
-  external num get y;
+  external double get y;
 
   /// The **`width`** read-only property of the **`DOMRectReadOnly`** interface
   /// represents the width of the `DOMRect`.
-  external num get width;
+  external double get width;
 
   /// The **`height`** read-only property of the **`DOMRectReadOnly`** interface
   /// represents the height of the `DOMRect`.
-  external num get height;
+  external double get height;
 
   /// The **`top`** read-only property of the **`DOMRectReadOnly`** interface
   /// returns the top coordinate value of the `DOMRect`. (Has the same value as
   /// `y`, or `y + height` if `height` is negative.)
-  external num get top;
+  external double get top;
 
   /// The **`right`** read-only property of the **`DOMRectReadOnly`** interface
   /// returns the right coordinate value of the `DOMRect`. (Has the same value
   /// as `x + width`, or `x` if `width` is negative.)
-  external num get right;
+  external double get right;
 
   /// The **`bottom`** read-only property of the **`DOMRectReadOnly`** interface
   /// returns the bottom coordinate value of the `DOMRect`. (Has the same value
   /// as `y + height`, or `y` if `height` is negative.)
-  external num get bottom;
+  external double get bottom;
 
   /// The **`left`** read-only property of the **`DOMRectReadOnly`** interface
   /// returns the left coordinate value of the `DOMRect`. (Has the same value as
   /// `x`, or `x + width` if `width` is negative.)
-  external num get left;
+  external double get left;
 }
 
 /// A **`DOMRect`** describes the size and position of a rectangle.
@@ -259,13 +259,13 @@ extension type DOMRect._(JSObject _) implements DOMRectReadOnly, JSObject {
   ]);
 
   external static DOMRect fromRect([DOMRectInit other]);
-  external num get x;
+  external double get x;
   external set x(num value);
-  external num get y;
+  external double get y;
   external set y(num value);
-  external num get width;
+  external double get width;
   external set width(num value);
-  external num get height;
+  external double get height;
   external set height(num value);
 }
 extension type DOMRectInit._(JSObject _) implements JSObject {
@@ -276,13 +276,13 @@ extension type DOMRectInit._(JSObject _) implements JSObject {
     num height,
   });
 
-  external num get x;
+  external double get x;
   external set x(num value);
-  external num get y;
+  external double get y;
   external set y(num value);
-  external num get width;
+  external double get width;
   external set width(num value);
-  external num get height;
+  external double get height;
   external set height(num value);
 }
 extension type DOMRectList._(JSObject _) implements JSObject {
@@ -414,28 +414,28 @@ extension type DOMMatrixReadOnly._(JSObject _) implements JSObject {
   external JSFloat32Array toFloat32Array();
   external JSFloat64Array toFloat64Array();
   external JSObject toJSON();
-  external num get a;
-  external num get b;
-  external num get c;
-  external num get d;
-  external num get e;
-  external num get f;
-  external num get m11;
-  external num get m12;
-  external num get m13;
-  external num get m14;
-  external num get m21;
-  external num get m22;
-  external num get m23;
-  external num get m24;
-  external num get m31;
-  external num get m32;
-  external num get m33;
-  external num get m34;
-  external num get m41;
-  external num get m42;
-  external num get m43;
-  external num get m44;
+  external double get a;
+  external double get b;
+  external double get c;
+  external double get d;
+  external double get e;
+  external double get f;
+  external double get m11;
+  external double get m12;
+  external double get m13;
+  external double get m14;
+  external double get m21;
+  external double get m22;
+  external double get m23;
+  external double get m24;
+  external double get m31;
+  external double get m32;
+  external double get m33;
+  external double get m34;
+  external double get m41;
+  external double get m42;
+  external double get m43;
+  external double get m44;
   external bool get is2D;
   external bool get isIdentity;
 }
@@ -500,49 +500,49 @@ extension type DOMMatrix._(JSObject _) implements DOMMatrixReadOnly, JSObject {
   external DOMMatrix skewYSelf([num sy]);
   external DOMMatrix invertSelf();
   external DOMMatrix setMatrixValue(String transformList);
-  external num get a;
+  external double get a;
   external set a(num value);
-  external num get b;
+  external double get b;
   external set b(num value);
-  external num get c;
+  external double get c;
   external set c(num value);
-  external num get d;
+  external double get d;
   external set d(num value);
-  external num get e;
+  external double get e;
   external set e(num value);
-  external num get f;
+  external double get f;
   external set f(num value);
-  external num get m11;
+  external double get m11;
   external set m11(num value);
-  external num get m12;
+  external double get m12;
   external set m12(num value);
-  external num get m13;
+  external double get m13;
   external set m13(num value);
-  external num get m14;
+  external double get m14;
   external set m14(num value);
-  external num get m21;
+  external double get m21;
   external set m21(num value);
-  external num get m22;
+  external double get m22;
   external set m22(num value);
-  external num get m23;
+  external double get m23;
   external set m23(num value);
-  external num get m24;
+  external double get m24;
   external set m24(num value);
-  external num get m31;
+  external double get m31;
   external set m31(num value);
-  external num get m32;
+  external double get m32;
   external set m32(num value);
-  external num get m33;
+  external double get m33;
   external set m33(num value);
-  external num get m34;
+  external double get m34;
   external set m34(num value);
-  external num get m41;
+  external double get m41;
   external set m41(num value);
-  external num get m42;
+  external double get m42;
   external set m42(num value);
-  external num get m43;
+  external double get m43;
   external set m43(num value);
-  external num get m44;
+  external double get m44;
   external set m44(num value);
 }
 extension type DOMMatrix2DInit._(JSObject _) implements JSObject {
@@ -561,29 +561,29 @@ extension type DOMMatrix2DInit._(JSObject _) implements JSObject {
     num m42,
   });
 
-  external num get a;
+  external double get a;
   external set a(num value);
-  external num get b;
+  external double get b;
   external set b(num value);
-  external num get c;
+  external double get c;
   external set c(num value);
-  external num get d;
+  external double get d;
   external set d(num value);
-  external num get e;
+  external double get e;
   external set e(num value);
-  external num get f;
+  external double get f;
   external set f(num value);
-  external num get m11;
+  external double get m11;
   external set m11(num value);
-  external num get m12;
+  external double get m12;
   external set m12(num value);
-  external num get m21;
+  external double get m21;
   external set m21(num value);
-  external num get m22;
+  external double get m22;
   external set m22(num value);
-  external num get m41;
+  external double get m41;
   external set m41(num value);
-  external num get m42;
+  external double get m42;
   external set m42(num value);
 }
 extension type DOMMatrixInit._(JSObject _)
@@ -614,25 +614,25 @@ extension type DOMMatrixInit._(JSObject _)
     bool is2D,
   });
 
-  external num get m13;
+  external double get m13;
   external set m13(num value);
-  external num get m14;
+  external double get m14;
   external set m14(num value);
-  external num get m23;
+  external double get m23;
   external set m23(num value);
-  external num get m24;
+  external double get m24;
   external set m24(num value);
-  external num get m31;
+  external double get m31;
   external set m31(num value);
-  external num get m32;
+  external double get m32;
   external set m32(num value);
-  external num get m33;
+  external double get m33;
   external set m33(num value);
-  external num get m34;
+  external double get m34;
   external set m34(num value);
-  external num get m43;
+  external double get m43;
   external set m43(num value);
-  external num get m44;
+  external double get m44;
   external set m44(num value);
   external bool get is2D;
   external set is2D(bool value);

--- a/lib/src/dom/gyroscope.dart
+++ b/lib/src/dom/gyroscope.dart
@@ -39,16 +39,16 @@ extension type Gyroscope._(JSObject _) implements Sensor, JSObject {
   /// The **`x`** read-only property of the
   /// [Gyroscope] interface returns a number specifying the
   /// angular velocity of the device along its x-axis.
-  external num? get x;
+  external double? get x;
 
   /// The **`y`** read-only property of the [Gyroscope] interface returns a
   /// number specifying the angular velocity of the device along its y-axis.
-  external num? get y;
+  external double? get y;
 
   /// The **`z`** read-only property of the
   /// [Gyroscope] interface returns a number specifying the
   /// angular velocity of the device along its z-axis.
-  external num? get z;
+  external double? get z;
 }
 extension type GyroscopeSensorOptions._(JSObject _)
     implements SensorOptions, JSObject {

--- a/lib/src/dom/hr_time.dart
+++ b/lib/src/dom/hr_time.dart
@@ -41,7 +41,7 @@ extension type Performance._(JSObject _) implements EventTarget, JSObject {
   /// [Performance.timeOrigin] (the time when navigation has started in window
   /// contexts, or the time when the worker is run in [Worker] and
   /// [ServiceWorker] contexts).
-  external DOMHighResTimeStamp now();
+  external double now();
 
   /// The **`toJSON()`** method of the [Performance] interface is a ; it returns
   /// a JSON representation of the [Performance] object.
@@ -207,7 +207,7 @@ extension type Performance._(JSObject _) implements EventTarget, JSObject {
   /// > [monotonic clock](https://w3c.github.io/hr-time/#dfn-monotonic-clock)
   /// > which current time never decreases and which isn't subject to these
   /// > adjustments.
-  external DOMHighResTimeStamp get timeOrigin;
+  external double get timeOrigin;
 
   /// The legacy
   /// **`Performance.timing`** read-only

--- a/lib/src/dom/html.dart
+++ b/lib/src/dom/html.dart
@@ -3467,13 +3467,13 @@ extension type HTMLMediaElement._(JSObject _) implements HTMLElement, JSObject {
   ///
   /// Changing the value of `currentTime` seeks the media to
   /// the new time.
-  external num get currentTime;
+  external double get currentTime;
   external set currentTime(num value);
 
   /// The _read-only_ [HTMLMediaElement]
   /// property **`duration`** indicates the length of the element's
   /// media in seconds.
-  external num get duration;
+  external double get duration;
 
   /// The read-only **`HTMLMediaElement.paused`** property
   /// tells whether the media element is paused.
@@ -3481,7 +3481,7 @@ extension type HTMLMediaElement._(JSObject _) implements HTMLElement, JSObject {
 
   /// The **`HTMLMediaElement.defaultPlaybackRate`** property indicates the
   /// default playback rate for the media.
-  external num get defaultPlaybackRate;
+  external double get defaultPlaybackRate;
   external set defaultPlaybackRate(num value);
 
   /// The **`HTMLMediaElement.playbackRate`** property sets the rate at which
@@ -3499,7 +3499,7 @@ extension type HTMLMediaElement._(JSObject _) implements HTMLElement, JSObject {
   ///
   /// The pitch of the audio is corrected by default. You can disable pitch
   /// correction using the [HTMLMediaElement.preservesPitch] property.
-  external num get playbackRate;
+  external double get playbackRate;
   external set playbackRate(num value);
 
   /// The **`HTMLMediaElement.preservesPitch`** property determines whether or
@@ -3566,7 +3566,7 @@ extension type HTMLMediaElement._(JSObject _) implements HTMLElement, JSObject {
 
   /// The **`HTMLMediaElement.volume`** property sets the volume at
   /// which the media will be played.
-  external num get volume;
+  external double get volume;
   external set volume(num value);
 
   /// The **`HTMLMediaElement.muted`** property indicates whether the media
@@ -4111,12 +4111,12 @@ extension type TextTrackCue._(JSObject _) implements EventTarget, JSObject {
 
   /// The **`startTime`** property of the [TextTrackCue] interface returns and
   /// sets the start time of the cue.
-  external num get startTime;
+  external double get startTime;
   external set startTime(num value);
 
   /// The **`endTime`** property of the [TextTrackCue] interface returns and
   /// sets the end time of the cue.
-  external num get endTime;
+  external double get endTime;
   external set endTime(num value);
 
   /// The **`pauseOnExit`** property of the [TextTrackCue] interface returns or
@@ -4147,11 +4147,11 @@ extension type TextTrackCue._(JSObject _) implements EventTarget, JSObject {
 extension type TimeRanges._(JSObject _) implements JSObject {
   /// The **`start()`** method of the [TimeRanges] interface returns the time
   /// offset at which a specified time range begins.
-  external num start(int index);
+  external double start(int index);
 
   /// The **`end()`** method of the [TimeRanges] interface returns the time
   /// offset at which a specified time range ends.
-  external num end(int index);
+  external double end(int index);
 
   /// The **`TimeRanges.length`** read-only property returns the
   /// number of ranges in the object.
@@ -5659,7 +5659,7 @@ extension type HTMLInputElement._(JSObject _) implements HTMLElement, JSObject {
   external set value(String value);
   external JSObject? get valueAsDate;
   external set valueAsDate(JSObject? value);
-  external num get valueAsNumber;
+  external double get valueAsNumber;
   external set valueAsNumber(num value);
   external int get width;
   external set width(int value);
@@ -6142,17 +6142,17 @@ extension type HTMLProgressElement._(JSObject _)
 
   /// The **`value`** property of the [HTMLProgressElement] interface represents
   /// the current progress of the `progress` element.
-  external num get value;
+  external double get value;
   external set value(num value);
 
   /// The **`max`** property of the [HTMLProgressElement] interface represents
   /// the upper bound of the `progress` element's range.
-  external num get max;
+  external double get max;
   external set max(num value);
 
   /// The **`position`** read-only property of the [HTMLProgressElement]
   /// interface returns current progress of the `progress` element.
-  external num get position;
+  external double get position;
 
   /// The **`HTMLProgressElement.labels`** read-only property returns
   /// a [NodeList] of the `label` elements associated with the
@@ -6173,17 +6173,17 @@ extension type HTMLMeterElement._(JSObject _) implements HTMLElement, JSObject {
   /// Creates an [HTMLMeterElement] using the tag 'meter'.
   HTMLMeterElement() : _ = document.createElement('meter');
 
-  external num get value;
+  external double get value;
   external set value(num value);
-  external num get min;
+  external double get min;
   external set min(num value);
-  external num get max;
+  external double get max;
   external set max(num value);
-  external num get low;
+  external double get low;
   external set low(num value);
-  external num get high;
+  external double get high;
   external set high(num value);
-  external num get optimum;
+  external double get optimum;
   external set optimum(num value);
 
   /// The **`HTMLMeterElement.labels`** read-only property returns a
@@ -7681,7 +7681,7 @@ extension type CanvasRenderingContext2D._(JSObject _) implements JSObject {
   /// > [Applying styles and color](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors)
   /// > in the
   /// > [Canvas Tutorial](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial).
-  external num get globalAlpha;
+  external double get globalAlpha;
   external set globalAlpha(num value);
 
   /// The
@@ -7769,7 +7769,7 @@ extension type CanvasRenderingContext2D._(JSObject _) implements JSObject {
   /// > [CanvasRenderingContext2D.shadowBlur], `shadowOffsetX`, or
   /// > [CanvasRenderingContext2D.shadowOffsetY] properties must
   /// > be non-zero, as well.
-  external num get shadowOffsetX;
+  external double get shadowOffsetX;
   external set shadowOffsetX(num value);
 
   /// The
@@ -7785,7 +7785,7 @@ extension type CanvasRenderingContext2D._(JSObject _) implements JSObject {
   /// > [CanvasRenderingContext2D.shadowOffsetX], or `shadowOffsetY` properties
   /// > must be non-zero, as
   /// > well.
-  external num get shadowOffsetY;
+  external double get shadowOffsetY;
   external set shadowOffsetY(num value);
 
   /// The
@@ -7800,7 +7800,7 @@ extension type CanvasRenderingContext2D._(JSObject _) implements JSObject {
   /// > [CanvasRenderingContext2D.shadowOffsetX], or
   /// > [CanvasRenderingContext2D.shadowOffsetY] properties must
   /// > be non-zero, as well.
-  external num get shadowBlur;
+  external double get shadowBlur;
   external set shadowBlur(num value);
 
   /// The
@@ -7838,7 +7838,7 @@ extension type CanvasRenderingContext2D._(JSObject _) implements JSObject {
   /// > [CanvasRenderingContext2D.stroke],
   /// > [CanvasRenderingContext2D.strokeRect],
   /// > and [CanvasRenderingContext2D.strokeText] methods.
-  external num get lineWidth;
+  external double get lineWidth;
   external set lineWidth(num value);
 
   /// The
@@ -7881,7 +7881,7 @@ extension type CanvasRenderingContext2D._(JSObject _) implements JSObject {
   /// > [Applying styles and color](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors)
   /// > in the
   /// > [Canvas tutorial](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial).
-  external num get miterLimit;
+  external double get miterLimit;
   external set miterLimit(num value);
 
   /// The
@@ -7890,7 +7890,7 @@ extension type CanvasRenderingContext2D._(JSObject _) implements JSObject {
   ///
   /// > **Note:** Lines are drawn by calling the
   /// > [CanvasRenderingContext2D.stroke] method.
-  external num get lineDashOffset;
+  external double get lineDashOffset;
   external set lineDashOffset(num value);
 
   /// The **`CanvasRenderingContext2D.font`** property of the Canvas 2D API
@@ -8053,7 +8053,7 @@ extension type CanvasPattern._(JSObject _) implements JSObject {
 extension type TextMetrics._(JSObject _) implements JSObject {
   /// The read-only **`width`** property of the [TextMetrics] interface contains
   /// the text's advance width (the width of that inline box) in CSS pixels.
-  external num get width;
+  external double get width;
 
   /// The read-only `actualBoundingBoxLeft` property of the [TextMetrics]
   /// interface is a `double` giving the distance parallel to the baseline from
@@ -8061,70 +8061,70 @@ extension type TextMetrics._(JSObject _) implements JSObject {
   /// property to the left side of the bounding rectangle of the given text, in
   /// CSS pixels; positive numbers indicating a distance going left from the
   /// given alignment point.
-  external num get actualBoundingBoxLeft;
+  external double get actualBoundingBoxLeft;
 
   /// The read-only `actualBoundingBoxRight` property of the [TextMetrics]
   /// interface is a `double` giving the distance parallel to the baseline from
   /// the alignment point given by the [CanvasRenderingContext2D.textAlign]
   /// property to the right side of the bounding rectangle of the given text, in
   /// CSS pixels.
-  external num get actualBoundingBoxRight;
+  external double get actualBoundingBoxRight;
 
   /// The read-only `fontBoundingBoxAscent` property of the [TextMetrics]
   /// interface returns the distance from the horizontal line indicated by the
   /// [CanvasRenderingContext2D.textBaseline] attribute, to the top of the
   /// highest bounding rectangle of all the fonts used to render the text, in
   /// CSS pixels.
-  external num get fontBoundingBoxAscent;
+  external double get fontBoundingBoxAscent;
 
   /// The read-only `fontBoundingBoxDescent` property of the [TextMetrics]
   /// interface returns the distance from the horizontal line indicated by the
   /// [CanvasRenderingContext2D.textBaseline] attribute to the bottom of the
   /// bounding rectangle of all the fonts used to render the text, in CSS
   /// pixels.
-  external num get fontBoundingBoxDescent;
+  external double get fontBoundingBoxDescent;
 
   /// The read-only **`actualBoundingBoxAscent`** property of the [TextMetrics]
   /// interface is a `double` giving the distance from the horizontal line
   /// indicated by the [CanvasRenderingContext2D.textBaseline] attribute to the
   /// top of the bounding rectangle used to render the text, in CSS pixels.
-  external num get actualBoundingBoxAscent;
+  external double get actualBoundingBoxAscent;
 
   /// The read-only `actualBoundingBoxDescent` property of the [TextMetrics]
   /// interface is a `double` giving the distance from the horizontal line
   /// indicated by the [CanvasRenderingContext2D.textBaseline] attribute to the
   /// bottom of the bounding rectangle used to render the text, in CSS pixels.
-  external num get actualBoundingBoxDescent;
+  external double get actualBoundingBoxDescent;
 
   /// The read-only `emHeightAscent` property of the [TextMetrics] interface
   /// returns the distance from the horizontal line indicated by the
   /// [CanvasRenderingContext2D.textBaseline] property to the top of the _em_
   /// square in the line box, in CSS pixels.
-  external num get emHeightAscent;
+  external double get emHeightAscent;
 
   /// The read-only `emHeightDescent` property of the [TextMetrics] interface
   /// returns the distance from the horizontal line indicated by the
   /// [CanvasRenderingContext2D.textBaseline] property to the bottom of the _em_
   /// square in the line box, in CSS pixels.
-  external num get emHeightDescent;
+  external double get emHeightDescent;
 
   /// The read-only `hangingBaseline` property of the [TextMetrics] interface is
   /// a `double` giving the distance from the horizontal line indicated by the
   /// [CanvasRenderingContext2D.textBaseline] property to the hanging baseline
   /// of the line box, in CSS pixels.
-  external num get hangingBaseline;
+  external double get hangingBaseline;
 
   /// The read-only `alphabeticBaseline` property of the [TextMetrics] interface
   /// is a `double` giving the distance from the horizontal line indicated by
   /// the [CanvasRenderingContext2D.textBaseline] property to the alphabetic
   /// baseline of the line box, in CSS pixels.
-  external num get alphabeticBaseline;
+  external double get alphabeticBaseline;
 
   /// The read-only `ideographicBaseline` property of the [TextMetrics]
   /// interface is a `double` giving the distance from the horizontal line
   /// indicated by the [CanvasRenderingContext2D.textBaseline] property to the
   /// ideographic baseline of the line box, in CSS pixels.
-  external num get ideographicBaseline;
+  external double get ideographicBaseline;
 }
 extension type ImageDataSettings._(JSObject _) implements JSObject {
   external factory ImageDataSettings({PredefinedColorSpace colorSpace});
@@ -8301,7 +8301,7 @@ extension type ImageEncodeOptions._(JSObject _) implements JSObject {
 
   external String get type;
   external set type(String value);
-  external num get quality;
+  external double get quality;
   external set quality(num value);
 }
 
@@ -8607,7 +8607,7 @@ extension type OffscreenCanvasRenderingContext2D._(JSObject _)
     bool counterclockwise,
   ]);
   external OffscreenCanvas get canvas;
-  external num get globalAlpha;
+  external double get globalAlpha;
   external set globalAlpha(num value);
   external String get globalCompositeOperation;
   external set globalCompositeOperation(String value);
@@ -8619,25 +8619,25 @@ extension type OffscreenCanvasRenderingContext2D._(JSObject _)
   external set strokeStyle(JSAny value);
   external JSAny get fillStyle;
   external set fillStyle(JSAny value);
-  external num get shadowOffsetX;
+  external double get shadowOffsetX;
   external set shadowOffsetX(num value);
-  external num get shadowOffsetY;
+  external double get shadowOffsetY;
   external set shadowOffsetY(num value);
-  external num get shadowBlur;
+  external double get shadowBlur;
   external set shadowBlur(num value);
   external String get shadowColor;
   external set shadowColor(String value);
   external String get filter;
   external set filter(String value);
-  external num get lineWidth;
+  external double get lineWidth;
   external set lineWidth(num value);
   external CanvasLineCap get lineCap;
   external set lineCap(CanvasLineCap value);
   external CanvasLineJoin get lineJoin;
   external set lineJoin(CanvasLineJoin value);
-  external num get miterLimit;
+  external double get miterLimit;
   external set miterLimit(num value);
-  external num get lineDashOffset;
+  external double get lineDashOffset;
   external set lineDashOffset(num value);
   external String get font;
   external set font(String value);
@@ -10214,7 +10214,7 @@ extension type Window._(JSObject _) implements EventTarget, JSObject {
   /// of pixels the
   /// document is scrolled vertically from the [Window.scrollY]
   /// property.
-  external num get scrollX;
+  external double get scrollX;
 
   /// The read-only **`scrollY`** property
   /// of the [Window] interface returns the number of pixels that the document
@@ -10225,7 +10225,7 @@ extension type Window._(JSObject _) implements EventTarget, JSObject {
   /// the number of
   /// pixels the document is scrolled horizontally from the [Window.scrollX]
   /// property.
-  external num get scrollY;
+  external double get scrollY;
 
   /// The **`Window.screenX`** read-only property returns the
   /// horizontal distance, in CSS pixels, of the left border of the user's
@@ -10298,7 +10298,7 @@ extension type Window._(JSObject _) implements EventTarget, JSObject {
   /// value of `devicePixelRatio` changes (which can happen, for example, if the
   /// user drags the window to a display with a different pixel density). See
   /// [the example below](#monitoring_screen_resolution_or_zoom_level_changes).
-  external num get devicePixelRatio;
+  external double get devicePixelRatio;
 
   /// The read-only [Window] property **`event`** returns the [Event] which is
   /// currently being handled by the site's code. Outside the context of an
@@ -11826,7 +11826,7 @@ extension type Navigator._(JSObject _) implements JSObject {
   /// clamped within lower and upper bounds to protect the privacy of owners of
   /// very low-memory or
   /// high-memory devices.
-  external num get deviceMemory;
+  external double get deviceMemory;
 
   /// The value of the **`Navigator.appCodeName`** property is
   /// always "`Mozilla`", in any browser. This property is kept only for
@@ -13007,7 +13007,7 @@ extension type WorkerNavigator._(JSObject _) implements JSObject {
   /// clamped within lower and upper bounds to protect the privacy of owners of
   /// very low-memory or
   /// high-memory devices.
-  external num get deviceMemory;
+  external double get deviceMemory;
 
   /// The value of the **`WorkerNavigator.appCodeName`** property is
   /// always "`Mozilla`", in any browser. This property is kept only for

--- a/lib/src/dom/image_capture.dart
+++ b/lib/src/dom/image_capture.dart
@@ -21,11 +21,11 @@ extension type MediaSettingsRange._(JSObject _) implements JSObject {
     num step,
   });
 
-  external num get max;
+  external double get max;
   external set max(num value);
-  external num get min;
+  external double get min;
   external set min(num value);
-  external num get step;
+  external double get step;
   external set step(num value);
 }
 extension type ConstrainPoint2DParameters._(JSObject _) implements JSObject {
@@ -45,8 +45,8 @@ extension type Point2D._(JSObject _) implements JSObject {
     num y,
   });
 
-  external num get x;
+  external double get x;
   external set x(num value);
-  external num get y;
+  external double get y;
   external set y(num value);
 }

--- a/lib/src/dom/intersection_observer.dart
+++ b/lib/src/dom/intersection_observer.dart
@@ -15,7 +15,6 @@ import 'dart:js_interop';
 
 import 'dom.dart';
 import 'geometry.dart';
-import 'hr_time.dart';
 
 typedef IntersectionObserverCallback = JSFunction;
 
@@ -166,7 +165,7 @@ extension type IntersectionObserverEntry._(JSObject _) implements JSObject {
   /// read-only **`time`** property is a
   /// [DOMHighResTimeStamp] that indicates the time at which the intersection
   /// change occurred relative to the time at which the document was created.
-  external DOMHighResTimeStamp get time;
+  external double get time;
 
   /// The [IntersectionObserverEntry] interface's
   /// read-only **`rootBounds`** property is a
@@ -204,7 +203,7 @@ extension type IntersectionObserverEntry._(JSObject _) implements JSObject {
   /// of the target element is currently visible within the root's intersection
   /// ratio, as a
   /// value between 0.0 and 1.0.
-  external num get intersectionRatio;
+  external double get intersectionRatio;
 
   /// The [IntersectionObserverEntry] interface's
   /// read-only **`target`** property indicates which targeted

--- a/lib/src/dom/largest_contentful_paint.dart
+++ b/lib/src/dom/largest_contentful_paint.dart
@@ -14,7 +14,6 @@ library;
 import 'dart:js_interop';
 
 import 'dom.dart';
-import 'hr_time.dart';
 import 'performance_timeline.dart';
 
 /// The `LargestContentfulPaint` interface provides timing information about the
@@ -32,11 +31,11 @@ extension type LargestContentfulPaint._(JSObject _)
 
   /// The **`renderTime`** read-only property of the [LargestContentfulPaint]
   /// interface represents the time that the element was rendered to the screen.
-  external DOMHighResTimeStamp get renderTime;
+  external double get renderTime;
 
   /// The **`loadTime`** read-only property of the [LargestContentfulPaint]
   /// interface returns the time that the element was loaded.
-  external DOMHighResTimeStamp get loadTime;
+  external double get loadTime;
 
   /// The **`size`** read-only property of the [LargestContentfulPaint]
   /// interface returns the intrinsic size of the element that is the largest

--- a/lib/src/dom/media_capabilities.dart
+++ b/lib/src/dom/media_capabilities.dart
@@ -80,7 +80,7 @@ extension type VideoConfiguration._(JSObject _) implements JSObject {
   external set height(int value);
   external int get bitrate;
   external set bitrate(int value);
-  external num get framerate;
+  external double get framerate;
   external set framerate(num value);
   external bool get hasAlphaChannel;
   external set hasAlphaChannel(bool value);

--- a/lib/src/dom/media_playback_quality.dart
+++ b/lib/src/dom/media_playback_quality.dart
@@ -13,8 +13,6 @@ library;
 
 import 'dart:js_interop';
 
-import 'hr_time.dart';
-
 /// A **`VideoPlaybackQuality`** object is returned by the
 /// [HTMLVideoElement.getVideoPlaybackQuality] method and contains metrics that
 /// can be used to determine the playback quality of a video.
@@ -27,7 +25,7 @@ extension type VideoPlaybackQuality._(JSObject _) implements JSObject {
   /// The read-only **`creationTime`** property on the
   /// [VideoPlaybackQuality] interface reports the number of milliseconds since
   /// the browsing context was created this quality sample was recorded.
-  external DOMHighResTimeStamp get creationTime;
+  external double get creationTime;
 
   /// The read-only **`droppedVideoFrames`**
   /// property of the [VideoPlaybackQuality] interface returns the number of

--- a/lib/src/dom/media_source.dart
+++ b/lib/src/dom/media_source.dart
@@ -91,7 +91,7 @@ extension type MediaSource._(JSObject _) implements EventTarget, JSObject {
 
   /// The **`duration`** property of the [MediaSource]
   /// interface gets and sets the duration of the current media being presented.
-  external num get duration;
+  external double get duration;
   external set duration(num value);
   external EventHandler get onsourceopen;
   external set onsourceopen(EventHandler value);
@@ -197,7 +197,7 @@ extension type SourceBuffer._(JSObject _) implements EventTarget, JSObject {
   /// media segments that are appended to the `SourceBuffer`.
   ///
   /// The initial value of `timestampOffset` is 0.
-  external num get timestampOffset;
+  external double get timestampOffset;
   external set timestampOffset(num value);
 
   /// The **`audioTracks`** read-only property of the
@@ -221,7 +221,7 @@ extension type SourceBuffer._(JSObject _) implements EventTarget, JSObject {
   ///
   /// The default value of `appendWindowStart` is the presentation start time,
   /// which is the beginning time of the playable media.
-  external num get appendWindowStart;
+  external double get appendWindowStart;
   external set appendWindowStart(num value);
 
   /// The **`appendWindowEnd`** property of the
@@ -234,7 +234,7 @@ extension type SourceBuffer._(JSObject _) implements EventTarget, JSObject {
   /// appended, whereas those outside the range will be filtered out.
   ///
   /// The default value of `appendWindowEnd` is positive infinity.
-  external num get appendWindowEnd;
+  external double get appendWindowEnd;
   external set appendWindowEnd(num value);
   external EventHandler get onupdatestart;
   external set onupdatestart(EventHandler value);

--- a/lib/src/dom/mediacapture_streams.dart
+++ b/lib/src/dom/mediacapture_streams.dart
@@ -1018,7 +1018,7 @@ extension type MediaTrackSettings._(JSObject _) implements JSObject {
   /// call to [MediaDevices.getSupportedConstraints]. However, typically this
   /// is unnecessary since browsers will ignore any constraints they're
   /// unfamiliar with.
-  external num get aspectRatio;
+  external double get aspectRatio;
   external set aspectRatio(num value);
 
   /// The [MediaTrackSettings] dictionary's
@@ -1038,7 +1038,7 @@ extension type MediaTrackSettings._(JSObject _) implements JSObject {
   /// call to [MediaDevices.getSupportedConstraints]. However, typically this
   /// is unnecessary since browsers will ignore any constraints they're
   /// unfamiliar with.
-  external num get frameRate;
+  external double get frameRate;
   external set frameRate(num value);
 
   /// The [MediaTrackSettings] dictionary's
@@ -1225,7 +1225,7 @@ extension type MediaTrackSettings._(JSObject _) implements JSObject {
   /// [WebRTC](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API)
   /// [RTCPeerConnection]
   /// will never include this property.
-  external num get latency;
+  external double get latency;
   external set latency(num value);
 
   /// The [MediaTrackSettings] dictionary's
@@ -1306,29 +1306,29 @@ extension type MediaTrackSettings._(JSObject _) implements JSObject {
   external set focusMode(String value);
   external JSArray<Point2D> get pointsOfInterest;
   external set pointsOfInterest(JSArray<Point2D> value);
-  external num get exposureCompensation;
+  external double get exposureCompensation;
   external set exposureCompensation(num value);
-  external num get exposureTime;
+  external double get exposureTime;
   external set exposureTime(num value);
-  external num get colorTemperature;
+  external double get colorTemperature;
   external set colorTemperature(num value);
-  external num get iso;
+  external double get iso;
   external set iso(num value);
-  external num get brightness;
+  external double get brightness;
   external set brightness(num value);
-  external num get contrast;
+  external double get contrast;
   external set contrast(num value);
-  external num get saturation;
+  external double get saturation;
   external set saturation(num value);
-  external num get sharpness;
+  external double get sharpness;
   external set sharpness(num value);
-  external num get focusDistance;
+  external double get focusDistance;
   external set focusDistance(num value);
-  external num get pan;
+  external double get pan;
   external set pan(num value);
-  external num get tilt;
+  external double get tilt;
   external set tilt(num value);
-  external num get zoom;
+  external double get zoom;
   external set zoom(num value);
   external bool get torch;
   external set torch(bool value);
@@ -1599,9 +1599,9 @@ extension type DoubleRange._(JSObject _) implements JSObject {
     num min,
   });
 
-  external num get max;
+  external double get max;
   external set max(num value);
-  external num get min;
+  external double get min;
   external set min(num value);
 }
 extension type ConstrainDoubleRange._(JSObject _)
@@ -1613,9 +1613,9 @@ extension type ConstrainDoubleRange._(JSObject _)
     num ideal,
   });
 
-  external num get exact;
+  external double get exact;
   external set exact(num value);
-  external num get ideal;
+  external double get ideal;
   external set ideal(num value);
 }
 extension type ULongRange._(JSObject _) implements JSObject {

--- a/lib/src/dom/mediasession.dart
+++ b/lib/src/dom/mediasession.dart
@@ -145,10 +145,10 @@ extension type MediaPositionState._(JSObject _) implements JSObject {
     num position,
   });
 
-  external num get duration;
+  external double get duration;
   external set duration(num value);
-  external num get playbackRate;
+  external double get playbackRate;
   external set playbackRate(num value);
-  external num get position;
+  external double get position;
   external set position(num value);
 }

--- a/lib/src/dom/mediastream_recording.dart
+++ b/lib/src/dom/mediastream_recording.dart
@@ -220,7 +220,7 @@ extension type MediaRecorderOptions._(JSObject _) implements JSObject {
   external set bitsPerSecond(int value);
   external BitrateMode get audioBitrateMode;
   external set audioBitrateMode(BitrateMode value);
-  external DOMHighResTimeStamp get videoKeyFrameIntervalDuration;
+  external double get videoKeyFrameIntervalDuration;
   external set videoKeyFrameIntervalDuration(DOMHighResTimeStamp value);
   external int get videoKeyFrameIntervalCount;
   external set videoKeyFrameIntervalCount(int value);
@@ -252,7 +252,7 @@ extension type BlobEvent._(JSObject _) implements Event, JSObject {
   ///
   /// Note that the `timecode` in the first produced `BlobEvent` does not need
   /// to be zero.
-  external DOMHighResTimeStamp get timecode;
+  external double get timecode;
 }
 extension type BlobEventInit._(JSObject _) implements JSObject {
   external factory BlobEventInit({
@@ -262,6 +262,6 @@ extension type BlobEventInit._(JSObject _) implements JSObject {
 
   external Blob get data;
   external set data(Blob value);
-  external DOMHighResTimeStamp get timecode;
+  external double get timecode;
   external set timecode(DOMHighResTimeStamp value);
 }

--- a/lib/src/dom/navigation_timing.dart
+++ b/lib/src/dom/navigation_timing.dart
@@ -13,7 +13,6 @@ library;
 
 import 'dart:js_interop';
 
-import 'hr_time.dart';
 import 'resource_timing.dart';
 
 typedef NavigationTimingType = String;
@@ -49,14 +48,14 @@ extension type PerformanceNavigationTiming._(JSObject _)
   /// document's
   /// [`unload`](https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event)
   /// event handler starts.
-  external DOMHighResTimeStamp get unloadEventStart;
+  external double get unloadEventStart;
 
   /// The **`unloadEventEnd`** read-only property returns a
   /// [DOMHighResTimeStamp] representing the time immediately after the current
   /// document's
   /// [`unload`](https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event)
   /// event handler completes.
-  external DOMHighResTimeStamp get unloadEventEnd;
+  external double get unloadEventEnd;
 
   /// The **`domInteractive`** read-only property returns a
   /// [DOMHighResTimeStamp] representing the time immediately before the user
@@ -77,7 +76,7 @@ extension type PerformanceNavigationTiming._(JSObject _)
   /// event (see
   /// [`domContentLoadedEventStart`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming/domContentLoadedEventStart)
   /// for the timestamp) will fire immediately after `domInteractive`.
-  external DOMHighResTimeStamp get domInteractive;
+  external double get domInteractive;
 
   /// The **`domContentLoadedEventStart`** read-only property returns a
   /// [DOMHighResTimeStamp] representing the time immediately before the current
@@ -90,7 +89,7 @@ extension type PerformanceNavigationTiming._(JSObject _)
   /// `domContentLoadedEventStart` and the
   /// [`domContentLoadedEventEnd`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming/domContentLoadedEventEnd)
   /// properties to calculate how long this takes to run.
-  external DOMHighResTimeStamp get domContentLoadedEventStart;
+  external double get domContentLoadedEventStart;
 
   /// The **`domContentLoadedEventEnd`** read-only property returns a
   /// [DOMHighResTimeStamp] representing the time immediately after the current
@@ -103,7 +102,7 @@ extension type PerformanceNavigationTiming._(JSObject _)
   /// `domContentLoadedEventEnd` and the
   /// [`domContentLoadedEventStart`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming/domContentLoadedEventStart)
   /// properties to calculate how long this takes to run.
-  external DOMHighResTimeStamp get domContentLoadedEventEnd;
+  external double get domContentLoadedEventEnd;
 
   /// The **`domComplete`** read-only property returns a [DOMHighResTimeStamp]
   /// representing the time immediately before the user agent sets the
@@ -115,20 +114,20 @@ extension type PerformanceNavigationTiming._(JSObject _)
   /// to this property and refers to the state in which the document and all
   /// sub-resources have finished loading. The state also indicates that the
   /// [Window.load_event] event is about to fire.
-  external DOMHighResTimeStamp get domComplete;
+  external double get domComplete;
 
   /// The **`loadEventStart`** read-only property returns a
   /// [DOMHighResTimeStamp] representing the time immediately before the current
   /// document's
   /// [`load`](https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event)
   /// event handler starts.
-  external DOMHighResTimeStamp get loadEventStart;
+  external double get loadEventStart;
 
   /// The **`loadEventEnd`** read-only property returns a [DOMHighResTimeStamp]
   /// representing the time immediately after the current document's
   /// [`load`](https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event)
   /// event handler completes.
-  external DOMHighResTimeStamp get loadEventEnd;
+  external double get loadEventEnd;
 
   /// The **`type`** read-only property returns the type of navigation.
   ///

--- a/lib/src/dom/orientation_event.dart
+++ b/lib/src/dom/orientation_event.dart
@@ -36,7 +36,7 @@ extension type DeviceOrientationEvent._(JSObject _) implements Event, JSObject {
   /// See
   /// [Orientation and motion data explained](https://developer.mozilla.org/en-US/docs/Web/API/Device_orientation_events/Orientation_and_motion_data_explained)
   /// for details.
-  external num? get alpha;
+  external double? get alpha;
 
   /// The **`beta`** read-only property of the [DeviceOrientationEvent]
   /// interface returns the rotation of the device around the X axis; that is,
@@ -46,7 +46,7 @@ extension type DeviceOrientationEvent._(JSObject _) implements Event, JSObject {
   /// See
   /// [Orientation and motion data explained](https://developer.mozilla.org/en-US/docs/Web/API/Device_orientation_events/Orientation_and_motion_data_explained)
   /// for details.
-  external num? get beta;
+  external double? get beta;
 
   /// The **`gamma`** read-only property of the [DeviceOrientationEvent]
   /// interface returns the rotation of the device around the Y axis; that is,
@@ -56,7 +56,7 @@ extension type DeviceOrientationEvent._(JSObject _) implements Event, JSObject {
   /// See
   /// [Orientation and motion data explained](https://developer.mozilla.org/en-US/docs/Web/API/Device_orientation_events/Orientation_and_motion_data_explained)
   /// for details.
-  external num? get gamma;
+  external double? get gamma;
 
   /// The **`absolute`** read-only property of the [DeviceOrientationEvent]
   /// interface indicates whether or not the device is providing orientation
@@ -81,11 +81,11 @@ extension type DeviceOrientationEventInit._(JSObject _)
     bool absolute,
   });
 
-  external num? get alpha;
+  external double? get alpha;
   external set alpha(num? value);
-  external num? get beta;
+  external double? get beta;
   external set beta(num? value);
-  external num? get gamma;
+  external double? get gamma;
   external set gamma(num? value);
   external bool get absolute;
   external set absolute(bool value);
@@ -105,21 +105,21 @@ extension type DeviceMotionEventAcceleration._(JSObject _) implements JSObject {
   /// axis in a
   /// [`DeviceMotionEventAcceleration`](https://developer.mozilla.org/en-US/docs/Web/API/DeviceMotionEventAcceleration)
   /// object.
-  external num? get x;
+  external double? get x;
 
   /// The **`y`** read-only property of the [DeviceMotionEventAcceleration]
   /// interface indicates the amount of acceleration that occurred along the Y
   /// axis in a
   /// [`DeviceMotionEventAcceleration`](https://developer.mozilla.org/en-US/docs/Web/API/DeviceMotionEventAcceleration)
   /// object.
-  external num? get y;
+  external double? get y;
 
   /// The **`z`** read-only property of the [DeviceMotionEventAcceleration]
   /// interface indicates the amount of acceleration that occurred along the Z
   /// axis in a
   /// [`DeviceMotionEventAcceleration`](https://developer.mozilla.org/en-US/docs/Web/API/DeviceMotionEventAcceleration)
   /// object.
-  external num? get z;
+  external double? get z;
 }
 
 /// A **`DeviceMotionEventRotationRate`** interface of the
@@ -134,17 +134,17 @@ extension type DeviceMotionEventRotationRate._(JSObject _) implements JSObject {
   /// The **`alpha`** read-only property of the [DeviceMotionEventRotationRate]
   /// interface indicates the rate of rotation around the Z axis, in degrees per
   /// second.
-  external num? get alpha;
+  external double? get alpha;
 
   /// The **`beta`** read-only property of the [DeviceMotionEventRotationRate]
   /// interface indicates the rate of rotation around the X axis, in degrees per
   /// second.
-  external num? get beta;
+  external double? get beta;
 
   /// The **`gamma`** read-only property of the [DeviceMotionEventRotationRate]
   /// interface indicates the rate of rotation around the Y axis, in degrees per
   /// second.
-  external num? get gamma;
+  external double? get gamma;
 }
 
 /// The **`DeviceMotionEvent`** interface of the [Device Orientation Events]
@@ -222,7 +222,7 @@ extension type DeviceMotionEvent._(JSObject _) implements Event, JSObject {
   /// returns the interval, in milliseconds, at which data is obtained from the
   /// underlying
   /// hardware. You can use this to determine the granularity of motion events.
-  external num get interval;
+  external double get interval;
 }
 extension type DeviceMotionEventAccelerationInit._(JSObject _)
     implements JSObject {
@@ -232,11 +232,11 @@ extension type DeviceMotionEventAccelerationInit._(JSObject _)
     num? z,
   });
 
-  external num? get x;
+  external double? get x;
   external set x(num? value);
-  external num? get y;
+  external double? get y;
   external set y(num? value);
-  external num? get z;
+  external double? get z;
   external set z(num? value);
 }
 extension type DeviceMotionEventRotationRateInit._(JSObject _)
@@ -247,11 +247,11 @@ extension type DeviceMotionEventRotationRateInit._(JSObject _)
     num? gamma,
   });
 
-  external num? get alpha;
+  external double? get alpha;
   external set alpha(num? value);
-  external num? get beta;
+  external double? get beta;
   external set beta(num? value);
-  external num? get gamma;
+  external double? get gamma;
   external set gamma(num? value);
 }
 extension type DeviceMotionEventInit._(JSObject _)
@@ -273,6 +273,6 @@ extension type DeviceMotionEventInit._(JSObject _)
       DeviceMotionEventAccelerationInit value);
   external DeviceMotionEventRotationRateInit get rotationRate;
   external set rotationRate(DeviceMotionEventRotationRateInit value);
-  external num get interval;
+  external double get interval;
   external set interval(num value);
 }

--- a/lib/src/dom/performance_timeline.dart
+++ b/lib/src/dom/performance_timeline.dart
@@ -72,12 +72,12 @@ extension type PerformanceEntry._(JSObject _) implements JSObject {
   /// The read-only **`startTime`** property returns the first  recorded for
   /// this . The meaning of this property depends on the value of this entry's
   /// [PerformanceEntry.entryType].
-  external DOMHighResTimeStamp get startTime;
+  external double get startTime;
 
   /// The read-only **`duration`** property returns a  that is the duration of
   /// the . The meaning of this property depends on the value of this entry's
   /// [PerformanceEntry.entryType].
-  external DOMHighResTimeStamp get duration;
+  external double get duration;
 }
 
 /// The **`PerformanceObserver`** interface is used to observe performance
@@ -128,7 +128,7 @@ extension type PerformanceObserverInit._(JSObject _) implements JSObject {
   external set type(String value);
   external bool get buffered;
   external set buffered(bool value);
-  external DOMHighResTimeStamp get durationThreshold;
+  external double get durationThreshold;
   external set durationThreshold(DOMHighResTimeStamp value);
 }
 

--- a/lib/src/dom/pointerevents.dart
+++ b/lib/src/dom/pointerevents.dart
@@ -68,13 +68,13 @@ extension type PointerEventInit._(JSObject _)
 
   external int get pointerId;
   external set pointerId(int value);
-  external num get width;
+  external double get width;
   external set width(num value);
-  external num get height;
+  external double get height;
   external set height(num value);
-  external num get pressure;
+  external double get pressure;
   external set pressure(num value);
-  external num get tangentialPressure;
+  external double get tangentialPressure;
   external set tangentialPressure(num value);
   external int get tiltX;
   external set tiltX(int value);
@@ -82,9 +82,9 @@ extension type PointerEventInit._(JSObject _)
   external set tiltY(int value);
   external int get twist;
   external set twist(int value);
-  external num get altitudeAngle;
+  external double get altitudeAngle;
   external set altitudeAngle(num value);
-  external num get azimuthAngle;
+  external double get azimuthAngle;
   external set azimuthAngle(num value);
   external String get pointerType;
   external set pointerType(String value);
@@ -176,7 +176,7 @@ extension type PointerEvent._(JSObject _) implements MouseEvent, JSObject {
   /// If the input hardware cannot report the contact geometry to the browser,
   /// the width
   /// defaults to `1`.
-  external num get width;
+  external double get width;
 
   /// The **`height`** read-only property of the
   /// [PointerEvent] interface represents the height of the pointer's contact
@@ -189,18 +189,18 @@ extension type PointerEvent._(JSObject _) implements MouseEvent, JSObject {
   /// If the input hardware cannot report the contact geometry to the browser,
   /// the height
   /// defaults to `1`.
-  external num get height;
+  external double get height;
 
   /// The **`pressure`** read-only property of the
   /// [PointerEvent] interface indicates the normalized pressure of the pointer
   /// input.
-  external num get pressure;
+  external double get pressure;
 
   /// The **`tangentialPressure`** read-only property of the
   /// [PointerEvent] interface represents the normalized tangential pressure of
   /// the pointer input (also known as barrel pressure or
   /// [cylinder stress](https://en.wikipedia.org/wiki/Cylinder_stress)).
-  external num get tangentialPressure;
+  external double get tangentialPressure;
 
   /// The **`tiltX`** read-only property of the
   /// [PointerEvent] interface is the angle (in degrees) between the _Y-Z

--- a/lib/src/dom/requestidlecallback.dart
+++ b/lib/src/dom/requestidlecallback.dart
@@ -13,8 +13,6 @@ library;
 
 import 'dart:js_interop';
 
-import 'hr_time.dart';
-
 typedef IdleRequestCallback = JSFunction;
 extension type IdleRequestOptions._(JSObject _) implements JSObject {
   external factory IdleRequestOptions({int timeout});
@@ -54,7 +52,7 @@ extension type IdleDeadline._(JSObject _) implements JSObject {
   ///
   /// By the time `timeRemaining()` reaches 0, it is suggested that the callback
   /// should return control to the user agent's event loop.
-  external DOMHighResTimeStamp timeRemaining();
+  external double timeRemaining();
 
   /// The read-only **`didTimeout`** property on the
   /// **[IdleDeadline]** interface is a Boolean value which

--- a/lib/src/dom/resize_observer.dart
+++ b/lib/src/dom/resize_observer.dart
@@ -125,7 +125,7 @@ extension type ResizeObserverSize._(JSObject _) implements JSObject {
   /// > **Note:** For more explanation of writing modes and block and inline
   /// > dimensions, read
   /// > [Handling different text directions](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Handling_different_text_directions).
-  external num get inlineSize;
+  external double get inlineSize;
 
   /// The **`blockSize`** read-only property of the [ResizeObserverSize]
   /// interface returns the length of the observed element's border box in the
@@ -136,5 +136,5 @@ extension type ResizeObserverSize._(JSObject _) implements JSObject {
   /// > **Note:** For more explanation of writing modes and block and inline
   /// > dimensions, read
   /// > [Handling different text directions](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Handling_different_text_directions).
-  external num get blockSize;
+  external double get blockSize;
 }

--- a/lib/src/dom/resource_timing.dart
+++ b/lib/src/dom/resource_timing.dart
@@ -13,7 +13,6 @@ library;
 
 import 'dart:js_interop';
 
-import 'hr_time.dart';
 import 'performance_timeline.dart';
 import 'server_timing.dart';
 
@@ -61,7 +60,7 @@ extension type PerformanceResourceTiming._(JSObject _)
   /// Service Worker thread is already running, or immediately before starting
   /// the Service Worker thread if it is not already running. If the resource is
   /// not intercepted by a Service Worker the property will always return 0.
-  external DOMHighResTimeStamp get workerStart;
+  external double get workerStart;
 
   /// The **`redirectStart`** read-only property returns a [DOMHighResTimeStamp]
   /// representing the start time of the fetch which that initiates the
@@ -75,7 +74,7 @@ extension type PerformanceResourceTiming._(JSObject _)
   ///
   /// To get the amount of redirects, see also
   /// [PerformanceNavigationTiming.redirectCount].
-  external DOMHighResTimeStamp get redirectStart;
+  external double get redirectStart;
 
   /// The **`redirectEnd`** read-only property returns a [DOMHighResTimeStamp]
   /// immediately after receiving the last byte of the response of the last
@@ -89,7 +88,7 @@ extension type PerformanceResourceTiming._(JSObject _)
   ///
   /// To get the amount of redirects, see also
   /// [PerformanceNavigationTiming.redirectCount].
-  external DOMHighResTimeStamp get redirectEnd;
+  external double get redirectEnd;
 
   /// The **`fetchStart`** read-only property represents a [DOMHighResTimeStamp]
   /// immediately before the browser starts to fetch the resource.
@@ -101,12 +100,12 @@ extension type PerformanceResourceTiming._(JSObject _)
   /// Unlike many other `PerformanceResourceTiming` properties, the `fetchStart`
   /// property is available for cross-origin requests without the need of the
   /// HTTP response header.
-  external DOMHighResTimeStamp get fetchStart;
+  external double get fetchStart;
 
   /// The **`domainLookupStart`** read-only property returns the
   /// [DOMHighResTimeStamp] immediately before the browser starts the domain
   /// name lookup for the resource.
-  external DOMHighResTimeStamp get domainLookupStart;
+  external double get domainLookupStart;
 
   /// The **`domainLookupEnd`** read-only property returns the
   /// [DOMHighResTimeStamp] immediately after the browser finishes the
@@ -116,12 +115,12 @@ extension type PerformanceResourceTiming._(JSObject _)
   /// [PerformanceResourceTiming.domainLookupStart] and
   /// [PerformanceResourceTiming.domainLookupEnd] represent the times when the
   /// user agent starts and ends the domain data retrieval from the cache.
-  external DOMHighResTimeStamp get domainLookupEnd;
+  external double get domainLookupEnd;
 
   /// The **`connectStart`** read-only property returns the
   /// [DOMHighResTimeStamp] immediately before the user agent starts
   /// establishing the connection to the server to retrieve the resource.
-  external DOMHighResTimeStamp get connectStart;
+  external double get connectStart;
 
   /// The **`connectEnd`** read-only property returns the [DOMHighResTimeStamp]
   /// immediately after the browser finishes establishing the connection to the
@@ -129,13 +128,13 @@ extension type PerformanceResourceTiming._(JSObject _)
   /// interval to establish the transport connection, as well as other time
   /// intervals such as TLS handshake and
   /// [SOCKS](https://en.wikipedia.org/wiki/SOCKS) authentication.
-  external DOMHighResTimeStamp get connectEnd;
+  external double get connectEnd;
 
   /// The **`secureConnectionStart`** read-only property returns a
   /// [DOMHighResTimeStamp] immediately before the browser starts the handshake
   /// process to secure the current connection. If a secure connection is not
   /// used, the property returns zero.
-  external DOMHighResTimeStamp get secureConnectionStart;
+  external double get secureConnectionStart;
 
   /// The **`requestStart`** read-only property returns a [DOMHighResTimeStamp]
   /// of the time immediately before the browser starts requesting the resource
@@ -146,12 +145,12 @@ extension type PerformanceResourceTiming._(JSObject _)
   /// There is no _end_ property for `requestStart`. To measure the request
   /// time, calculate [PerformanceResourceTiming.responseStart] - `requestStart`
   /// (see the example below).
-  external DOMHighResTimeStamp get requestStart;
+  external double get requestStart;
 
   /// The **`responseStart`** read-only property returns a [DOMHighResTimeStamp]
   /// immediately after the browser receives the first byte of the response from
   /// the server, cache, or local resource.
-  external DOMHighResTimeStamp get responseStart;
+  external double get responseStart;
 
   /// The **`responseEnd`** read-only property returns a [DOMHighResTimeStamp]
   /// immediately after the browser receives the last byte of the resource or
@@ -161,7 +160,7 @@ extension type PerformanceResourceTiming._(JSObject _)
   /// Unlike many other `PerformanceResourceTiming` properties, the
   /// `responseEnd` property is available for cross-origin requests without the
   /// need of the  HTTP response header.
-  external DOMHighResTimeStamp get responseEnd;
+  external double get responseEnd;
 
   /// The **`transferSize`** read-only property represents the size (in octets)
   /// of the fetched resource. The size includes the response header fields plus

--- a/lib/src/dom/server_timing.dart
+++ b/lib/src/dom/server_timing.dart
@@ -13,8 +13,6 @@ library;
 
 import 'dart:js_interop';
 
-import 'hr_time.dart';
-
 /// The **`PerformanceServerTiming`** interface surfaces server metrics that are
 /// sent with the response in the  HTTP header.
 ///
@@ -39,7 +37,7 @@ extension type PerformanceServerTiming._(JSObject _) implements JSObject {
 
   /// The **`duration`** read-only property returns a double that contains the
   /// server-specified metric duration, or the value `0.0`.
-  external DOMHighResTimeStamp get duration;
+  external double get duration;
 
   /// The **`description`** read-only property returns a
   /// string value of the server-specified metric description, or an empty

--- a/lib/src/dom/speech_api.dart
+++ b/lib/src/dom/speech_api.dart
@@ -176,7 +176,7 @@ extension type SpeechRecognitionAlternative._(JSObject _) implements JSObject {
   ///
   /// > **Note:** Mozilla's implementation of `confidence` is still
   /// > being worked on — at the moment, it always seems to return 1.
-  external num get confidence;
+  external double get confidence;
 }
 
 /// The **`SpeechRecognitionResult`** interface of the
@@ -391,21 +391,21 @@ extension type SpeechSynthesisUtterance._(JSObject _)
   /// and sets the volume that the utterance will be spoken at.
   ///
   /// If not set, the default value 1 will be used.
-  external num get volume;
+  external double get volume;
   external set volume(num value);
 
   /// The **`rate`** property of the [SpeechSynthesisUtterance] interface gets
   /// and sets the speed at which the utterance will be spoken at.
   ///
   /// If unset, a default value of 1 will be used.
-  external num get rate;
+  external double get rate;
   external set rate(num value);
 
   /// The **`pitch`** property of the [SpeechSynthesisUtterance] interface gets
   /// and sets the pitch at which the utterance will be spoken at.
   ///
   /// If unset, a default value of 1 will be used.
-  external num get pitch;
+  external double get pitch;
   external set pitch(num value);
   external EventHandler get onstart;
   external set onstart(EventHandler value);
@@ -461,7 +461,7 @@ extension type SpeechSynthesisEvent._(JSObject _) implements Event, JSObject {
   /// [SpeechSynthesisUtterance.text] started being spoken, at which the
   /// [event](https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesisUtterance#events)
   /// was triggered.
-  external num get elapsedTime;
+  external double get elapsedTime;
 
   /// The **`name`** read-only property of the [SpeechSynthesisUtterance]
   /// interface returns the name associated with certain types of events
@@ -491,7 +491,7 @@ extension type SpeechSynthesisEventInit._(JSObject _)
   external set charIndex(int value);
   external int get charLength;
   external set charLength(int value);
-  external num get elapsedTime;
+  external double get elapsedTime;
   external set elapsedTime(num value);
   external String get name;
   external set name(String value);

--- a/lib/src/dom/streams.dart
+++ b/lib/src/dom/streams.dart
@@ -411,7 +411,7 @@ extension type ReadableStreamDefaultController._(JSObject _)
   /// The **`desiredSize`** read-only property of the
   /// [ReadableStreamDefaultController] interface returns the desired size
   /// required to fill the stream's internal queue.
-  external num? get desiredSize;
+  external double? get desiredSize;
 }
 
 /// The **`ReadableByteStreamController`** interface of the
@@ -534,7 +534,7 @@ extension type ReadableByteStreamController._(JSObject _) implements JSObject {
   /// The `desiredSize` is used to apply
   /// [backpressure](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API/Concepts#backpressure)
   /// from downstream consumers.
-  external num? get desiredSize;
+  external double? get desiredSize;
 }
 
 /// The **`ReadableStreamBYOBRequest`** interface of the
@@ -732,7 +732,7 @@ extension type WritableStreamDefaultWriter._(JSObject _) implements JSObject {
   /// The **`desiredSize`** read-only property of the
   /// [WritableStreamDefaultWriter] interface returns the desired size required
   /// to fill the stream's internal queue.
-  external num? get desiredSize;
+  external double? get desiredSize;
 
   /// The **`ready`** read-only property of the
   /// [WritableStreamDefaultWriter] interface returns a `Promise`
@@ -862,7 +862,7 @@ extension type TransformStreamDefaultController._(JSObject _)
   /// this information to
   /// [manually apply backpressure](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API/Concepts#backpressure)
   /// to manage the queue.
-  external num? get desiredSize;
+  external double? get desiredSize;
 }
 extension type QueuingStrategy._(JSObject _) implements JSObject {
   external factory QueuingStrategy({
@@ -870,7 +870,7 @@ extension type QueuingStrategy._(JSObject _) implements JSObject {
     QueuingStrategySize size,
   });
 
-  external num get highWaterMark;
+  external double get highWaterMark;
   external set highWaterMark(num value);
   external QueuingStrategySize get size;
   external set size(QueuingStrategySize value);
@@ -878,7 +878,7 @@ extension type QueuingStrategy._(JSObject _) implements JSObject {
 extension type QueuingStrategyInit._(JSObject _) implements JSObject {
   external factory QueuingStrategyInit({required num highWaterMark});
 
-  external num get highWaterMark;
+  external double get highWaterMark;
   external set highWaterMark(num value);
 }
 
@@ -908,7 +908,7 @@ extension type ByteLengthQueuingStrategy._(JSObject _) implements JSObject {
   /// > given a stream of chunks, how many bytes worth of those chunks (rather
   /// > than a count of how many of those chunks) can be contained in the
   /// > internal queue before backpressure is applied.
-  external num get highWaterMark;
+  external double get highWaterMark;
 
   /// The **`size()`** method of the
   /// [ByteLengthQueuingStrategy] interface returns the given chunk's
@@ -931,7 +931,7 @@ extension type CountQueuingStrategy._(JSObject _) implements JSObject {
   /// The read-only **`CountQueuingStrategy.highWaterMark`** property returns
   /// the total number of chunks that can be contained in the internal queue
   /// before backpressure is applied.
-  external num get highWaterMark;
+  external double get highWaterMark;
 
   /// The **`size()`** method of the
   /// [CountQueuingStrategy] interface always returns `1`, so that the

--- a/lib/src/dom/svg.dart
+++ b/lib/src/dom/svg.dart
@@ -358,7 +358,7 @@ extension type SVGGeometryElement._(JSObject _)
   /// The **`SVGGeometryElement.getTotalLength()`** method returns
   /// the user agent's computed value for the total length of the path in user
   /// units.
-  external num getTotalLength();
+  external double getTotalLength();
 
   /// The
   /// **`SVGGeometryElement.getPointAtLength()`** method returns the
@@ -381,7 +381,7 @@ extension type SVGGeometryElement._(JSObject _)
 /// API documentation sourced from
 /// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/SVGNumber).
 extension type SVGNumber._(JSObject _) implements JSObject {
-  external num get value;
+  external double get value;
   external set value(num value);
 }
 
@@ -409,9 +409,9 @@ extension type SVGLength._(JSObject _) implements JSObject {
   );
   external void convertToSpecifiedUnits(int unitType);
   external int get unitType;
-  external num get value;
+  external double get value;
   external set value(num value);
-  external num get valueInSpecifiedUnits;
+  external double get valueInSpecifiedUnits;
   external set valueInSpecifiedUnits(num value);
   external String get valueAsString;
   external set valueAsString(String value);
@@ -452,9 +452,9 @@ extension type SVGAngle._(JSObject _) implements JSObject {
   );
   external void convertToSpecifiedUnits(int unitType);
   external int get unitType;
-  external num get value;
+  external double get value;
   external set value(num value);
-  external num get valueInSpecifiedUnits;
+  external double get valueInSpecifiedUnits;
   external set valueInSpecifiedUnits(num value);
   external String get valueAsString;
   external set valueAsString(String value);
@@ -581,9 +581,9 @@ extension type SVGAnimatedInteger._(JSObject _) implements JSObject {
 /// API documentation sourced from
 /// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/SVGAnimatedNumber).
 extension type SVGAnimatedNumber._(JSObject _) implements JSObject {
-  external num get baseVal;
+  external double get baseVal;
   external set baseVal(num value);
-  external num get animVal;
+  external double get animVal;
 }
 
 /// The **`SVGAnimatedLength`** interface represents attributes of type
@@ -777,13 +777,13 @@ extension type SVGSVGElement._(JSObject _)
   external void pauseAnimations();
   external void unpauseAnimations();
   external bool animationsPaused();
-  external num getCurrentTime();
+  external double getCurrentTime();
   external void setCurrentTime(num seconds);
   external SVGAnimatedLength get x;
   external SVGAnimatedLength get y;
   external SVGAnimatedLength get width;
   external SVGAnimatedLength get height;
-  external num get currentScale;
+  external double get currentScale;
   external set currentScale(num value);
   external DOMPointReadOnly get currentTranslate;
   external SVGAnimatedRect get viewBox;
@@ -1040,7 +1040,7 @@ extension type SVGTransform._(JSObject _) implements JSObject {
   external void setSkewY(num angle);
   external int get type;
   external DOMMatrix get matrix;
-  external num get angle;
+  external double get angle;
 }
 
 ///
@@ -1352,15 +1352,15 @@ extension type SVGTextContentElement._(JSObject _)
   external static int get LENGTHADJUST_SPACING;
   external static int get LENGTHADJUST_SPACINGANDGLYPHS;
   external int getNumberOfChars();
-  external num getComputedTextLength();
-  external num getSubStringLength(
+  external double getComputedTextLength();
+  external double getSubStringLength(
     int charnum,
     int nchars,
   );
   external DOMPoint getStartPositionOfChar(int charnum);
   external DOMPoint getEndPositionOfChar(int charnum);
   external DOMRect getExtentOfChar(int charnum);
-  external num getRotationOfChar(int charnum);
+  external double getRotationOfChar(int charnum);
   external int getCharNumAtPosition([DOMPointInit point]);
   external void selectSubString(
     int charnum,

--- a/lib/src/dom/svg_animations.dart
+++ b/lib/src/dom/svg_animations.dart
@@ -47,9 +47,9 @@ extension type TimeEvent._(JSObject _) implements Event, JSObject {
 /// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/SVGAnimationElement).
 extension type SVGAnimationElement._(JSObject _)
     implements SVGElement, JSObject {
-  external num getStartTime();
-  external num getCurrentTime();
-  external num getSimpleDuration();
+  external double getStartTime();
+  external double getCurrentTime();
+  external double getSimpleDuration();
   external void beginElement();
   external void beginElementAt(num offset);
   external void endElement();

--- a/lib/src/dom/touch_events.dart
+++ b/lib/src/dom/touch_events.dart
@@ -41,29 +41,29 @@ extension type TouchInit._(JSObject _) implements JSObject {
   external set identifier(int value);
   external EventTarget get target;
   external set target(EventTarget value);
-  external num get clientX;
+  external double get clientX;
   external set clientX(num value);
-  external num get clientY;
+  external double get clientY;
   external set clientY(num value);
-  external num get screenX;
+  external double get screenX;
   external set screenX(num value);
-  external num get screenY;
+  external double get screenY;
   external set screenY(num value);
-  external num get pageX;
+  external double get pageX;
   external set pageX(num value);
-  external num get pageY;
+  external double get pageY;
   external set pageY(num value);
-  external num get radiusX;
+  external double get radiusX;
   external set radiusX(num value);
-  external num get radiusY;
+  external double get radiusY;
   external set radiusY(num value);
-  external num get rotationAngle;
+  external double get rotationAngle;
   external set rotationAngle(num value);
-  external num get force;
+  external double get force;
   external set force(num value);
-  external num get altitudeAngle;
+  external double get altitudeAngle;
   external set altitudeAngle(num value);
-  external num get azimuthAngle;
+  external double get azimuthAngle;
   external set azimuthAngle(num value);
   external TouchType get touchType;
   external set touchType(TouchType value);
@@ -113,32 +113,32 @@ extension type Touch._(JSObject _) implements JSObject {
 
   /// Returns the X coordinate of the touch point relative to the screen, not
   /// including any scroll offset.
-  external num get screenX;
+  external double get screenX;
 
   /// Returns the Y coordinate of the touch point relative to the screen, not
   /// including any scroll offset.
-  external num get screenY;
+  external double get screenY;
 
   /// The `Touch.clientX` read-only property returns the X coordinate of the
   /// touch
   /// point relative to the viewport, not including any scroll offset.
-  external num get clientX;
+  external double get clientX;
 
   /// The **`Touch.clientY`** read-only property returns the Y
   /// coordinate of the touch point relative to the browser's viewport, not
   /// including any
   /// scroll offset.
-  external num get clientY;
+  external double get clientY;
 
   /// The **`Touch.pageX`** read-only property returns the X
   /// coordinate of the touch point relative to the viewport, including any
   /// scroll offset.
-  external num get pageX;
+  external double get pageX;
 
   /// The **`Touch.pageY`** read-only property returns the Y
   /// coordinate of the touch point relative to the viewport, including any
   /// scroll offset.
-  external num get pageY;
+  external double get pageY;
 
   /// The **`radiusX`** read-only property of the [Touch] interface returns the
   /// X radius of the ellipse that most closely circumscribes the area of
@@ -150,7 +150,7 @@ extension type Touch._(JSObject _) implements JSObject {
   /// contact between the user and the screen. This may be a relatively large
   /// ellipse representing the contact between a fingertip and the screen or a
   /// small area representing the tip of a stylus, for example.
-  external num get radiusX;
+  external double get radiusX;
 
   /// The **`radiusY`** read-only property of the [Touch] interface returns the
   /// Y radius of the ellipse that most closely circumscribes the area of
@@ -162,7 +162,7 @@ extension type Touch._(JSObject _) implements JSObject {
   /// contact between the user and the screen. This may be a large ellipse
   /// representing the contact between a fingertip and the screen or a small one
   /// representing the tip of a stylus, for example.
-  external num get radiusY;
+  external double get radiusY;
 
   /// The **`rotationAngle`** read-only property of the [Touch] interface
   /// returns the rotation angle, in degrees, of the contact area ellipse
@@ -172,13 +172,13 @@ extension type Touch._(JSObject _) implements JSObject {
   /// This may be a relatively large ellipse representing the contact between a
   /// fingertip and the screen or a small area representing the tip of a stylus,
   /// for example.
-  external num get rotationAngle;
+  external double get rotationAngle;
 
   /// The **`Touch.force`** read-only property returns the amount of
   /// pressure the user is applying to the touch surface for a [Touch] point.
-  external num get force;
-  external num get altitudeAngle;
-  external num get azimuthAngle;
+  external double get force;
+  external double get altitudeAngle;
+  external double get azimuthAngle;
   external TouchType get touchType;
 }
 

--- a/lib/src/dom/uievents.dart
+++ b/lib/src/dom/uievents.dart
@@ -262,31 +262,31 @@ extension type MouseEvent._(JSObject _) implements UIEvent, JSObject {
   /// See
   /// [Coordinate systems](https://developer.mozilla.org/en-US/docs/Web/CSS/CSSOM_view/Coordinate_systems#page)
   /// for additional information about coordinates specified in this fashion.
-  external num get pageX;
+  external double get pageX;
 
   /// The **`pageY`** read-only property of the [MouseEvent] interface returns
   /// the Y (vertical) coordinate in pixels of the event relative to the whole
   /// document.
   /// This property takes into account any vertical scrolling of the page.
-  external num get pageY;
+  external double get pageY;
 
   /// The **`MouseEvent.x`** property is an alias for the [MouseEvent.clientX]
   /// property.
-  external num get x;
+  external double get x;
 
   /// The **`MouseEvent.y`** property is an alias for the [MouseEvent.clientY]
   /// property.
-  external num get y;
+  external double get y;
 
   /// The **`offsetX`** read-only property of the [MouseEvent] interface
   /// provides the offset in the X coordinate of the mouse pointer between that
   /// event and the padding edge of the target node.
-  external num get offsetX;
+  external double get offsetX;
 
   /// The **`offsetY`** read-only property of the [MouseEvent] interface
   /// provides the offset in the Y coordinate of the mouse pointer between that
   /// event and the padding edge of the target node.
-  external num get offsetY;
+  external double get offsetY;
 
   /// The **`movementX`** read-only property of the [MouseEvent] interface
   /// provides the difference in the X coordinate of the mouse pointer between
@@ -302,7 +302,7 @@ extension type MouseEvent._(JSObject _) implements UIEvent, JSObject {
   /// > instead calculate the delta between the current client values
   /// > ([MouseEvent.screenX], [MouseEvent.screenY]) and the previous client
   /// > values.
-  external num get movementX;
+  external double get movementX;
 
   /// The **`movementY`** read-only property of the [MouseEvent] interface
   /// provides the difference in the Y coordinate of the mouse pointer between
@@ -318,7 +318,7 @@ extension type MouseEvent._(JSObject _) implements UIEvent, JSObject {
   /// > instead calculate the delta between the current client values
   /// > ([MouseEvent.screenX], [MouseEvent.screenY]) and the previous client
   /// > values.
-  external num get movementY;
+  external double get movementY;
 
   /// The **`screenX`** read-only property of the [MouseEvent] interface
   /// provides the horizontal coordinate (offset) of the mouse pointer in
@@ -560,9 +560,9 @@ extension type MouseEventInit._(JSObject _)
   external set buttons(int value);
   external EventTarget? get relatedTarget;
   external set relatedTarget(EventTarget? value);
-  external num get movementX;
+  external double get movementX;
   external set movementX(num value);
-  external num get movementY;
+  external double get movementY;
   external set movementY(num value);
 }
 extension type EventModifierInit._(JSObject _)
@@ -656,17 +656,17 @@ extension type WheelEvent._(JSObject _) implements MouseEvent, JSObject {
   /// The **`WheelEvent.deltaX`** read-only property is a
   /// `double` representing the horizontal scroll amount in the
   /// [WheelEvent.deltaMode] unit.
-  external num get deltaX;
+  external double get deltaX;
 
   /// The **`WheelEvent.deltaY`** read-only property is a
   /// `double` representing the vertical scroll amount in the
   /// [WheelEvent.deltaMode] unit.
-  external num get deltaY;
+  external double get deltaY;
 
   /// The **`WheelEvent.deltaZ`** read-only property is a
   /// `double` representing the scroll amount along the z-axis, in the
   /// [WheelEvent.deltaMode] unit.
-  external num get deltaZ;
+  external double get deltaZ;
 
   /// The **`WheelEvent.deltaMode`** read-only property returns an
   /// `unsigned long` representing the unit of the delta values scroll amount.
@@ -718,11 +718,11 @@ extension type WheelEventInit._(JSObject _)
     int deltaMode,
   });
 
-  external num get deltaX;
+  external double get deltaX;
   external set deltaX(num value);
-  external num get deltaY;
+  external double get deltaY;
   external set deltaY(num value);
-  external num get deltaZ;
+  external double get deltaZ;
   external set deltaZ(num value);
   external int get deltaMode;
   external set deltaMode(int value);

--- a/lib/src/dom/user_timing.dart
+++ b/lib/src/dom/user_timing.dart
@@ -24,7 +24,7 @@ extension type PerformanceMarkOptions._(JSObject _) implements JSObject {
 
   external JSAny? get detail;
   external set detail(JSAny? value);
-  external DOMHighResTimeStamp get startTime;
+  external double get startTime;
   external set startTime(DOMHighResTimeStamp value);
 }
 extension type PerformanceMeasureOptions._(JSObject _) implements JSObject {
@@ -39,7 +39,7 @@ extension type PerformanceMeasureOptions._(JSObject _) implements JSObject {
   external set detail(JSAny? value);
   external JSAny get start;
   external set start(JSAny value);
-  external DOMHighResTimeStamp get duration;
+  external double get duration;
   external set duration(DOMHighResTimeStamp value);
   external JSAny get end;
   external set end(JSAny value);

--- a/lib/src/dom/web_animations.dart
+++ b/lib/src/dom/web_animations.dart
@@ -48,7 +48,7 @@ extension type AnimationTimeline._(JSObject _) implements JSObject {
 extension type DocumentTimelineOptions._(JSObject _) implements JSObject {
   external factory DocumentTimelineOptions({DOMHighResTimeStamp originTime});
 
-  external DOMHighResTimeStamp get originTime;
+  external double get originTime;
   external set originTime(DOMHighResTimeStamp value);
 }
 
@@ -225,7 +225,7 @@ extension type Animation._(JSObject _) implements EventTarget, JSObject {
   /// Animations have a **playback rate** that provides a scaling factor from
   /// the rate of change of the animation's [DocumentTimeline] time values to
   /// the animation's current time. The playback rate is initially `1`.
-  external num get playbackRate;
+  external double get playbackRate;
   external set playbackRate(num value);
 
   /// The read-only **`Animation.playState`** property of the
@@ -334,19 +334,19 @@ extension type EffectTiming._(JSObject _) implements JSObject {
 
   external FillMode get fill;
   external set fill(FillMode value);
-  external num get iterationStart;
+  external double get iterationStart;
   external set iterationStart(num value);
-  external num get iterations;
+  external double get iterations;
   external set iterations(num value);
   external PlaybackDirection get direction;
   external set direction(PlaybackDirection value);
   external String get easing;
   external set easing(String value);
-  external num get delay;
+  external double get delay;
   external set delay(num value);
-  external num get endDelay;
+  external double get endDelay;
   external set endDelay(num value);
-  external num get playbackRate;
+  external double get playbackRate;
   external set playbackRate(num value);
   external JSAny get duration;
   external set duration(JSAny value);
@@ -364,15 +364,15 @@ extension type OptionalEffectTiming._(JSObject _) implements JSObject {
     num playbackRate,
   });
 
-  external num get delay;
+  external double get delay;
   external set delay(num value);
-  external num get endDelay;
+  external double get endDelay;
   external set endDelay(num value);
   external FillMode get fill;
   external set fill(FillMode value);
-  external num get iterationStart;
+  external double get iterationStart;
   external set iterationStart(num value);
-  external num get iterations;
+  external double get iterations;
   external set iterations(num value);
   external JSAny get duration;
   external set duration(JSAny value);
@@ -380,7 +380,7 @@ extension type OptionalEffectTiming._(JSObject _) implements JSObject {
   external set direction(PlaybackDirection value);
   external String get easing;
   external set easing(String value);
-  external num get playbackRate;
+  external double get playbackRate;
   external set playbackRate(num value);
 }
 extension type ComputedEffectTiming._(JSObject _)
@@ -403,9 +403,9 @@ extension type ComputedEffectTiming._(JSObject _)
     CSSNumberish? localTime,
   });
 
-  external num? get progress;
+  external double? get progress;
   external set progress(num? value);
-  external num? get currentIteration;
+  external double? get currentIteration;
   external set currentIteration(num? value);
   external CSSNumberish get startTime;
   external set startTime(CSSNumberish value);

--- a/lib/src/dom/webaudio.dart
+++ b/lib/src/dom/webaudio.dart
@@ -306,14 +306,14 @@ extension type BaseAudioContext._(JSObject _) implements EventTarget, JSObject {
   /// floating point number representing the sample rate, in samples per second,
   /// used by all nodes in this audio context.
   /// This limitation means that sample-rate converters are not supported.
-  external num get sampleRate;
+  external double get sampleRate;
 
   /// The `currentTime` read-only property of the [BaseAudioContext]
   /// interface returns a double representing an ever-increasing hardware
   /// timestamp in seconds that
   /// can be used for scheduling audio playback, visualizing timelines, etc. It
   /// starts at 0.
-  external num get currentTime;
+  external double get currentTime;
 
   /// The `listener` property of the [BaseAudioContext] interface
   /// returns an [AudioListener] object that can then be used for
@@ -464,7 +464,7 @@ extension type AudioContext._(JSObject _)
   /// > **Note:** You can request a certain latency during
   /// > [AudioContext.AudioContext] with the
   /// > `latencyHint` option, but the browser may ignore the option.
-  external num get baseLatency;
+  external double get baseLatency;
 
   /// The **`outputLatency`** read-only property of
   /// the [AudioContext] Interface provides an estimation of the output latency
@@ -478,7 +478,7 @@ extension type AudioContext._(JSObject _)
   /// device.
   ///
   /// It varies depending on the platform and the available hardware.
-  external num get outputLatency;
+  external double get outputLatency;
 }
 extension type AudioContextOptions._(JSObject _) implements JSObject {
   external factory AudioContextOptions({
@@ -490,7 +490,7 @@ extension type AudioContextOptions._(JSObject _) implements JSObject {
 
   external JSAny get latencyHint;
   external set latencyHint(JSAny value);
-  external num get sampleRate;
+  external double get sampleRate;
   external set sampleRate(num value);
   external JSAny get sinkId;
   external set sinkId(JSAny value);
@@ -509,9 +509,9 @@ extension type AudioTimestamp._(JSObject _) implements JSObject {
     DOMHighResTimeStamp performanceTime,
   });
 
-  external num get contextTime;
+  external double get contextTime;
   external set contextTime(num value);
-  external DOMHighResTimeStamp get performanceTime;
+  external double get performanceTime;
   external set performanceTime(DOMHighResTimeStamp value);
 }
 
@@ -595,7 +595,7 @@ extension type OfflineAudioContextOptions._(JSObject _) implements JSObject {
   external set numberOfChannels(int value);
   external int get length;
   external set length(int value);
-  external num get sampleRate;
+  external double get sampleRate;
   external set sampleRate(num value);
   external JSAny get renderSizeHint;
   external set renderSizeHint(JSAny value);
@@ -691,7 +691,7 @@ extension type AudioBuffer._(JSObject _) implements JSObject {
   /// The **`sampleRate`** property of the [AudioBuffer] interface returns a
   /// float representing the sample rate, in samples per second, of the PCM data
   /// stored in the buffer.
-  external num get sampleRate;
+  external double get sampleRate;
 
   /// The **`length`** property of the [AudioBuffer]
   /// interface returns an integer representing the length, in sample-frames, of
@@ -702,7 +702,7 @@ extension type AudioBuffer._(JSObject _) implements JSObject {
   /// The **`duration`** property of the [AudioBuffer] interface returns a
   /// double representing the duration, in seconds, of the PCM data stored in
   /// the buffer.
-  external num get duration;
+  external double get duration;
 
   /// The `numberOfChannels` property of the [AudioBuffer]
   /// interface returns an integer representing the number of discrete audio
@@ -721,7 +721,7 @@ extension type AudioBufferOptions._(JSObject _) implements JSObject {
   external set numberOfChannels(int value);
   external int get length;
   external set length(int value);
-  external num get sampleRate;
+  external double get sampleRate;
   external set sampleRate(num value);
 }
 
@@ -935,7 +935,7 @@ extension type AudioParam._(JSObject _) implements JSObject {
   /// calling [AudioParam.setValueAtTime] with the time returned by the
   /// `AudioContext`'s [BaseAudioContext.currentTime]
   /// property.
-  external num get value;
+  external double get value;
   external set value(num value);
   external AutomationRate get automationRate;
   external set automationRate(AutomationRate value);
@@ -944,17 +944,17 @@ extension type AudioParam._(JSObject _) implements JSObject {
   /// read-only property of the [AudioParam] interface represents the initial
   /// value of the attributes as defined by the specific [AudioNode] creating
   /// the `AudioParam`.
-  external num get defaultValue;
+  external double get defaultValue;
 
   /// The **`minValue`**
   /// read-only property of the [AudioParam] interface represents the minimum
   /// possible value for the parameter's nominal (effective) range.
-  external num get minValue;
+  external double get minValue;
 
   /// The **`maxValue`**
   /// read-only property of the [AudioParam] interface represents the maximum
   /// possible value for the parameter's nominal (effective) range.
-  external num get maxValue;
+  external double get maxValue;
 }
 
 /// The `AudioScheduledSourceNode` interface—part of the Web Audio API—is a
@@ -1114,7 +1114,7 @@ extension type AnalyserNode._(JSObject _) implements AudioNode, JSObject {
   /// FFT analysis data, for conversion to unsigned byte values — basically,
   /// this specifies the minimum value for the range of results when using
   /// `getByteFrequencyData()`.
-  external num get minDecibels;
+  external double get minDecibels;
   external set minDecibels(num value);
 
   /// The **`maxDecibels`** property of the [AnalyserNode] interface is a double
@@ -1122,7 +1122,7 @@ extension type AnalyserNode._(JSObject _) implements AudioNode, JSObject {
   /// FFT analysis data, for conversion to unsigned byte values — basically,
   /// this specifies the maximum value for the range of results when using
   /// `getByteFrequencyData()`.
-  external num get maxDecibels;
+  external double get maxDecibels;
   external set maxDecibels(num value);
 
   /// The **`smoothingTimeConstant`** property of the [AnalyserNode] interface
@@ -1130,7 +1130,7 @@ extension type AnalyserNode._(JSObject _) implements AudioNode, JSObject {
   /// analysis frame. It's basically an average between the current buffer and
   /// the last buffer the `AnalyserNode` processed, and results in a much
   /// smoother set of value changes over time.
-  external num get smoothingTimeConstant;
+  external double get smoothingTimeConstant;
   external set smoothingTimeConstant(num value);
 }
 extension type AnalyserOptions._(JSObject _)
@@ -1147,11 +1147,11 @@ extension type AnalyserOptions._(JSObject _)
 
   external int get fftSize;
   external set fftSize(int value);
-  external num get maxDecibels;
+  external double get maxDecibels;
   external set maxDecibels(num value);
-  external num get minDecibels;
+  external double get minDecibels;
   external set minDecibels(num value);
-  external num get smoothingTimeConstant;
+  external double get smoothingTimeConstant;
   external set smoothingTimeConstant(num value);
 }
 
@@ -1278,7 +1278,7 @@ extension type AudioBufferSourceNode._(JSObject _)
   /// the restart of the play must happen.
   ///
   /// The `loopStart` property's default value is `0`.
-  external num get loopStart;
+  external double get loopStart;
   external set loopStart(num value);
 
   /// The `loopEnd` property of the [AudioBufferSourceNode]
@@ -1288,7 +1288,7 @@ extension type AudioBufferSourceNode._(JSObject _)
   /// indicated by the [AudioBufferSourceNode.loopStart] property.
   /// This is only used if the [AudioBufferSourceNode.loop] property is
   /// `true`.
-  external num get loopEnd;
+  external double get loopEnd;
   external set loopEnd(num value);
 }
 extension type AudioBufferSourceOptions._(JSObject _) implements JSObject {
@@ -1303,15 +1303,15 @@ extension type AudioBufferSourceOptions._(JSObject _) implements JSObject {
 
   external AudioBuffer? get buffer;
   external set buffer(AudioBuffer? value);
-  external num get detune;
+  external double get detune;
   external set detune(num value);
   external bool get loop;
   external set loop(bool value);
-  external num get loopEnd;
+  external double get loopEnd;
   external set loopEnd(num value);
-  external num get loopStart;
+  external double get loopStart;
   external set loopStart(num value);
-  external num get playbackRate;
+  external double get playbackRate;
   external set playbackRate(num value);
 }
 
@@ -1528,7 +1528,7 @@ extension type AudioProcessingEvent._(JSObject _) implements Event, JSObject {
   /// The **`playbackTime`** read-only property of the [AudioProcessingEvent]
   /// interface represents the time when the audio will be played. It is in the
   /// same coordinate system as the time used by the [AudioContext].
-  external num get playbackTime;
+  external double get playbackTime;
 
   /// The **`inputBuffer`** read-only property of the [AudioProcessingEvent]
   /// interface represents the input buffer of an audio processing event.
@@ -1563,7 +1563,7 @@ extension type AudioProcessingEventInit._(JSObject _)
     required AudioBuffer outputBuffer,
   });
 
-  external num get playbackTime;
+  external double get playbackTime;
   external set playbackTime(num value);
   external AudioBuffer get inputBuffer;
   external set inputBuffer(AudioBuffer value);
@@ -1685,13 +1685,13 @@ extension type BiquadFilterOptions._(JSObject _)
 
   external BiquadFilterType get type;
   external set type(BiquadFilterType value);
-  external num get Q;
+  external double get Q;
   external set Q(num value);
-  external num get detune;
+  external double get detune;
   external set detune(num value);
-  external num get frequency;
+  external double get frequency;
   external set frequency(num value);
-  external num get gain;
+  external double get gain;
   external set gain(num value);
 }
 
@@ -1888,7 +1888,7 @@ extension type ConstantSourceNode._(JSObject _)
 extension type ConstantSourceOptions._(JSObject _) implements JSObject {
   external factory ConstantSourceOptions({num offset});
 
-  external num get offset;
+  external double get offset;
   external set offset(num value);
 }
 
@@ -2058,9 +2058,9 @@ extension type DelayOptions._(JSObject _)
     num delayTime,
   });
 
-  external num get maxDelayTime;
+  external double get maxDelayTime;
   external set maxDelayTime(num value);
-  external num get delayTime;
+  external double get delayTime;
   external set delayTime(num value);
 }
 
@@ -2150,7 +2150,7 @@ extension type DynamicsCompressorNode._(JSObject _)
   /// Intended for metering purposes, it returns a value in dB, or `0` (no gain
   /// reduction) if no signal is fed into the `DynamicsCompressorNode`. The
   /// range of this value is between `-20` and `0` (in dB).
-  external num get reduction;
+  external double get reduction;
 
   /// The `attack` property of the [DynamicsCompressorNode] interface is a
   /// [k-rate](https://developer.mozilla.org/en-US/docs/Web/API/AudioParam#k-rate)
@@ -2185,15 +2185,15 @@ extension type DynamicsCompressorOptions._(JSObject _)
     num threshold,
   });
 
-  external num get attack;
+  external double get attack;
   external set attack(num value);
-  external num get knee;
+  external double get knee;
   external set knee(num value);
-  external num get ratio;
+  external double get ratio;
   external set ratio(num value);
-  external num get release;
+  external double get release;
   external set release(num value);
-  external num get threshold;
+  external double get threshold;
   external set threshold(num value);
 }
 
@@ -2258,7 +2258,7 @@ extension type GainOptions._(JSObject _) implements AudioNodeOptions, JSObject {
     num gain,
   });
 
-  external num get gain;
+  external double get gain;
   external set gain(num value);
 }
 
@@ -2690,9 +2690,9 @@ extension type OscillatorOptions._(JSObject _)
 
   external OscillatorType get type;
   external set type(OscillatorType value);
-  external num get frequency;
+  external double get frequency;
   external set frequency(num value);
-  external num get detune;
+  external double get detune;
   external set detune(num value);
   external PeriodicWave get periodicWave;
   external set periodicWave(PeriodicWave value);
@@ -3021,7 +3021,7 @@ extension type PannerNode._(JSObject _) implements AudioNode, JSObject {
   /// models.
   ///
   /// The `refDistance` property's default value is `1`.
-  external num get refDistance;
+  external double get refDistance;
   external set refDistance(num value);
 
   /// The `maxDistance` property of the [PannerNode] interface is a double value
@@ -3030,14 +3030,14 @@ extension type PannerNode._(JSObject _) implements AudioNode, JSObject {
   /// used only by the `linear` distance model.
   ///
   /// The `maxDistance` property's default value is `10000`.
-  external num get maxDistance;
+  external double get maxDistance;
   external set maxDistance(num value);
 
   /// The `rolloffFactor` property of the [PannerNode] interface is a double
   /// value describing how quickly the volume is reduced as the source moves
   /// away from the listener. This value is used by all distance models. The
   /// `rolloffFactor` property's default value is `1`.
-  external num get rolloffFactor;
+  external double get rolloffFactor;
   external set rolloffFactor(num value);
 
   /// The `coneInnerAngle` property of the [PannerNode] interface is a double
@@ -3046,7 +3046,7 @@ extension type PannerNode._(JSObject _) implements AudioNode, JSObject {
   ///
   /// The `coneInnerAngle` property's default value is `360`, suitable for a
   /// non-directional source.
-  external num get coneInnerAngle;
+  external double get coneInnerAngle;
   external set coneInnerAngle(num value);
 
   /// The `coneOuterAngle` property of the [PannerNode] interface is a double
@@ -3055,7 +3055,7 @@ extension type PannerNode._(JSObject _) implements AudioNode, JSObject {
   /// [PannerNode.coneOuterGain] property.
   ///
   /// The `coneOuterAngle` property's default value is `0`.
-  external num get coneOuterAngle;
+  external double get coneOuterAngle;
   external set coneOuterAngle(num value);
 
   /// The `coneOuterGain` property of the [PannerNode] interface is a double
@@ -3064,7 +3064,7 @@ extension type PannerNode._(JSObject _) implements AudioNode, JSObject {
   ///
   /// The `coneOuterGain` property's default value is `0`, meaning that no sound
   /// can be heard outside the cone.
-  external num get coneOuterGain;
+  external double get coneOuterGain;
   external set coneOuterGain(num value);
 }
 extension type PannerOptions._(JSObject _)
@@ -3093,29 +3093,29 @@ extension type PannerOptions._(JSObject _)
   external set panningModel(PanningModelType value);
   external DistanceModelType get distanceModel;
   external set distanceModel(DistanceModelType value);
-  external num get positionX;
+  external double get positionX;
   external set positionX(num value);
-  external num get positionY;
+  external double get positionY;
   external set positionY(num value);
-  external num get positionZ;
+  external double get positionZ;
   external set positionZ(num value);
-  external num get orientationX;
+  external double get orientationX;
   external set orientationX(num value);
-  external num get orientationY;
+  external double get orientationY;
   external set orientationY(num value);
-  external num get orientationZ;
+  external double get orientationZ;
   external set orientationZ(num value);
-  external num get refDistance;
+  external double get refDistance;
   external set refDistance(num value);
-  external num get maxDistance;
+  external double get maxDistance;
   external set maxDistance(num value);
-  external num get rolloffFactor;
+  external double get rolloffFactor;
   external set rolloffFactor(num value);
-  external num get coneInnerAngle;
+  external double get coneInnerAngle;
   external set coneInnerAngle(num value);
-  external num get coneOuterAngle;
+  external double get coneOuterAngle;
   external set coneOuterAngle(num value);
-  external num get coneOuterGain;
+  external double get coneOuterGain;
   external set coneOuterGain(num value);
 }
 
@@ -3298,7 +3298,7 @@ extension type StereoPannerOptions._(JSObject _)
     num pan,
   });
 
-  external num get pan;
+  external double get pan;
   external set pan(num value);
 }
 
@@ -3453,12 +3453,12 @@ extension type AudioWorkletGlobalScope._(JSObject _)
   /// time of the audio block being processed. It is equal to the
   /// [BaseAudioContext.currentTime] property of the [BaseAudioContext] the
   /// worklet belongs to.
-  external num get currentTime;
+  external double get currentTime;
 
   /// The read-only **`sampleRate`** property of the [AudioWorkletGlobalScope]
   /// interface returns a float that represents the sample rate of the
   /// associated [BaseAudioContext] the worklet belongs to.
-  external num get sampleRate;
+  external double get sampleRate;
 }
 
 /// The **`AudioParamMap`** interface of the

--- a/lib/src/dom/webcodecs.dart
+++ b/lib/src/dom/webcodecs.dart
@@ -284,7 +284,7 @@ extension type VideoEncoderConfig._(JSObject _) implements JSObject {
   external set displayHeight(int value);
   external int get bitrate;
   external set bitrate(int value);
-  external num get framerate;
+  external double get framerate;
   external set framerate(num value);
   external HardwareAcceleration get hardwareAcceleration;
   external set hardwareAcceleration(HardwareAcceleration value);

--- a/lib/src/dom/webrtc.dart
+++ b/lib/src/dom/webrtc.dart
@@ -1243,9 +1243,9 @@ extension type RTCRtpEncodingParameters._(JSObject _)
   external set active(bool value);
   external int get maxBitrate;
   external set maxBitrate(int value);
-  external num get maxFramerate;
+  external double get maxFramerate;
   external set maxFramerate(num value);
-  external num get scaleResolutionDownBy;
+  external double get scaleResolutionDownBy;
   external set scaleResolutionDownBy(num value);
   external RTCPriorityType get priority;
   external set priority(RTCPriorityType value);
@@ -1440,11 +1440,11 @@ extension type RTCRtpContributingSource._(JSObject _) implements JSObject {
     required int rtpTimestamp,
   });
 
-  external DOMHighResTimeStamp get timestamp;
+  external double get timestamp;
   external set timestamp(DOMHighResTimeStamp value);
   external int get source;
   external set source(int value);
-  external num get audioLevel;
+  external double get audioLevel;
   external set audioLevel(num value);
   external int get rtpTimestamp;
   external set rtpTimestamp(int value);
@@ -1868,7 +1868,7 @@ extension type RTCSctpTransport._(JSObject _) implements EventTarget, JSObject {
   /// The **`maxMessageSize`** read-only property of the [RTCSctpTransport]
   /// interface indicates the maximum size of a message that can be sent using
   /// the [RTCDataChannel.send] method.
-  external num get maxMessageSize;
+  external double get maxMessageSize;
 
   /// The **`maxChannels`** read-only property of the [RTCSctpTransport]
   /// interface indicates the maximum number of [RTCDataChannel] objects that

--- a/lib/src/dom/webtransport.dart
+++ b/lib/src/dom/webtransport.dart
@@ -73,13 +73,13 @@ extension type WebTransportDatagramDuplexStream._(JSObject _)
   /// The **`incomingMaxAge`** property of the
   /// [WebTransportDatagramDuplexStream] interface gets or sets the maximum age
   /// for incoming datagrams, in milliseconds.
-  external num? get incomingMaxAge;
+  external double? get incomingMaxAge;
   external set incomingMaxAge(num? value);
 
   /// The **`outgoingMaxAge`** property of the
   /// [WebTransportDatagramDuplexStream] interface gets or sets the maximum age
   /// for outgoing datagrams, in milliseconds.
-  external num? get outgoingMaxAge;
+  external double? get outgoingMaxAge;
   external set outgoingMaxAge(num? value);
 
   /// The **`incomingHighWaterMark`** property of the
@@ -89,7 +89,7 @@ extension type WebTransportDatagramDuplexStream._(JSObject _)
   /// considered full. See
   /// [Internal queues and queuing strategies](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API/Concepts#internal_queues_and_queuing_strategies)
   /// for more information.
-  external num get incomingHighWaterMark;
+  external double get incomingHighWaterMark;
   external set incomingHighWaterMark(num value);
 
   /// The **`outgoingHighWaterMark`** property of the
@@ -99,7 +99,7 @@ extension type WebTransportDatagramDuplexStream._(JSObject _)
   /// considered full. See
   /// [Internal queues and queuing strategies](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API/Concepts#internal_queues_and_queuing_strategies)
   /// for more information.
-  external num get outgoingHighWaterMark;
+  external double get outgoingHighWaterMark;
   external set outgoingHighWaterMark(num value);
 }
 

--- a/lib/src/dom/webvtt.dart
+++ b/lib/src/dom/webvtt.dart
@@ -81,7 +81,7 @@ extension type VTTCue._(JSObject _) implements TextTrackCue, JSObject {
 
   /// The **`size`** property of the [VTTCue] interface represents the size of
   /// the cue as a percentage of the video size.
-  external num get size;
+  external double get size;
   external set size(num value);
 
   /// The **`align`** property of the [VTTCue] interface represents the
@@ -108,17 +108,17 @@ extension type VTTRegion._(JSObject _) implements JSObject {
 
   external String get id;
   external set id(String value);
-  external num get width;
+  external double get width;
   external set width(num value);
   external int get lines;
   external set lines(int value);
-  external num get regionAnchorX;
+  external double get regionAnchorX;
   external set regionAnchorX(num value);
-  external num get regionAnchorY;
+  external double get regionAnchorY;
   external set regionAnchorY(num value);
-  external num get viewportAnchorX;
+  external double get viewportAnchorX;
   external set viewportAnchorX(num value);
-  external num get viewportAnchorY;
+  external double get viewportAnchorY;
   external set viewportAnchorY(num value);
   external ScrollSetting get scroll;
   external set scroll(ScrollSetting value);

--- a/lib/src/dom/webxr_hand_input.dart
+++ b/lib/src/dom/webxr_hand_input.dart
@@ -51,5 +51,5 @@ extension type XRJointSpace._(JSObject _) implements XRSpace, JSObject {
 extension type XRJointPose._(JSObject _) implements XRPose, JSObject {
   /// The read-only **`radius`** property of the [XRJointPose] interface
   /// indicates the radius (distance from skin) for a joint.
-  external num get radius;
+  external double get radius;
 }

--- a/tool/generator/translator.dart
+++ b/tool/generator/translator.dart
@@ -751,24 +751,29 @@ class Translator {
 
   code.TypeDef _typedef(String name, _RawType rawType) => code.TypeDef((b) => b
     ..name = name
+    // Any typedefs that need to be handled differently when used in a return
+    // type context will be handled in `_typeReference` separately.
     ..definition = _typeReference(rawType));
 
   code.Method _topLevelGetter(_RawType type, String getterName) =>
       code.Method((b) => b
         ..annotations.addAll(_jsOverride('', alwaysEmit: true))
         ..external = true
-        ..returns = _typeReference(type)
+        ..returns = _typeReference(type, returnType: true)
         ..name = getterName
         ..type = code.MethodType.getter);
 
-  // Given a raw type, convert it to the Dart type that will be emitted by the
-  // translator.
-  //
-  // If [onlyEmitInteropTypes] is true, we don't convert to Dart primitives but
-  // rather only emit a valid interop type. This is used for type arguments as
-  // they are bound to `JSAny?`.
+  /// Given a raw type, convert it to the Dart type that will be emitted by the
+  /// translator.
+  ///
+  /// If [returnType] is true, [type] is assumed to be used as a return type of
+  /// some member.
+  ///
+  /// If [onlyEmitInteropTypes] is true, we don't convert to Dart primitives but
+  /// rather only emit a valid interop type. This is used for type arguments as
+  /// they are bound to `JSAny?`.
   code.TypeReference _typeReference(_RawType type,
-      {bool onlyEmitInteropTypes = false}) {
+      {bool returnType = false, bool onlyEmitInteropTypes = false}) {
     var dartType = type.type;
     var nullable = type.nullable;
     var typeParameter = type.typeParameter;
@@ -782,7 +787,8 @@ class Translator {
 
       // TODO(srujzs): Some of these typedefs definitions may end up being
       // unused as they were ever only used in a generic. Should we delete them
-      // or does it provide value to users?
+      // or do they provide value to users? If we do delete them, a good way of
+      // detecting if they're unused is making `_usedTypes` a ref counter.
       final rawType = _desugarTypedef(type);
       if (rawType != null &&
           jsTypeToDartPrimitiveAliases.containsKey(rawType.type)) {
@@ -800,7 +806,18 @@ class Translator {
         _ => dartType,
       };
     } else {
-      // Convert JS types to primitives.
+      if (returnType) {
+        // To avoid users downcasting `num`, which works differently based on
+        // the platform, we return `double` if it's a double type.
+        // TODO(srujzs): Some of these typedefs definitions may end up being
+        // unused as they were ever only used in a return type. Should we delete
+        // them or do they provide value to users? If we do delete them, a good
+        // way of detecting if they're unused is making `_usedTypes` a ref
+        // counter.
+        final rawType = _desugarTypedef(type);
+        final underlyingType = rawType?.type ?? dartType;
+        if (underlyingType == 'JSDouble') dartType = 'double';
+      }
       dartType = jsTypeToDartPrimitiveAliases[dartType] ?? dartType;
       if (dartType == 'void') nullable = false;
     }
@@ -840,9 +857,6 @@ class Translator {
     return url;
   }
 
-  code.TypeReference _typeToTypeReference(_RawType type) =>
-      _typeReference(type);
-
   T _overridableMember<T>(
       _OverridableMember member,
       T Function(List<code.Parameter> requiredParameters,
@@ -853,7 +867,7 @@ class Translator {
     for (final rawParameter in member.parameters) {
       final parameter = code.Parameter((b) => b
         ..name = dartRename(rawParameter.name)
-        ..type = _typeToTypeReference(rawParameter.type));
+        ..type = _typeReference(rawParameter.type));
       if (rawParameter.isOptional) {
         optionalParameters.add(parameter);
       } else {
@@ -945,7 +959,7 @@ class Translator {
         ..annotations.addAll(_jsOverride(memberName.jsOverride))
         ..external = true
         ..static = operation.isStatic
-        ..returns = _typeToTypeReference(operation.returnType)
+        ..returns = _typeReference(operation.returnType, returnType: true)
         ..name = memberName.name
         ..docs.addAll(operation.mdnProperty?.formattedDocs ?? [])
         ..requiredParameters.addAll(requiredParameters)
@@ -955,7 +969,8 @@ class Translator {
 
   List<code.Method> _getterSetter({
     required _MemberName memberName,
-    required code.Reference Function() getType,
+    required code.Reference Function() getGetterType,
+    required code.Reference Function() getSetterType,
     required bool isStatic,
     required bool readOnly,
     required MdnInterface? mdnInterface,
@@ -969,7 +984,7 @@ class Translator {
           ..annotations.addAll(_jsOverride(memberName.jsOverride))
           ..external = true
           ..static = isStatic
-          ..returns = getType()
+          ..returns = getGetterType()
           ..type = code.MethodType.getter
           ..name = name
           ..docs.addAll(docs),
@@ -985,7 +1000,7 @@ class Translator {
             ..requiredParameters.add(
               code.Parameter(
                 (b) => b
-                  ..type = getType()
+                  ..type = getSetterType()
                   ..name = 'value',
               ),
             ),
@@ -997,7 +1012,8 @@ class Translator {
       _Attribute attribute, MdnInterface? mdnInterface) {
     return _getterSetter(
       memberName: attribute.name,
-      getType: () => _typeReference(attribute.type),
+      getGetterType: () => _typeReference(attribute.type, returnType: true),
+      getSetterType: () => _typeReference(attribute.type),
       readOnly: attribute.isReadOnly,
       isStatic: attribute.isStatic,
       mdnInterface: mdnInterface,
@@ -1011,7 +1027,7 @@ class Translator {
           ..annotations.addAll(_jsOverride(constant.name.jsOverride))
           ..external = true
           ..static = true
-          ..returns = _typeReference(constant.type)
+          ..returns = _typeReference(constant.type, returnType: true)
           ..type = code.MethodType.getter
           ..name = constant.name.name,
       )
@@ -1021,7 +1037,8 @@ class Translator {
   List<code.Method> _field(_Field field, MdnInterface? mdnInterface) {
     return _getterSetter(
       memberName: field.name,
-      getType: () => _typeReference(field.type),
+      getGetterType: () => _typeReference(field.type, returnType: true),
+      getSetterType: () => _typeReference(field.type),
       readOnly: false,
       isStatic: false,
       mdnInterface: mdnInterface,
@@ -1050,7 +1067,9 @@ class Translator {
       for (final style in _cssStyleDeclarations)
         ..._getterSetter(
           memberName: _MemberName(style),
-          getType: () => code.TypeReference((b) => b..symbol = 'String'),
+          getGetterType: () =>
+              _typeReference(_RawType('JSString', false), returnType: true),
+          getSetterType: () => _typeReference(_RawType('JSString', false)),
           isStatic: false,
           readOnly: false,
           mdnInterface: null,

--- a/tool/generator/type_aliases.dart
+++ b/tool/generator/type_aliases.dart
@@ -62,6 +62,10 @@ const jsTypeToDartPrimitiveAliases = <String, String>{
   'JSBoolean': 'bool',
   'JSString': 'String',
   'JSInteger': 'int',
+  // Since we want users to be able to be pass integer values for where doubles
+  // are expected, we keep this as `num`. We handle cases where doubles are
+  // returned from a browser API differently however. See
+  // `Translator._typeReference` for more details.
   'JSDouble': 'num',
   'JSNumber': 'num',
   'JSUndefined': 'void',


### PR DESCRIPTION
Closes https://github.com/dart-lang/web/issues/57

In cases where the return type is known to be a double value, prefer double over num so users don't try and downcast the type, which won't work consistently on all compilers. In order to do this, _typeReference is amended to take an extra option 'returnType' which determines if the `_RawType` is used in a return type context.