### PR TITLE
Update dart_style and use latestLanguageVersion

### DIFF
--- a/web_generator/lib/src/dart_main.dart
+++ b/web_generator/lib/src/dart_main.dart
@@ -44,6 +44,6 @@ String _emitLibrary(code.Library library) {
   );
 
   final source = library.accept(emitter);
-  return DartFormatter(experimentFlags: [inlineClassExperimentFlag])
+  return DartFormatter(languageVersion: DartFormatter.latestLanguageVersion)
       .format(source.toString());
 }

--- a/web_generator/lib/src/util.dart
+++ b/web_generator/lib/src/util.dart
@@ -30,9 +30,6 @@ final List<String> mozLicenseHeader = [
   'under [CC-BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/.',
 ];
 
-// Needed for dart_style until 2.3.5 is published.
-const String inlineClassExperimentFlag = 'inline-class';
-
 const String generatedFileDisclaimer = 'Generated from Web IDL definitions.';
 
 extension StringExt on String {

--- a/web_generator/pubspec.yaml
+++ b/web_generator/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   code_builder: ^4.10.0
   collection: ^1.18.0
   dart_flutter_team_lints: ^3.0.0
-  dart_style: ^2.3.4
+  dart_style: ^2.3.7
   io: ^1.0.4
   path: ^1.8.3
   test: ^1.24.4


### PR DESCRIPTION
languageVersion will soon be a required parameter. For our purposes, it suffices to use the latest as it includes formatting for extension types. There are no changes in the generated output.