### PR TITLE
[feat] Adds helpers to convert js lists to a dart list (Resolves #281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Added `HttpStatus` class that declares http status codes. This is a copy of 
   the `HttpStatus` from the `dart:_internal` library that's exposed only through
   `dart:io` and `dart:html`.
+- Added `JSImmutableListWrapper` which helps create a dart list from a JS list.
+- Deprecated `TouchListWrapper` and `TouchListConvert` in favor of `JSImmutableListWrapper`.
 
 ## 1.0.0
 

--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -25,6 +25,7 @@ import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
 
 import 'dom.dart';
+import 'helpers/lists.dart';
 
 export 'helpers/enums.dart';
 export 'helpers/events/events.dart';
@@ -94,3 +95,8 @@ HTMLAudioElement createAudioElement() => _audioConstructor.callAsConstructor();
 /// ```
 @Deprecated('Directly use document.querySelector instead.')
 Element? querySelector(String selector) => document.querySelector(selector);
+
+@Deprecated('Use JSImmutableListWrapper<TouchList, Touch> instead.')
+class TouchListWrapper extends JSImmutableListWrapper<TouchList, Touch> {
+TouchListWrapper(super._original);
+}

--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -98,5 +98,5 @@ Element? querySelector(String selector) => document.querySelector(selector);
 
 @Deprecated('Use JSImmutableListWrapper<TouchList, Touch> instead.')
 class TouchListWrapper extends JSImmutableListWrapper<TouchList, Touch> {
-TouchListWrapper(super._original);
+  TouchListWrapper(super._original);
 }

--- a/lib/src/helpers/extensions.dart
+++ b/lib/src/helpers/extensions.dart
@@ -99,13 +99,13 @@ extension StorageGlue on Storage {
 }
 
 extension TouchListConvert on TouchList {
-  List<Touch> toList() => JSImmutableListWrapper<Touch>(this);
+  List<Touch> toList() => JSImmutableListWrapper<TouchList,Touch>(this);
 }
 
 extension HTMLCollectionConvert on HTMLCollection {
-  List<Element> toList() => JSImmutableListWrapper<Element>(this);
+  List<Element> toList() => JSImmutableListWrapper<HTMLCollection,Element>(this);
 }
 
 extension NodeListConvert on NodeList {
-  List<Node> toList() => JSImmutableListWrapper<Node>(this);
+  List<Node> toList() => JSImmutableListWrapper<NodeList,Node>(this);
 }

--- a/lib/src/helpers/extensions.dart
+++ b/lib/src/helpers/extensions.dart
@@ -99,5 +99,13 @@ extension StorageGlue on Storage {
 }
 
 extension TouchListConvert on TouchList {
-  List<Touch> toList() => TouchListWrapper(this);
+  List<Touch> toList() => JSListWrapper<Touch>(this);
+}
+
+extension HTMLCollectionConvert on HTMLCollection {
+  List<Element> toList() => JSListWrapper<Element>(this);
+}
+
+extension NodeListConvert on NodeList {
+  List<Node> toList() => JSListWrapper<Node>(this);
 }

--- a/lib/src/helpers/extensions.dart
+++ b/lib/src/helpers/extensions.dart
@@ -98,14 +98,8 @@ extension StorageGlue on Storage {
   void operator []=(String key, String value) => setItem(key, value);
 }
 
+@Deprecated('Use JSImmutableListWrapper<TouchList, Touch> instead.')
 extension TouchListConvert on TouchList {
-  List<Touch> toList() => JSImmutableListWrapper<TouchList,Touch>(this);
-}
-
-extension HTMLCollectionConvert on HTMLCollection {
-  List<Element> toList() => JSImmutableListWrapper<HTMLCollection,Element>(this);
-}
-
-extension NodeListConvert on NodeList {
-  List<Node> toList() => JSImmutableListWrapper<NodeList,Node>(this);
+  @Deprecated('Use JSImmutableListWrapper<TouchList, Touch> directly instead.')
+  List<Touch> toList() => JSImmutableListWrapper<TouchList, Touch>(this);
 }

--- a/lib/src/helpers/extensions.dart
+++ b/lib/src/helpers/extensions.dart
@@ -99,13 +99,13 @@ extension StorageGlue on Storage {
 }
 
 extension TouchListConvert on TouchList {
-  List<Touch> toList() => JSListWrapper<Touch>(this);
+  List<Touch> toList() => JSImmutableListWrapper<Touch>(this);
 }
 
 extension HTMLCollectionConvert on HTMLCollection {
-  List<Element> toList() => JSListWrapper<Element>(this);
+  List<Element> toList() => JSImmutableListWrapper<Element>(this);
 }
 
 extension NodeListConvert on NodeList {
-  List<Node> toList() => JSListWrapper<Node>(this);
+  List<Node> toList() => JSImmutableListWrapper<Node>(this);
 }

--- a/lib/src/helpers/lists.dart
+++ b/lib/src/helpers/lists.dart
@@ -5,13 +5,16 @@
 import 'dart:collection';
 import 'dart:js_interop';
 
+/// Defines interop members on a JSObject that would be present on a js list object.
+/// The JSObject is assumed to be one of the js list type as right now
+/// we don't have a single interface that would represent all the js list types.
 extension on JSObject {
   /// The **`item()`** method returns the [JSObject]
-  /// at the specified index in the assumed js list.
+  /// at the specified index in the list.
   external JSObject item(int index);
 
   /// The **`length`** read-only property indicates the number of
-  /// items in a given assumed js list.
+  /// items in a given list.
   external int get length;
 }
 

--- a/lib/src/helpers/lists.dart
+++ b/lib/src/helpers/lists.dart
@@ -18,12 +18,10 @@ extension type _JSList<T extends JSObject>(JSObject _) implements JSObject {
   external int get length;
 }
 
-
 /// A wrapper to present a JS immutable list of type T as a `List<U>` where U
 /// is the list item type.
-class JSImmutableListWrapper<T extends JSObject, U extends JSObject> extends Object
-    with ListMixin<U>
-    implements List<U> {
+class JSImmutableListWrapper<T extends JSObject, U extends JSObject>
+    extends Object with ListMixin<U> implements List<U> {
   final T _original;
   JSImmutableListWrapper(this._original);
 
@@ -64,11 +62,11 @@ class JSImmutableListWrapper<T extends JSObject, U extends JSObject> extends Obj
   }
 
   @override
-   U get single {
+  U get single {
     if (length > 1) throw StateError('More than one element');
     return first;
   }
 
   @override
-   U elementAt(int index) => this[index];
+  U elementAt(int index) => this[index];
 }

--- a/lib/src/helpers/lists.dart
+++ b/lib/src/helpers/lists.dart
@@ -8,7 +8,7 @@ import 'dart:js_interop';
 extension on JSObject {
   /// The **`item()`** method returns the [JSObject]
   /// at the specified index in the assumed js list.
-  external JSObject? item(int index);
+  external JSObject item(int index);
 
   /// The **`length`** read-only property indicates the number of
   /// items in a given assumed js list.

--- a/lib/src/helpers/lists.dart
+++ b/lib/src/helpers/lists.dart
@@ -19,26 +19,27 @@ extension on JSObject {
 }
 
 
-/// A wrapper to present a JS immutable list as a `List<T>`.
-class JSImmutableListWrapper<T extends JSObject> extends Object
-    with ListMixin<T>
-    implements List<T> {
-  final JSObject _original;
+/// A wrapper to present a JS immutable list of type T as a `List<U>` where U
+/// is the list item type.
+class JSImmutableListWrapper<T extends JSObject, U extends JSObject> extends Object
+    with ListMixin<U>
+    implements List<U> {
+  final T _original;
   JSImmutableListWrapper(this._original);
 
   @override
   int get length => _original.length;
 
   @override
-  T operator [](int index) {
+  U operator [](int index) {
     if (index > length) {
       throw IndexError.withLength(index, length, indexable: this);
     }
-    return _original.item(index) as T;
+    return _original.item(index) as  U;
   }
 
   @override
-  void operator []=(int index, T value) {
+  void operator []=(int index, U value) {
     throw UnsupportedError('Cannot assign element of immutable List.');
   }
 
@@ -48,24 +49,24 @@ class JSImmutableListWrapper<T extends JSObject> extends Object
   }
 
   @override
-  T get first {
-    if (length > 0) return _original.item(0) as T;
+  U get first {
+    if (length > 0) return _original.item(0) as  U;
     throw StateError('No elements');
   }
 
   @override
-  T get last {
+  U get last {
     final len = length;
-    if (len > 0) return _original.item(len - 1) as T;
+    if (len > 0) return _original.item(len - 1) as  U;
     throw StateError('No elements');
   }
 
   @override
-  T get single {
+   U get single {
     if (length > 1) throw StateError('More than one element');
     return first;
   }
 
   @override
-  T elementAt(int index) => this[index];
+   U elementAt(int index) => this[index];
 }

--- a/lib/src/helpers/lists.dart
+++ b/lib/src/helpers/lists.dart
@@ -8,10 +8,10 @@ import 'dart:js_interop';
 /// Defines interop members on a JSObject that would be present on a JS list object.
 /// The JSObject is assumed to be one of the JS list type as right now
 /// we don't have a single interface that would represent all the JS list types.
-extension on JSObject {
+extension type _JSList<T extends JSObject>(JSObject _) implements JSObject {
   /// The **`item()`** method returns the [JSObject]
   /// at the specified index in the list.
-  external JSObject item(int index);
+  external T item(int index);
 
   /// The **`length`** read-only property indicates the number of
   /// items in a given list.
@@ -27,15 +27,17 @@ class JSImmutableListWrapper<T extends JSObject, U extends JSObject> extends Obj
   final T _original;
   JSImmutableListWrapper(this._original);
 
+  _JSList<U> get _jsList => _JSList<U>(_original);
+
   @override
-  int get length => _original.length;
+  int get length => _jsList.length;
 
   @override
   U operator [](int index) {
     if (index > length) {
       throw IndexError.withLength(index, length, indexable: this);
     }
-    return _original.item(index) as  U;
+    return _jsList.item(index);
   }
 
   @override
@@ -50,14 +52,14 @@ class JSImmutableListWrapper<T extends JSObject, U extends JSObject> extends Obj
 
   @override
   U get first {
-    if (length > 0) return _original.item(0) as  U;
+    if (length > 0) return _jsList.item(0);
     throw StateError('No elements');
   }
 
   @override
   U get last {
     final len = length;
-    if (len > 0) return _original.item(len - 1) as  U;
+    if (len > 0) return _jsList.item(len - 1);
     throw StateError('No elements');
   }
 

--- a/lib/src/helpers/lists.dart
+++ b/lib/src/helpers/lists.dart
@@ -22,12 +22,9 @@ extension type _JSList<T extends JSObject>(JSObject _) implements JSObject {
 /// a `List<U>`.
 class JSImmutableListWrapper<T extends JSObject, U extends JSObject>
     extends Object with ListMixin<U> implements List<U> {
-  // ignore: unused_field
-  final T _original;
-
   final _JSList<U> _jsList;
 
-  JSImmutableListWrapper(this._original) : _jsList = _JSList<U>(_original);
+  JSImmutableListWrapper(T original) : _jsList = _JSList<U>(original);
 
   @override
   int get length => _jsList.length;

--- a/lib/src/helpers/lists.dart
+++ b/lib/src/helpers/lists.dart
@@ -5,9 +5,9 @@
 import 'dart:collection';
 import 'dart:js_interop';
 
-/// Defines interop members on a JSObject that would be present on a JS list object.
-/// The JSObject is assumed to be one of the JS list type as right now
-/// we don't have a single interface that would represent all the JS list types.
+/// `_JSList` acts as a wrapper around a JS list object providing an interface to
+/// access the list items and list length while also allowing us to specify the
+/// list item type from outside.
 extension type _JSList<T extends JSObject>(JSObject _) implements JSObject {
   /// The **`item()`** method returns the [JSObject]
   /// at the specified index in the list.
@@ -18,14 +18,16 @@ extension type _JSList<T extends JSObject>(JSObject _) implements JSObject {
   external int get length;
 }
 
-/// A wrapper to present a JS immutable list of type T as a `List<U>` where U
-/// is the list item type.
+/// A wrapper to present a JS immutable list of type `T` and list item type `U` as
+/// a `List<U>`.
 class JSImmutableListWrapper<T extends JSObject, U extends JSObject>
     extends Object with ListMixin<U> implements List<U> {
+  // ignore: unused_field
   final T _original;
-  JSImmutableListWrapper(this._original);
 
-  _JSList<U> get _jsList => _JSList<U>(_original);
+  final _JSList<U> _jsList;
+
+  JSImmutableListWrapper(this._original) : _jsList = _JSList<U>(_original);
 
   @override
   int get length => _jsList.length;

--- a/lib/src/helpers/lists.dart
+++ b/lib/src/helpers/lists.dart
@@ -5,9 +5,9 @@
 import 'dart:collection';
 import 'dart:js_interop';
 
-/// Defines interop members on a JSObject that would be present on a js list object.
-/// The JSObject is assumed to be one of the js list type as right now
-/// we don't have a single interface that would represent all the js list types.
+/// Defines interop members on a JSObject that would be present on a JS list object.
+/// The JSObject is assumed to be one of the JS list type as right now
+/// we don't have a single interface that would represent all the JS list types.
 extension on JSObject {
   /// The **`item()`** method returns the [JSObject]
   /// at the specified index in the list.
@@ -19,12 +19,12 @@ extension on JSObject {
 }
 
 
-/// A wrapper to present a js list as a `List<T>`.
-class JSListWrapper<T extends JSObject> extends Object
+/// A wrapper to present a JS immutable list as a `List<T>`.
+class JSImmutableListWrapper<T extends JSObject> extends Object
     with ListMixin<T>
     implements List<T> {
   final JSObject _original;
-  JSListWrapper(this._original);
+  JSImmutableListWrapper(this._original);
 
   @override
   int get length => _original.length;

--- a/lib/src/helpers/lists.dart
+++ b/lib/src/helpers/lists.dart
@@ -3,29 +3,39 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:collection';
+import 'dart:js_interop';
 
-import '../../web.dart' show Touch, TouchList;
+extension on JSObject {
+  /// The **`item()`** method returns the [JSObject]
+  /// at the specified index in the assumed js list.
+  external JSObject? item(int index);
 
-/// A wrapper to present a [TouchList] as a `List<Touch>`.
-class TouchListWrapper extends Object
-    with ListMixin<Touch>
-    implements List<Touch> {
-  final TouchList _original;
-  TouchListWrapper(this._original);
+  /// The **`length`** read-only property indicates the number of
+  /// items in a given assumed js list.
+  external int get length;
+}
+
+
+/// A wrapper to present a js list as a `List<T>`.
+class JSListWrapper<T extends JSObject> extends Object
+    with ListMixin<T>
+    implements List<T> {
+  final JSObject _original;
+  JSListWrapper(this._original);
 
   @override
   int get length => _original.length;
 
   @override
-  Touch operator [](int index) {
+  T operator [](int index) {
     if (index > length) {
       throw IndexError.withLength(index, length, indexable: this);
     }
-    return _original.item(index)!;
+    return _original.item(index) as T;
   }
 
   @override
-  void operator []=(int index, Touch value) {
+  void operator []=(int index, T value) {
     throw UnsupportedError('Cannot assign element of immutable List.');
   }
 
@@ -35,24 +45,24 @@ class TouchListWrapper extends Object
   }
 
   @override
-  Touch get first {
-    if (length > 0) return _original.item(0)!;
+  T get first {
+    if (length > 0) return _original.item(0) as T;
     throw StateError('No elements');
   }
 
   @override
-  Touch get last {
+  T get last {
     final len = length;
-    if (len > 0) return _original.item(len - 1)!;
+    if (len > 0) return _original.item(len - 1) as T;
     throw StateError('No elements');
   }
 
   @override
-  Touch get single {
+  T get single {
     if (length > 1) throw StateError('More than one element');
     return first;
   }
 
   @override
-  Touch elementAt(int index) => this[index];
+  T elementAt(int index) => this[index];
 }

--- a/test/helpers_test.dart
+++ b/test/helpers_test.dart
@@ -17,4 +17,23 @@ void main() {
     expect(div.instanceOfString('bob'), false);
     expect(div.instanceOfString('HTMLDivElement'), true);
   });
+
+  test('Converts a JS list to a dart list using JSImmutableListWrapper', () {
+    final div = (document.createElement('div'))
+      ..append(document.createElement('div')..text = '1')
+      ..append(document.createElement('div')..text = '2')
+      ..append(document.createElement('div')..text = '3');
+
+    final List<Node> dartList =
+        JSImmutableListWrapper<NodeList, Node>(div.querySelectorAll('div'));
+
+    // Ensure accessing length does not throw.
+    expect(() => dartList.length, returnsNormally);
+
+    // Ensure list length is correct.
+    expect(dartList.length, 3);
+
+    // Ensure accessing any arbitrary item in the list does not throw.
+    expect(() => dartList[0], returnsNormally);
+  });
 }


### PR DESCRIPTION
[feat] Adds a helpers to convert js list to a dart list  (Resolves #281)

Updates:

* Converted `TouchListWrapper` to `JSListWrapper` which is a generic wrapper  to work with different types of js list.
* Updates `TouchListConvert` to use `JSListWrapper`.
* Added two new helpers, `HTMLCollectionConvert` on `HTMLCollection` and `NodeListConvert` on `NodeList` to convert js list to a dart list.

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
