### PR TITLE
 Add a generate-all flag to emit all bindings

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -420,6 +420,90 @@ jobs:
       - job_008
       - job_009
   job_012:
+    name: "generate_all_and_analyze; Dart dev; PKG: web_generator; `dart analyze --fatal-infos .`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:web_generator;commands:analyze"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:web_generator
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
+        with:
+          sdk: dev
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - id: web_generator_pub_upgrade
+        name: web_generator; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: web_generator
+      - name: "web_generator; dart analyze --fatal-infos ."
+        run: dart analyze --fatal-infos .
+        if: "always() && steps.web_generator_pub_upgrade.conclusion == 'success'"
+        working-directory: web_generator
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+      - job_007
+      - job_008
+      - job_009
+      - job_010
+      - job_011
+  job_013:
+    name: "generate_all_and_analyze; Dart dev; PKG: web_generator; `dart bin/update_bindings.dart --generate-all`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:web_generator;commands:command_2"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:web_generator
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
+        with:
+          sdk: dev
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - id: web_generator_pub_upgrade
+        name: web_generator; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: web_generator
+      - name: "web_generator; dart bin/update_bindings.dart --generate-all"
+        run: dart bin/update_bindings.dart --generate-all
+        if: "always() && steps.web_generator_pub_upgrade.conclusion == 'success'"
+        working-directory: web_generator
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+      - job_007
+      - job_008
+      - job_009
+      - job_010
+      - job_011
+  job_014:
     name: "dart_fixes; Dart main; PKG: web; `dart fix --compare-to-golden test_fixes`"
     runs-on: ubuntu-latest
     steps:
@@ -461,3 +545,5 @@ jobs:
       - job_009
       - job_010
       - job_011
+      - job_012
+      - job_013

--- a/mono_repo.yaml
+++ b/mono_repo.yaml
@@ -9,3 +9,4 @@ merge_stages:
   - unit_test
   - dart_fixes
   - generate_and_analyze
+  - generate_all_and_analyze

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -75,6 +75,10 @@ for PKG in ${PKGS}; do
         echo 'dart bin/update_bindings.dart'
         dart bin/update_bindings.dart || EXIT_CODE=$?
         ;;
+      command_2)
+        echo 'dart bin/update_bindings.dart --generate-all'
+        dart bin/update_bindings.dart --generate-all || EXIT_CODE=$?
+        ;;
       format)
         echo 'dart format --output=none --set-exit-if-changed .'
         dart format --output=none --set-exit-if-changed . || EXIT_CODE=$?

--- a/web_generator/CHANGELOG.md
+++ b/web_generator/CHANGELOG.md
@@ -3,9 +3,9 @@
 - Initial separation of `web_generator` from `web`.
 - New IDL interface `RHL` added. `ExtendedAttribute` idl interface updated to
   expose its `rhs` property and `Interfacelike` idl interface updated to expose
-  `extAttrs` property. The generator now adds a 
+  `extAttrs` property. The generator now adds a
   `JS(LegacyNamespace.$extensionTypeName)` annotation on `JS` objects if
   they've an IDL extended attribute `[LegacyNamespace=Foo]` defined in their IDL
-  description. 
-
- 
+  description.
+- Added `--generate-all` option to generate all bindings, including experimental
+  and non-standard APIs.

--- a/web_generator/README.md
+++ b/web_generator/README.md
@@ -75,6 +75,17 @@ definitions:
   emit code that is standards track and is not experimental to reduce the number
   of breaking changes.
 
+## Generate all bindings
+
+To ignore the compatibility data and emit all members, run:
+
+```shell
+dart bin/update_bindings.dart --generate-all
+```
+
+This is useful if you want to avoid having to write bindings manually for some
+experimental and non-standard APIs.
+
 ## Web IDL versions
 
 Based on:

--- a/web_generator/bin/update_bindings.dart
+++ b/web_generator/bin/update_bindings.dart
@@ -78,9 +78,14 @@ $_usage''');
   };
 
   // Run app with `node`.
+  final generateAll = argResult['generate-all'] as bool;
   await _runProc(
     'node',
-    ['main.mjs', Platform.script.resolve('../../web/lib/src').path],
+    [
+      'main.mjs',
+      '--output-directory=${Platform.script.resolve('../../web/lib/src').path}',
+      if (generateAll) '--generate-all',
+    ],
     workingDirectory: _bindingsGeneratorPath,
   );
 
@@ -232,4 +237,8 @@ ${_parser.usage}''';
 final _parser = ArgParser()
   ..addFlag('update', abbr: 'u', help: 'Update npm dependencies')
   ..addFlag('compile', defaultsTo: true)
-  ..addFlag('help', negatable: false);
+  ..addFlag('help', negatable: false)
+  ..addFlag('generate-all',
+      negatable: false,
+      help: 'Generate bindings for all IDL definitions, including experimental '
+          'and non-standard APIs.');

--- a/web_generator/lib/src/bcd.dart
+++ b/web_generator/lib/src/bcd.dart
@@ -15,12 +15,18 @@ import 'filesystem_api.dart';
 class BrowserCompatData {
   static final Map<String, Set<BCDPropertyStatus>> _eventHandlers = {};
 
+  /// Whether to generate all the bindings regardless of property status.
+  static bool generateAll = false;
+
   /// Returns whether [name] is an event handler that is supported in any
   /// interface.
   static bool isEventHandlerSupported(String name) =>
+      generateAll ||
       _eventHandlers[name]?.any((bcd) => bcd.shouldGenerate) == true;
 
-  static BrowserCompatData read() {
+  static BrowserCompatData read({required bool generateAll}) {
+    BrowserCompatData.generateAll = generateAll;
+
     final path =
         p.join('node_modules', '@mdn', 'browser-compat-data', 'data.json');
     final content = (fs.readFileSync(
@@ -84,7 +90,7 @@ class BrowserCompatData {
   BCDInterfaceStatus? retrieveInterfaceFor(String name) => interfaces[name];
 
   bool shouldGenerateInterface(String name) =>
-      retrieveInterfaceFor(name)?.shouldGenerate ?? false;
+      generateAll || (retrieveInterfaceFor(name)?.shouldGenerate ?? false);
 }
 
 class BCDInterfaceStatus extends BCDItem {
@@ -120,7 +126,8 @@ class BCDInterfaceStatus extends BCDItem {
     return _properties[name];
   }
 
-  bool get shouldGenerate => standardTrack && !experimental;
+  bool get shouldGenerate =>
+      BrowserCompatData.generateAll || (standardTrack && !experimental);
 }
 
 class BCDPropertyStatus extends BCDItem {
@@ -128,7 +135,8 @@ class BCDPropertyStatus extends BCDItem {
 
   BCDPropertyStatus(super.name, super.json, this.parent);
 
-  bool get shouldGenerate => standardTrack && !experimental;
+  bool get shouldGenerate =>
+      BrowserCompatData.generateAll || (standardTrack && !experimental);
 }
 
 abstract class BCDItem {

--- a/web_generator/lib/src/generate_bindings.dart
+++ b/web_generator/lib/src/generate_bindings.dart
@@ -69,11 +69,13 @@ Future<Map<String, Set<String>>> _generateElementTagMap() async {
 }
 
 Future<TranslationResult> generateBindings(
-    String packageRoot, String librarySubDir) async {
+    String packageRoot, String librarySubDir,
+    {required bool generateAll}) async {
   final cssStyleDeclarations = await _generateCSSStyleDeclarations();
   final elementHTMLMap = await _generateElementTagMap();
   final translator = Translator(
-      packageRoot, librarySubDir, cssStyleDeclarations, elementHTMLMap);
+      packageRoot, librarySubDir, cssStyleDeclarations, elementHTMLMap,
+      generateAll: generateAll);
   final array = objectEntries(await idl.parseAll().toDart);
   for (var i = 0; i < array.length; i++) {
     final entry = array[i] as JSArray<JSAny?>;

--- a/web_generator/lib/src/main.mjs
+++ b/web_generator/lib/src/main.mjs
@@ -21,8 +21,8 @@ globalThis.idl = idl;
 globalThis.location = { href: `file://${process.cwd()}/` }
 
 globalThis.dartMainRunner = async function (main, args) {
-  const dir = process.argv[2];
-  await main(dir);
+  const dartArgs = process.argv.slice(2);
+  await main(dartArgs);
 }
 
 async function scriptMain() {

--- a/web_generator/lib/src/translator.dart
+++ b/web_generator/lib/src/translator.dart
@@ -522,7 +522,7 @@ class _PartialInterfacelike {
               // TODO(srujzs): Should we handle other special operations,
               // unnamed or otherwise? For now, don't emit the unnamed ones and
               // do nothing special for the named ones.
-              if (operationName.isEmpty) break;
+              if (operationName.isEmpty) continue;
           }
           final isStatic = operation.special == 'static';
           if (shouldQueryMDN &&
@@ -591,6 +591,7 @@ class _PartialInterfacelike {
   /// Given a [memberName] and whether it [isStatic], return whether it is a
   /// member that should be emitted according to the compat data.
   bool _shouldGenerateMember(String memberName, {bool isStatic = false}) {
+    if (BrowserCompatData.generateAll) return true;
     // Compat data only exists for interfaces and namespaces. Mixins and
     // dictionaries should always generate their members.
     if (type != 'interface' && type != 'namespace') return true;
@@ -665,10 +666,11 @@ class Translator {
   static Translator? instance;
 
   Translator(this.packageRoot, this._librarySubDir, this._cssStyleDeclarations,
-      this._elementTagMap) {
+      this._elementTagMap,
+      {required bool generateAll}) {
     instance = this;
     docProvider = DocProvider.create();
-    browserCompatData = BrowserCompatData.read();
+    browserCompatData = BrowserCompatData.read(generateAll: generateAll);
   }
 
   void _addOrUpdateInterfaceLike(idl.Interfacelike interfacelike) {
@@ -702,30 +704,30 @@ class Translator {
         ...library.partialInterfaces
       ]) {
         final name = interfacelike.name;
-        bool shouldGenerate;
         switch (interfacelike.type) {
           case 'interface':
-            shouldGenerate = browserCompatData.shouldGenerateInterface(name);
+            if (browserCompatData.shouldGenerateInterface(name)) {
+              _addOrUpdateInterfaceLike(interfacelike);
+              _usedTypes.add(interfacelike);
+            }
             break;
           case 'namespace':
             // Browser compat data doesn't document namespaces that only contain
             // constants.
             // https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/api.md#namespaces
-            shouldGenerate = browserCompatData.shouldGenerateInterface(name) ||
+            if (browserCompatData.shouldGenerateInterface(name) ||
                 interfacelike.members.toDart
-                    .every((member) => member.type == 'const');
+                    .every((member) => member.type == 'const')) {
+              _addOrUpdateInterfaceLike(interfacelike);
+              _usedTypes.add(interfacelike);
+            }
             break;
           case 'dictionary':
-            shouldGenerate = false;
+            if (BrowserCompatData.generateAll) markTypeAsUsed(name);
             break;
           default:
             throw Exception(
                 'Unexpected interfacelike type ${interfacelike.type}');
-        }
-
-        if (shouldGenerate) {
-          _addOrUpdateInterfaceLike(interfacelike);
-          _usedTypes.add(interfacelike);
         }
       }
       for (final interfacelike in [

--- a/web_generator/mono_pkg.yaml
+++ b/web_generator/mono_pkg.yaml
@@ -11,3 +11,6 @@ stages:
 - generate_and_analyze:
   - command: dart bin/update_bindings.dart
   - analyze: --fatal-infos .
+- generate_all_and_analyze:
+  - command: dart bin/update_bindings.dart --generate-all
+  - analyze: --fatal-infos .


### PR DESCRIPTION
    In the case where a user wants to use an experimental API
    that we don't include in package:web, it is useful to have the
    generator emit bindings still so they can copy it over instead
    of having to write all of it themselves. This also allows us to
    find problems in our tools with newer bindings before they
    become standard.

    - Adds a generate-all flag to the tools and refactors code to
    incorporate it when determining whether to generate declarations.
    - Cleans up argument passing so we're always using package:args.
    - Adds a generate_all_and_analyze job to the Dart CI.