### PR TITLE
Add `responseHeaders` extension on `XMLHttpRequest`

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Deprecated `TouchListWrapper` and `TouchListConvert` in favor of `JSImmutableListWrapper`.
 - Added `[]` and `[]=` overloaded operators to types which define unnamed
   `getter`s and `setter`s, respectively.
+- Add an extension `responseHeaders` to `XMLHttpRequest`.
 
 ## 1.0.0
 

--- a/web/lib/src/helpers/extensions.dart
+++ b/web/lib/src/helpers/extensions.dart
@@ -103,3 +103,30 @@ extension TouchListConvert on TouchList {
   @Deprecated('Use JSImmutableListWrapper<TouchList, Touch> directly instead.')
   List<Touch> toList() => JSImmutableListWrapper<TouchList, Touch>(this);
 }
+
+extension XMLHttpRequestGlue on XMLHttpRequest {
+  Map<String, String> get responseHeaders {
+    // from Closure's goog.net.Xhrio.getResponseHeaders.
+    final headers = <String, String>{};
+    final headersString = getAllResponseHeaders();
+    final headersList = headersString.split('\r\n');
+    for (final header in headersList) {
+      if (header.isEmpty) {
+        continue;
+      }
+
+      final splitIdx = header.indexOf(': ');
+      if (splitIdx == -1) {
+        continue;
+      }
+      final key = header.substring(0, splitIdx).toLowerCase();
+      final value = header.substring(splitIdx + 2);
+      if (headers.containsKey(key)) {
+        headers[key] = '${headers[key]}, $value';
+      } else {
+        headers[key] = value;
+      }
+    }
+    return headers;
+  }
+}

--- a/web/lib/src/helpers/extensions.dart
+++ b/web/lib/src/helpers/extensions.dart
@@ -21,6 +21,7 @@
 ///  * conversions: for example to wrap a `TouchList` as a `List<Touch>`
 library;
 
+import 'dart:convert';
 import 'dart:js_interop';
 import 'dart:math' show Point;
 
@@ -115,8 +116,7 @@ extension XMLHttpRequestGlue on XMLHttpRequest {
     // from Closure's goog.net.Xhrio.getResponseHeaders.
     final headers = <String, String>{};
     final headersString = getAllResponseHeaders();
-    final headersList = headersString.split('\r\n');
-    for (final header in headersList) {
+    for (final header in LineSplitter.split(headersString)) {
       if (header.isEmpty) {
         continue;
       }

--- a/web/lib/src/helpers/extensions.dart
+++ b/web/lib/src/helpers/extensions.dart
@@ -119,12 +119,12 @@ extension XMLHttpRequestGlue on XMLHttpRequest {
     final headersList =
         LineSplitter.split(headersString).where((header) => header.isNotEmpty);
     for (final header in headersList) {
-      final splitIdx = header.indexOf(': ');
-      if (splitIdx == -1) {
+      final split = header.split(': ');
+      if (split.length <= 1) {
         continue;
       }
-      final key = header.substring(0, splitIdx).toLowerCase();
-      final value = header.substring(splitIdx + 2);
+      final key = split[0].toLowerCase();
+      final value = split.skip(1).join(': ');
       headers.update(
         key,
         (oldValue) => '$oldValue, $value',

--- a/web/lib/src/helpers/extensions.dart
+++ b/web/lib/src/helpers/extensions.dart
@@ -104,6 +104,12 @@ extension TouchListConvert on TouchList {
   List<Touch> toList() => JSImmutableListWrapper<TouchList, Touch>(this);
 }
 
+/// Returns all response headers as a key-value map.
+///
+/// Multiple values for the same header key can be combined into one,
+/// separated by a comma and a space.
+///
+/// See: http://www.w3.org/TR/XMLHttpRequest/#the-getresponseheader()-method
 extension XMLHttpRequestGlue on XMLHttpRequest {
   Map<String, String> get responseHeaders {
     // from Closure's goog.net.Xhrio.getResponseHeaders.

--- a/web/lib/src/helpers/extensions.dart
+++ b/web/lib/src/helpers/extensions.dart
@@ -116,22 +116,20 @@ extension XMLHttpRequestGlue on XMLHttpRequest {
     // from Closure's goog.net.Xhrio.getResponseHeaders.
     final headers = <String, String>{};
     final headersString = getAllResponseHeaders();
-    for (final header in LineSplitter.split(headersString)) {
-      if (header.isEmpty) {
-        continue;
-      }
-
+    final headersList =
+        LineSplitter.split(headersString).where((header) => header.isNotEmpty);
+    for (final header in headersList) {
       final splitIdx = header.indexOf(': ');
       if (splitIdx == -1) {
         continue;
       }
       final key = header.substring(0, splitIdx).toLowerCase();
       final value = header.substring(splitIdx + 2);
-      if (headers.containsKey(key)) {
-        headers[key] = '${headers[key]}, $value';
-      } else {
-        headers[key] = value;
-      }
+      headers.update(
+        key,
+        (oldValue) => '$oldValue, $value',
+        ifAbsent: () => value,
+      );
     }
     return headers;
   }

--- a/web/test/helpers_test.dart
+++ b/web/test/helpers_test.dart
@@ -36,4 +36,22 @@ void main() {
     // Ensure accessing any arbitrary item in the list does not throw.
     expect(() => dartList[0], returnsNormally);
   });
+
+  test('Headers to map', () async {
+    final request = XMLHttpRequest();
+    request.open('GET', 'www.google.com');
+    request.send();
+    await request.onLoad.first;
+
+    expect(
+      request.responseHeaders,
+      allOf(
+        containsPair('content-length', '10'),
+        containsPair('content-type', 'text/plain; charset=utf-8'),
+        containsPair('x-content-type-options', 'nosniff'),
+        containsPair('x-frame-options', 'SAMEORIGIN'),
+        containsPair('x-xss-protection', '1; mode=block'),
+      ),
+    );
+  });
 }

--- a/web/test/helpers_test.dart
+++ b/web/test/helpers_test.dart
@@ -37,10 +37,11 @@ void main() {
     expect(() => dartList[0], returnsNormally);
   });
 
-  test('Headers to map', () async {
-    final request = XMLHttpRequest();
-    request.open('GET', 'www.google.com');
-    request.send();
+  test('responseHeaders transforms headers into a map', () async {
+    final request = XMLHttpRequest()
+      ..open('GET', 'www.google.com')
+      ..send();
+
     await request.onLoad.first;
 
     expect(


### PR DESCRIPTION
Move this extension from [`package:http`](https://github.com/dart-lang/http/blob/b97b8dc22ea808c4fbd63f73abd7af8ecf694323/pkgs/http/lib/src/browser_client.dart#L124) here, it might also be used in [`package:grpc`](https://github.com/grpc/grpc-dart/pull/730/files#r1722304772).


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
