### PR TITLE
Add MAC_FF_META to KeyCode constants

### DIFF
--- a/lib/src/helpers/enums.dart
+++ b/lib/src/helpers/enums.dart
@@ -213,7 +213,8 @@ abstract final class KeyCode {
   // ignore: constant_identifier_names
   static const int NUM_PERIOD = 110;
   // ignore: constant_identifier_names
-  static const int MAC_FF_META = 224; // Firefox (Gecko) fires this for the meta key instead of 91
+  static const int MAC_FF_META =
+      224; // Firefox (Gecko) fires this for the meta key instead of 91
 }
 
 abstract final class Device {

--- a/lib/src/helpers/enums.dart
+++ b/lib/src/helpers/enums.dart
@@ -212,9 +212,9 @@ abstract final class KeyCode {
   static const int NUM_MINUS = 109;
   // ignore: constant_identifier_names
   static const int NUM_PERIOD = 110;
+  // Firefox (Gecko) fires this for the meta key instead of 91
   // ignore: constant_identifier_names
-  static const int MAC_FF_META =
-      224; // Firefox (Gecko) fires this for the meta key instead of 91
+  static const int MAC_FF_META = 224;
 }
 
 abstract final class Device {

--- a/lib/src/helpers/enums.dart
+++ b/lib/src/helpers/enums.dart
@@ -212,6 +212,8 @@ abstract final class KeyCode {
   static const int NUM_MINUS = 109;
   // ignore: constant_identifier_names
   static const int NUM_PERIOD = 110;
+  // ignore: constant_identifier_names
+  static const int MAC_FF_META = 224; // Firefox (Gecko) fires this for the meta key instead of 91
 }
 
 abstract final class Device {


### PR DESCRIPTION
This PR adds the missing declaration of `MAC_FF_META` key code value to the `KeyCode` constants.
`MAC_Fleur_META` (value is 224)  is fired by Firefox on macOS when pressing the META key, instead of the common META key value (91).

I kept the same comment as Closure's Keycode enumeration.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
