### PR TITLE
Relabel unused_element ignore to unused_element_parameter

### DIFF
--- a/tool/generator/translator.dart
+++ b/tool/generator/translator.dart
@@ -303,7 +303,7 @@ sealed class _Property {
 
   // TODO(srujzs): Remove ignore after
   // https://github.com/dart-lang/sdk/issues/55720 is resolved.
-  // ignore: unused_element
+  // ignore: unused_element_parameter
   _Property(_MemberName name, idl.IDLType idlType, [this.mdnProperty])
       : type = _getRawType(idlType) {
     // Rename the property if there's a collision with the type name.


### PR DESCRIPTION
The latter was separated from the former to avoid conflation (see https://github.com/dart-lang/sdk/issues/49025). Makes CI green again.
