### PR TITLE
Fix location of `responseHeaders` API doc

### DIFF
--- a/web/lib/src/helpers/extensions.dart
+++ b/web/lib/src/helpers/extensions.dart
@@ -105,13 +105,13 @@ extension TouchListConvert on TouchList {
   List<Touch> toList() => JSImmutableListWrapper<TouchList, Touch>(this);
 }
 
-/// Returns all response headers as a key-value map.
-///
-/// Multiple values for the same header key can be combined into one,
-/// separated by a comma and a space.
-///
-/// See: http://www.w3.org/TR/XMLHttpRequest/#the-getresponseheader()-method
 extension XMLHttpRequestGlue on XMLHttpRequest {
+  /// Returns all response headers as a key-value map.
+  ///
+  /// Multiple values for the same header key can be combined into one,
+  /// separated by a comma and a space.
+  ///
+  /// See: https://xhr.spec.whatwg.org/#the-getresponseheader()-method
   Map<String, String> get responseHeaders {
     // from Closure's goog.net.Xhrio.getResponseHeaders.
     final headers = <String, String>{};


### PR DESCRIPTION
Also update the spec reference to a functional, up-to-date location.