### PR TITLE
Ignore unintended_html_in_doc_comment

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -22,6 +22,7 @@ analyzer:
     unreachable_from_main: ignore
     # MDN comments include HTML docs that trigger this lint. Reenable once
     # that's resolved.
+    # ignore: unrecognized_error_code
     unintended_html_in_doc_comment: ignore
 
 linter:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -20,10 +20,6 @@ analyzer:
     non_constant_identifier_names: ignore
     # Consider removing from dart_flutter_team_lints.
     unreachable_from_main: ignore
-    # MDN comments include HTML docs that trigger this lint. Reenable once
-    # that's resolved.
-    # ignore: unrecognized_error_code
-    unintended_html_in_doc_comment: ignore
 
 linter:
   rules:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -23,18 +23,21 @@ analyzer:
 
 linter:
   rules:
-  - avoid_bool_literals_in_conditional_expressions
-  - avoid_private_typedef_functions
-  - avoid_redundant_argument_values
-  - avoid_returning_this
-  - avoid_unused_constructor_parameters
-  - cancel_subscriptions
-  - join_return_with_assignment
-  - literal_only_boolean_expressions
-  - no_adjacent_strings_in_list
-  - no_runtimeType_toString
-  - package_api_docs
-  - prefer_const_declarations
-  - prefer_final_locals
-  - unnecessary_await_in_return
-  - use_string_buffers
+    avoid_bool_literals_in_conditional_expressions: true
+    avoid_private_typedef_functions: true
+    avoid_redundant_argument_values: true
+    avoid_returning_this: true
+    avoid_unused_constructor_parameters: true
+    cancel_subscriptions: true
+    join_return_with_assignment: true
+    literal_only_boolean_expressions: true
+    no_adjacent_strings_in_list: true
+    no_runtimeType_toString: true
+    package_api_docs: true
+    prefer_const_declarations: true
+    prefer_final_locals: true
+    # MDN comments include HTML docs that trigger this lint. Reenable once
+    # that's resolved.
+    unintended_html_in_doc_comment: false
+    unnecessary_await_in_return: true
+    use_string_buffers: true

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -20,24 +20,24 @@ analyzer:
     non_constant_identifier_names: ignore
     # Consider removing from dart_flutter_team_lints.
     unreachable_from_main: ignore
+    # MDN comments include HTML docs that trigger this lint. Reenable once
+    # that's resolved.
+    unintended_html_in_doc_comment: ignore
 
 linter:
   rules:
-    avoid_bool_literals_in_conditional_expressions: true
-    avoid_private_typedef_functions: true
-    avoid_redundant_argument_values: true
-    avoid_returning_this: true
-    avoid_unused_constructor_parameters: true
-    cancel_subscriptions: true
-    join_return_with_assignment: true
-    literal_only_boolean_expressions: true
-    no_adjacent_strings_in_list: true
-    no_runtimeType_toString: true
-    package_api_docs: true
-    prefer_const_declarations: true
-    prefer_final_locals: true
-    # MDN comments include HTML docs that trigger this lint. Reenable once
-    # that's resolved.
-    unintended_html_in_doc_comment: false
-    unnecessary_await_in_return: true
-    use_string_buffers: true
+  - avoid_bool_literals_in_conditional_expressions
+  - avoid_private_typedef_functions
+  - avoid_redundant_argument_values
+  - avoid_returning_this
+  - avoid_unused_constructor_parameters
+  - cancel_subscriptions
+  - join_return_with_assignment
+  - literal_only_boolean_expressions
+  - no_adjacent_strings_in_list
+  - no_runtimeType_toString
+  - package_api_docs
+  - prefer_const_declarations
+  - prefer_final_locals
+  - unnecessary_await_in_return
+  - use_string_buffers

--- a/lib/src/dom/accelerometer.dart
+++ b/lib/src/dom/accelerometer.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/angle_instanced_arrays.dart
+++ b/lib/src/dom/angle_instanced_arrays.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/attribution_reporting_api.dart
+++ b/lib/src/dom/attribution_reporting_api.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/background_sync.dart
+++ b/lib/src/dom/background_sync.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/battery_status.dart
+++ b/lib/src/dom/battery_status.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/clipboard_apis.dart
+++ b/lib/src/dom/clipboard_apis.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/compression.dart
+++ b/lib/src/dom/compression.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/console.dart
+++ b/lib/src/dom/console.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/cookie_store.dart
+++ b/lib/src/dom/cookie_store.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/credential_management.dart
+++ b/lib/src/dom/credential_management.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/csp.dart
+++ b/lib/src/dom/csp.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/css_animations.dart
+++ b/lib/src/dom/css_animations.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/css_animations_2.dart
+++ b/lib/src/dom/css_animations_2.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/css_cascade.dart
+++ b/lib/src/dom/css_cascade.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/css_cascade_6.dart
+++ b/lib/src/dom/css_cascade_6.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/css_conditional.dart
+++ b/lib/src/dom/css_conditional.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/css_conditional_5.dart
+++ b/lib/src/dom/css_conditional_5.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/css_contain.dart
+++ b/lib/src/dom/css_contain.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/css_counter_styles.dart
+++ b/lib/src/dom/css_counter_styles.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/css_font_loading.dart
+++ b/lib/src/dom/css_font_loading.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/css_fonts.dart
+++ b/lib/src/dom/css_fonts.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/css_highlight_api.dart
+++ b/lib/src/dom/css_highlight_api.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/css_masking.dart
+++ b/lib/src/dom/css_masking.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/css_paint_api.dart
+++ b/lib/src/dom/css_paint_api.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/css_properties_values_api.dart
+++ b/lib/src/dom/css_properties_values_api.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/css_transitions.dart
+++ b/lib/src/dom/css_transitions.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/css_transitions_2.dart
+++ b/lib/src/dom/css_transitions_2.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/css_typed_om.dart
+++ b/lib/src/dom/css_typed_om.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/css_view_transitions.dart
+++ b/lib/src/dom/css_view_transitions.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/css_view_transitions_2.dart
+++ b/lib/src/dom/css_view_transitions_2.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/cssom.dart
+++ b/lib/src/dom/cssom.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/cssom_view.dart
+++ b/lib/src/dom/cssom_view.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/digital_identities.dart
+++ b/lib/src/dom/digital_identities.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/dom.dart
+++ b/lib/src/dom/dom.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/dom_parsing.dart
+++ b/lib/src/dom/dom_parsing.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/encoding.dart
+++ b/lib/src/dom/encoding.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/encrypted_media.dart
+++ b/lib/src/dom/encrypted_media.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/entries_api.dart
+++ b/lib/src/dom/entries_api.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/event_timing.dart
+++ b/lib/src/dom/event_timing.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/ext_blend_minmax.dart
+++ b/lib/src/dom/ext_blend_minmax.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/ext_color_buffer_float.dart
+++ b/lib/src/dom/ext_color_buffer_float.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/ext_color_buffer_half_float.dart
+++ b/lib/src/dom/ext_color_buffer_half_float.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/ext_disjoint_timer_query.dart
+++ b/lib/src/dom/ext_disjoint_timer_query.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/ext_disjoint_timer_query_webgl2.dart
+++ b/lib/src/dom/ext_disjoint_timer_query_webgl2.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/ext_float_blend.dart
+++ b/lib/src/dom/ext_float_blend.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/ext_frag_depth.dart
+++ b/lib/src/dom/ext_frag_depth.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/ext_shader_texture_lod.dart
+++ b/lib/src/dom/ext_shader_texture_lod.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/ext_srgb.dart
+++ b/lib/src/dom/ext_srgb.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/ext_texture_compression_bptc.dart
+++ b/lib/src/dom/ext_texture_compression_bptc.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/ext_texture_compression_rgtc.dart
+++ b/lib/src/dom/ext_texture_compression_rgtc.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/ext_texture_filter_anisotropic.dart
+++ b/lib/src/dom/ext_texture_filter_anisotropic.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/ext_texture_norm16.dart
+++ b/lib/src/dom/ext_texture_norm16.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/fedcm.dart
+++ b/lib/src/dom/fedcm.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/fetch.dart
+++ b/lib/src/dom/fetch.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/fido.dart
+++ b/lib/src/dom/fido.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/fileapi.dart
+++ b/lib/src/dom/fileapi.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/filter_effects.dart
+++ b/lib/src/dom/filter_effects.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/fs.dart
+++ b/lib/src/dom/fs.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/fullscreen.dart
+++ b/lib/src/dom/fullscreen.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/gamepad.dart
+++ b/lib/src/dom/gamepad.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/generic_sensor.dart
+++ b/lib/src/dom/generic_sensor.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/geolocation.dart
+++ b/lib/src/dom/geolocation.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/geometry.dart
+++ b/lib/src/dom/geometry.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/gyroscope.dart
+++ b/lib/src/dom/gyroscope.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/hr_time.dart
+++ b/lib/src/dom/hr_time.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/html.dart
+++ b/lib/src/dom/html.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/image_capture.dart
+++ b/lib/src/dom/image_capture.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/indexeddb.dart
+++ b/lib/src/dom/indexeddb.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/intersection_observer.dart
+++ b/lib/src/dom/intersection_observer.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/khr_parallel_shader_compile.dart
+++ b/lib/src/dom/khr_parallel_shader_compile.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/largest_contentful_paint.dart
+++ b/lib/src/dom/largest_contentful_paint.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/mathml_core.dart
+++ b/lib/src/dom/mathml_core.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/media_capabilities.dart
+++ b/lib/src/dom/media_capabilities.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/media_playback_quality.dart
+++ b/lib/src/dom/media_playback_quality.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/media_source.dart
+++ b/lib/src/dom/media_source.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/mediacapture_fromelement.dart
+++ b/lib/src/dom/mediacapture_fromelement.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/mediacapture_streams.dart
+++ b/lib/src/dom/mediacapture_streams.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/mediacapture_transform.dart
+++ b/lib/src/dom/mediacapture_transform.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/mediasession.dart
+++ b/lib/src/dom/mediasession.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/mediastream_recording.dart
+++ b/lib/src/dom/mediastream_recording.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/mst_content_hint.dart
+++ b/lib/src/dom/mst_content_hint.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/navigation_timing.dart
+++ b/lib/src/dom/navigation_timing.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/netinfo.dart
+++ b/lib/src/dom/netinfo.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/notifications.dart
+++ b/lib/src/dom/notifications.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/oes_draw_buffers_indexed.dart
+++ b/lib/src/dom/oes_draw_buffers_indexed.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/oes_element_index_uint.dart
+++ b/lib/src/dom/oes_element_index_uint.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/oes_fbo_render_mipmap.dart
+++ b/lib/src/dom/oes_fbo_render_mipmap.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/oes_standard_derivatives.dart
+++ b/lib/src/dom/oes_standard_derivatives.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/oes_texture_float.dart
+++ b/lib/src/dom/oes_texture_float.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/oes_texture_float_linear.dart
+++ b/lib/src/dom/oes_texture_float_linear.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/oes_texture_half_float.dart
+++ b/lib/src/dom/oes_texture_half_float.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/oes_texture_half_float_linear.dart
+++ b/lib/src/dom/oes_texture_half_float_linear.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/oes_vertex_array_object.dart
+++ b/lib/src/dom/oes_vertex_array_object.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/orientation_event.dart
+++ b/lib/src/dom/orientation_event.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/orientation_sensor.dart
+++ b/lib/src/dom/orientation_sensor.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/ovr_multiview2.dart
+++ b/lib/src/dom/ovr_multiview2.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/paint_timing.dart
+++ b/lib/src/dom/paint_timing.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/payment_request.dart
+++ b/lib/src/dom/payment_request.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/performance_timeline.dart
+++ b/lib/src/dom/performance_timeline.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/permissions.dart
+++ b/lib/src/dom/permissions.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/picture_in_picture.dart
+++ b/lib/src/dom/picture_in_picture.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/pointerevents.dart
+++ b/lib/src/dom/pointerevents.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/pointerlock.dart
+++ b/lib/src/dom/pointerlock.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/private_network_access.dart
+++ b/lib/src/dom/private_network_access.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/push_api.dart
+++ b/lib/src/dom/push_api.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/referrer_policy.dart
+++ b/lib/src/dom/referrer_policy.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/remote_playback.dart
+++ b/lib/src/dom/remote_playback.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/reporting.dart
+++ b/lib/src/dom/reporting.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/requestidlecallback.dart
+++ b/lib/src/dom/requestidlecallback.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/resize_observer.dart
+++ b/lib/src/dom/resize_observer.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/resource_timing.dart
+++ b/lib/src/dom/resource_timing.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/saa_non_cookie_storage.dart
+++ b/lib/src/dom/saa_non_cookie_storage.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/sanitizer_api.dart
+++ b/lib/src/dom/sanitizer_api.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/scheduling_apis.dart
+++ b/lib/src/dom/scheduling_apis.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/screen_capture.dart
+++ b/lib/src/dom/screen_capture.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/screen_orientation.dart
+++ b/lib/src/dom/screen_orientation.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/screen_wake_lock.dart
+++ b/lib/src/dom/screen_wake_lock.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/secure_payment_confirmation.dart
+++ b/lib/src/dom/secure_payment_confirmation.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/selection_api.dart
+++ b/lib/src/dom/selection_api.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/server_timing.dart
+++ b/lib/src/dom/server_timing.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/service_workers.dart
+++ b/lib/src/dom/service_workers.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/speech_api.dart
+++ b/lib/src/dom/speech_api.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/storage.dart
+++ b/lib/src/dom/storage.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/streams.dart
+++ b/lib/src/dom/streams.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/svg.dart
+++ b/lib/src/dom/svg.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/svg_animations.dart
+++ b/lib/src/dom/svg_animations.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/touch_events.dart
+++ b/lib/src/dom/touch_events.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/trust_token_api.dart
+++ b/lib/src/dom/trust_token_api.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/trusted_types.dart
+++ b/lib/src/dom/trusted_types.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/uievents.dart
+++ b/lib/src/dom/uievents.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/url.dart
+++ b/lib/src/dom/url.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/user_timing.dart
+++ b/lib/src/dom/user_timing.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/vibration.dart
+++ b/lib/src/dom/vibration.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/video_rvfc.dart
+++ b/lib/src/dom/video_rvfc.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/wasm_js_api.dart
+++ b/lib/src/dom/wasm_js_api.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/web_animations.dart
+++ b/lib/src/dom/web_animations.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/web_animations_2.dart
+++ b/lib/src/dom/web_animations_2.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/web_bluetooth.dart
+++ b/lib/src/dom/web_bluetooth.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/web_locks.dart
+++ b/lib/src/dom/web_locks.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/web_otp.dart
+++ b/lib/src/dom/web_otp.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/web_share.dart
+++ b/lib/src/dom/web_share.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webaudio.dart
+++ b/lib/src/dom/webaudio.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webauthn.dart
+++ b/lib/src/dom/webauthn.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webcodecs.dart
+++ b/lib/src/dom/webcodecs.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webcodecs_av1_codec_registration.dart
+++ b/lib/src/dom/webcodecs_av1_codec_registration.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webcodecs_avc_codec_registration.dart
+++ b/lib/src/dom/webcodecs_avc_codec_registration.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webcodecs_hevc_codec_registration.dart
+++ b/lib/src/dom/webcodecs_hevc_codec_registration.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webcodecs_vp9_codec_registration.dart
+++ b/lib/src/dom/webcodecs_vp9_codec_registration.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webcryptoapi.dart
+++ b/lib/src/dom/webcryptoapi.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webgl1.dart
+++ b/lib/src/dom/webgl1.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webgl2.dart
+++ b/lib/src/dom/webgl2.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webgl_color_buffer_float.dart
+++ b/lib/src/dom/webgl_color_buffer_float.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webgl_compressed_texture_astc.dart
+++ b/lib/src/dom/webgl_compressed_texture_astc.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webgl_compressed_texture_etc.dart
+++ b/lib/src/dom/webgl_compressed_texture_etc.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webgl_compressed_texture_etc1.dart
+++ b/lib/src/dom/webgl_compressed_texture_etc1.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webgl_compressed_texture_pvrtc.dart
+++ b/lib/src/dom/webgl_compressed_texture_pvrtc.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webgl_compressed_texture_s3tc.dart
+++ b/lib/src/dom/webgl_compressed_texture_s3tc.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webgl_compressed_texture_s3tc_srgb.dart
+++ b/lib/src/dom/webgl_compressed_texture_s3tc_srgb.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webgl_debug_renderer_info.dart
+++ b/lib/src/dom/webgl_debug_renderer_info.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webgl_debug_shaders.dart
+++ b/lib/src/dom/webgl_debug_shaders.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webgl_depth_texture.dart
+++ b/lib/src/dom/webgl_depth_texture.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webgl_draw_buffers.dart
+++ b/lib/src/dom/webgl_draw_buffers.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webgl_lose_context.dart
+++ b/lib/src/dom/webgl_lose_context.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webgl_multi_draw.dart
+++ b/lib/src/dom/webgl_multi_draw.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webgpu.dart
+++ b/lib/src/dom/webgpu.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webidl.dart
+++ b/lib/src/dom/webidl.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webmidi.dart
+++ b/lib/src/dom/webmidi.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webrtc.dart
+++ b/lib/src/dom/webrtc.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webrtc_encoded_transform.dart
+++ b/lib/src/dom/webrtc_encoded_transform.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webrtc_identity.dart
+++ b/lib/src/dom/webrtc_identity.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webrtc_priority.dart
+++ b/lib/src/dom/webrtc_priority.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/websockets.dart
+++ b/lib/src/dom/websockets.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webtransport.dart
+++ b/lib/src/dom/webtransport.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webvtt.dart
+++ b/lib/src/dom/webvtt.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webxr.dart
+++ b/lib/src/dom/webxr.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/webxr_hand_input.dart
+++ b/lib/src/dom/webxr_hand_input.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/lib/src/dom/xhr.dart
+++ b/lib/src/dom/xhr.dart
@@ -8,6 +8,8 @@
 
 // Generated from Web IDL definitions.
 
+// ignore_for_file: unintended_html_in_doc_comment
+
 @JS()
 library;
 

--- a/tool/generator/translator.dart
+++ b/tool/generator/translator.dart
@@ -1273,7 +1273,8 @@ class Translator {
       '',
       ...mozLicenseHeader,
     ])
-    // TODO(56450): Remove this once this bug has been resolved.
+    // TODO(https://github.com/dart-lang/sdk/issues/56450): Remove this once
+    // this bug has been resolved.
     ..ignoreForFile.addAll([
       'unintended_html_in_doc_comment',
     ])

--- a/tool/generator/translator.dart
+++ b/tool/generator/translator.dart
@@ -1273,6 +1273,10 @@ class Translator {
       '',
       ...mozLicenseHeader,
     ])
+    // TODO(56450): Remove this once this bug has been resolved.
+    ..ignoreForFile.addAll([
+      'unintended_html_in_doc_comment',
+    ])
     ..generatedByComment = generatedFileDisclaimer
     // TODO(srujzs): This is to address the issue around extension type object
     // literal constructors in https://github.com/dart-lang/sdk/issues/54801.

--- a/tool/generator/webidl_api.dart
+++ b/tool/generator/webidl_api.dart
@@ -117,10 +117,10 @@ extension type Constant._(JSObject _) implements Member {
 }
 
 /// Grab bag to handle declarations in members:
-///   * iterable<>
-///   * async iterable<>
-///   * maplike<>
-///   * setlike<>
+///   * iterable
+///   * async iterable
+///   * maplike
+///   * setlike
 extension type MemberDeclaration._(JSObject _) implements JSObject {
   external String get type;
   external IDLType get idlType;


### PR DESCRIPTION
MDN docs includes some variants of html tags that this rule disallows, like `<table class="properties">`, `<th scope="row">`, and `<br />`. In order to make the CI pass, this is ignored for now. Fixes cases unrelated to the MDN docs.

cc @kallentu for some fun edge cases from the MDN.