### PR TITLE
Refactor generation logic so partials come after

### DIFF
--- a/web/lib/src/dom/cssom.dart
+++ b/web/lib/src/dom/cssom.dart
@@ -352,18 +352,6 @@ extension type CSSRuleList._(JSObject _) implements JSObject {
 /// API documentation sourced from
 /// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/CSSRule).
 extension type CSSRule._(JSObject _) implements JSObject {
-  static const int KEYFRAMES_RULE = 7;
-
-  static const int KEYFRAME_RULE = 8;
-
-  static const int SUPPORTS_RULE = 12;
-
-  static const int COUNTER_STYLE_RULE = 11;
-
-  static const int FONT_FEATURE_VALUES_RULE = 14;
-
-  static const int VIEW_TRANSITION_RULE = 15;
-
   static const int STYLE_RULE = 1;
 
   static const int CHARSET_RULE = 2;
@@ -379,6 +367,18 @@ extension type CSSRule._(JSObject _) implements JSObject {
   static const int MARGIN_RULE = 9;
 
   static const int NAMESPACE_RULE = 10;
+
+  static const int KEYFRAMES_RULE = 7;
+
+  static const int KEYFRAME_RULE = 8;
+
+  static const int SUPPORTS_RULE = 12;
+
+  static const int COUNTER_STYLE_RULE = 11;
+
+  static const int FONT_FEATURE_VALUES_RULE = 14;
+
+  static const int VIEW_TRANSITION_RULE = 15;
 
   /// The **`cssText`** property of the [CSSRule]
   /// interface returns the actual text of a [CSSStyleSheet] style-rule.
@@ -439,11 +439,6 @@ extension type CSSRule._(JSObject _) implements JSObject {
 /// API documentation sourced from
 /// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleRule).
 extension type CSSStyleRule._(JSObject _) implements CSSGroupingRule, JSObject {
-  /// The **`styleMap`** read-only property of the
-  /// [CSSStyleRule] interface returns a [StylePropertyMap] object
-  /// which provides access to the rule's property-value pairs.
-  external StylePropertyMap get styleMap;
-
   /// The **`selectorText`** property of the [CSSStyleRule] interface gets and
   /// sets the selectors associated with the `CSSStyleRule`.
   external String get selectorText;
@@ -454,6 +449,11 @@ extension type CSSStyleRule._(JSObject _) implements CSSGroupingRule, JSObject {
   /// [declaration block](https://www.w3.org/TR/1998/REC-CSS2-19980512/syndata.html#block)
   /// of the [CSSStyleRule].
   external JSObject get style;
+
+  /// The **`styleMap`** read-only property of the
+  /// [CSSStyleRule] interface returns a [StylePropertyMap] object
+  /// which provides access to the rule's property-value pairs.
+  external StylePropertyMap get styleMap;
 }
 
 /// The **`CSSImportRule`** interface represents an
@@ -1930,6 +1930,7 @@ external $CSS get CSS;
 /// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/CSS).
 @JS('CSS')
 extension type $CSS._(JSObject _) implements JSObject {
+  external String escape(String ident);
   external bool supports(
     String conditionTextOrProperty, [
     String value,
@@ -1999,6 +2000,5 @@ extension type $CSS._(JSObject _) implements JSObject {
   external CSSUnitValue dpcm(num value);
   external CSSUnitValue dppx(num value);
   external CSSUnitValue fr(num value);
-  external String escape(String ident);
   external HighlightRegistry get highlights;
 }

--- a/web/lib/src/dom/dom.dart
+++ b/web/lib/src/dom/dom.dart
@@ -1356,70 +1356,6 @@ extension type Document._(JSObject _) implements Node, JSObject {
   /// of UTF-8, and a URL of "about:blank"
   external static Document parseHTMLUnsafe(JSAny html);
 
-  /// The **`startViewTransition()`** method of the [Document] interface starts
-  /// a new same-document (SPA)
-  /// [view transition](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API)
-  /// and returns a [ViewTransition] object to represent it.
-  ///
-  /// When `startViewTransition()` is invoked, a sequence of steps is followed
-  /// as explained in
-  /// [The view transition process](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API/Using#the_view_transition_process).
-  external ViewTransition startViewTransition([JSObject callbackOptions]);
-
-  /// The **`elementFromPoint()`**
-  /// method, available on the [Document] object, returns the topmost [Element]
-  /// at the specified coordinates
-  /// (relative to the viewport).
-  ///
-  /// If the element at the specified point belongs to another document (for
-  /// example, the
-  /// document of an `iframe`), that document's parent element is returned
-  /// (the `<iframe>` itself). If the element at the given point is anonymous
-  /// or XBL generated content, such as a textbox's scroll bars, then the first
-  /// non-anonymous
-  /// ancestor element (for example, the textbox) is returned.
-  ///
-  /// Elements with  set to `none` will be ignored,
-  /// and the element below it will be returned.
-  ///
-  /// If the method is run on another document (like an `<iframe>`'s
-  /// subdocument), the coordinates are relative to the document where the
-  /// method is being
-  /// called.
-  ///
-  /// If the specified point is outside the visible bounds of the document or
-  /// either
-  /// coordinate is negative, the result is `null`.
-  ///
-  /// If you need to find the specific position inside the element, use
-  /// [Document.caretPositionFromPoint].
-  external Element? elementFromPoint(
-    num x,
-    num y,
-  );
-
-  /// The **`elementsFromPoint()`** method
-  /// of the [Document] interface returns an array of all elements
-  /// at the specified coordinates (relative to the viewport).
-  /// The elements are ordered from the topmost to the bottommost box of the
-  /// viewport.
-  ///
-  /// It operates in a similar way to the [Document.elementFromPoint] method.
-  external JSArray<Element> elementsFromPoint(
-    num x,
-    num y,
-  );
-
-  /// The **`caretPositionFromPoint()`**
-  /// method of the [Document] interface returns a
-  /// [CaretPosition] object, containing the DOM node, along with the caret and
-  /// caret's character offset within that node.
-  external JSObject? caretPositionFromPoint(
-    num x,
-    num y, [
-    CaretPositionFromPointOptions options,
-  ]);
-
   /// The **`getElementsByTagName`** method of
   /// [Document] interface returns an
   /// [HTMLCollection] of elements with the given tag name.
@@ -1579,6 +1515,70 @@ extension type Document._(JSObject _) implements Node, JSObject {
     Node root, [
     int whatToShow,
     NodeFilter? filter,
+  ]);
+
+  /// The **`startViewTransition()`** method of the [Document] interface starts
+  /// a new same-document (SPA)
+  /// [view transition](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API)
+  /// and returns a [ViewTransition] object to represent it.
+  ///
+  /// When `startViewTransition()` is invoked, a sequence of steps is followed
+  /// as explained in
+  /// [The view transition process](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API/Using#the_view_transition_process).
+  external ViewTransition startViewTransition([JSObject callbackOptions]);
+
+  /// The **`elementFromPoint()`**
+  /// method, available on the [Document] object, returns the topmost [Element]
+  /// at the specified coordinates
+  /// (relative to the viewport).
+  ///
+  /// If the element at the specified point belongs to another document (for
+  /// example, the
+  /// document of an `iframe`), that document's parent element is returned
+  /// (the `<iframe>` itself). If the element at the given point is anonymous
+  /// or XBL generated content, such as a textbox's scroll bars, then the first
+  /// non-anonymous
+  /// ancestor element (for example, the textbox) is returned.
+  ///
+  /// Elements with  set to `none` will be ignored,
+  /// and the element below it will be returned.
+  ///
+  /// If the method is run on another document (like an `<iframe>`'s
+  /// subdocument), the coordinates are relative to the document where the
+  /// method is being
+  /// called.
+  ///
+  /// If the specified point is outside the visible bounds of the document or
+  /// either
+  /// coordinate is negative, the result is `null`.
+  ///
+  /// If you need to find the specific position inside the element, use
+  /// [Document.caretPositionFromPoint].
+  external Element? elementFromPoint(
+    num x,
+    num y,
+  );
+
+  /// The **`elementsFromPoint()`** method
+  /// of the [Document] interface returns an array of all elements
+  /// at the specified coordinates (relative to the viewport).
+  /// The elements are ordered from the topmost to the bottommost box of the
+  /// viewport.
+  ///
+  /// It operates in a similar way to the [Document.elementFromPoint] method.
+  external JSArray<Element> elementsFromPoint(
+    num x,
+    num y,
+  );
+
+  /// The **`caretPositionFromPoint()`**
+  /// method of the [Document] interface returns a
+  /// [CaretPosition] object, containing the DOM node, along with the caret and
+  /// caret's character offset within that node.
+  external JSObject? caretPositionFromPoint(
+    num x,
+    num y, [
+    CaretPositionFromPointOptions options,
   ]);
 
   /// The [Document] method
@@ -1900,24 +1900,6 @@ extension type Document._(JSObject _) implements Node, JSObject {
     XPathResult? result,
   ]);
 
-  /// **`Document.rootElement`** returns the [Element]
-  /// that is the root element of the [document] if it is an
-  /// element, otherwise `null`. It is deprecated in favor of
-  /// [Document.documentElement], which returns the root element for all
-  /// documents.
-  external SVGSVGElement? get rootElement;
-
-  /// The **`scrollingElement`** read-only property of the
-  /// [Document] interface returns a reference to the [Element] that
-  /// scrolls the document. In standards mode, this is the root element of the
-  /// document, [document.documentElement].
-  ///
-  /// When in quirks mode, the `scrollingElement` attribute returns the HTML
-  /// `body` element if it exists and is
-  /// [potentially scrollable](https://drafts.csswg.org/cssom-view/#potentially-scrollable),
-  /// otherwise it returns null.
-  external Element? get scrollingElement;
-
   /// The **`Document.implementation`** property returns a
   /// [DOMImplementation] object associated with the current document.
   external DOMImplementation get implementation;
@@ -1969,6 +1951,24 @@ extension type Document._(JSObject _) implements Node, JSObject {
   /// [Element] that is the root element of the [document] (for
   /// example, the `html` element for HTML documents).
   external Element? get documentElement;
+
+  /// **`Document.rootElement`** returns the [Element]
+  /// that is the root element of the [document] if it is an
+  /// element, otherwise `null`. It is deprecated in favor of
+  /// [Document.documentElement], which returns the root element for all
+  /// documents.
+  external SVGSVGElement? get rootElement;
+
+  /// The **`scrollingElement`** read-only property of the
+  /// [Document] interface returns a reference to the [Element] that
+  /// scrolls the document. In standards mode, this is the root element of the
+  /// document, [document.documentElement].
+  ///
+  /// When in quirks mode, the `scrollingElement` attribute returns the HTML
+  /// `body` element if it exists and is
+  /// [potentially scrollable](https://drafts.csswg.org/cssom-view/#potentially-scrollable),
+  /// otherwise it returns null.
+  external Element? get scrollingElement;
 
   /// The read-only **`fullscreenEnabled`**
   /// property on the [Document] interface indicates whether or not fullscreen
@@ -2404,22 +2404,6 @@ extension type Document._(JSObject _) implements Node, JSObject {
   /// To get the number of children of a specific element, see
   /// [Element.childElementCount].
   external int get childElementCount;
-  external EventHandler get onanimationstart;
-  external set onanimationstart(EventHandler value);
-  external EventHandler get onanimationiteration;
-  external set onanimationiteration(EventHandler value);
-  external EventHandler get onanimationend;
-  external set onanimationend(EventHandler value);
-  external EventHandler get onanimationcancel;
-  external set onanimationcancel(EventHandler value);
-  external EventHandler get ontransitionrun;
-  external set ontransitionrun(EventHandler value);
-  external EventHandler get ontransitionstart;
-  external set ontransitionstart(EventHandler value);
-  external EventHandler get ontransitionend;
-  external set ontransitionend(EventHandler value);
-  external EventHandler get ontransitioncancel;
-  external set ontransitioncancel(EventHandler value);
   external EventHandler get onabort;
   external set onabort(EventHandler value);
   external EventHandler get onauxclick;
@@ -2560,6 +2544,22 @@ extension type Document._(JSObject _) implements Node, JSObject {
   external set onwaiting(EventHandler value);
   external EventHandler get onwheel;
   external set onwheel(EventHandler value);
+  external EventHandler get onanimationstart;
+  external set onanimationstart(EventHandler value);
+  external EventHandler get onanimationiteration;
+  external set onanimationiteration(EventHandler value);
+  external EventHandler get onanimationend;
+  external set onanimationend(EventHandler value);
+  external EventHandler get onanimationcancel;
+  external set onanimationcancel(EventHandler value);
+  external EventHandler get ontransitionrun;
+  external set ontransitionrun(EventHandler value);
+  external EventHandler get ontransitionstart;
+  external set ontransitionstart(EventHandler value);
+  external EventHandler get ontransitionend;
+  external set ontransitionend(EventHandler value);
+  external EventHandler get ontransitioncancel;
+  external set ontransitioncancel(EventHandler value);
   external EventHandler get onpointerover;
   external set onpointerover(EventHandler value);
   external EventHandler get onpointerenter;
@@ -3045,86 +3045,6 @@ extension type ShadowRoot._(JSObject _) implements DocumentFragment, JSObject {
 /// API documentation sourced from
 /// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/Element).
 extension type Element._(JSObject _) implements Node, JSObject {
-  /// The **`computedStyleMap()`** method of
-  /// the [Element] interface returns a [StylePropertyMapReadOnly]
-  /// interface which provides a read-only representation of a CSS declaration
-  /// block that is
-  /// an alternative to [CSSStyleDeclaration].
-  external StylePropertyMapReadOnly computedStyleMap();
-
-  /// The **`getClientRects()`** method of the [Element]
-  /// interface returns a collection of [DOMRect] objects that indicate the
-  /// bounding rectangles for each
-  /// [CSS border box](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
-  /// in a client.
-  ///
-  /// Most elements only have one border box each, but a multiline
-  /// [inline-level element](https://developer.mozilla.org/en-US/docs/Glossary/Inline-level_content)
-  /// (such as a multiline
-  /// `span` element, by default) has a border box around each line.
-  external DOMRectList getClientRects();
-
-  /// The **`Element.getBoundingClientRect()`** method returns a
-  /// [DOMRect] object providing information about the size of an element and
-  /// its
-  /// position relative to the
-  /// [viewport](https://developer.mozilla.org/en-US/docs/Glossary/Viewport).
-  external DOMRect getBoundingClientRect();
-
-  /// The **`checkVisibility()`** method of the [Element] interface checks
-  /// whether the element is visible.
-  ///
-  /// The method returns `false` in either of the following situations:
-  ///
-  /// - The element doesn't have an associated box, for example because the CSS
-  ///   `display` property is set to
-  ///   [`none`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#none)
-  ///   or
-  ///   [`contents`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#contents).
-  /// - The element is not being rendered because the element or an ancestor
-  ///   element sets the  property to
-  ///   [`hidden`](https://developer.mozilla.org/en-US/docs/Web/CSS/content-visibility#hidden).
-  ///
-  /// The optional parameter enables additional checks to test for other
-  /// interpretations of what "visible" means.
-  /// For example, you can further check whether an element has an opacity of
-  /// `0`, if the value of the element
-  /// [`visibility`](https://developer.mozilla.org/en-US/docs/Web/CSS/visibility)
-  /// property makes it invisible, or if the element  property has a value of
-  /// [`auto`](https://developer.mozilla.org/en-US/docs/Web/CSS/content-visibility#auto)
-  /// and its rendering is currently being skipped.
-  external bool checkVisibility([CheckVisibilityOptions options]);
-
-  /// The [Element] interface's
-  /// **`scrollIntoView()`** method scrolls the element's ancestor
-  /// containers such that the element on which `scrollIntoView()` is called is
-  /// visible to the user.
-  external void scrollIntoView([JSAny arg]);
-
-  /// The **`scroll()`** method of the [Element]
-  /// interface scrolls the element to a particular set of coordinates inside a
-  /// given
-  /// element.
-  external void scroll([
-    JSAny optionsOrX,
-    num y,
-  ]);
-
-  /// The **`scrollTo()`** method of the [Element]
-  /// interface scrolls to a particular set of coordinates inside a given
-  /// element.
-  external void scrollTo([
-    JSAny optionsOrX,
-    num y,
-  ]);
-
-  /// The **`scrollBy()`** method of the [Element]
-  /// interface scrolls an element by the given amount.
-  external void scrollBy([
-    JSAny optionsOrX,
-    num y,
-  ]);
-
   /// The **`hasAttributes()`** method of the [Element]
   /// interface returns a boolean value indicating whether the current element
   /// has any
@@ -3373,6 +3293,86 @@ extension type Element._(JSObject _) implements Node, JSObject {
     String data,
   );
 
+  /// The **`computedStyleMap()`** method of
+  /// the [Element] interface returns a [StylePropertyMapReadOnly]
+  /// interface which provides a read-only representation of a CSS declaration
+  /// block that is
+  /// an alternative to [CSSStyleDeclaration].
+  external StylePropertyMapReadOnly computedStyleMap();
+
+  /// The **`getClientRects()`** method of the [Element]
+  /// interface returns a collection of [DOMRect] objects that indicate the
+  /// bounding rectangles for each
+  /// [CSS border box](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+  /// in a client.
+  ///
+  /// Most elements only have one border box each, but a multiline
+  /// [inline-level element](https://developer.mozilla.org/en-US/docs/Glossary/Inline-level_content)
+  /// (such as a multiline
+  /// `span` element, by default) has a border box around each line.
+  external DOMRectList getClientRects();
+
+  /// The **`Element.getBoundingClientRect()`** method returns a
+  /// [DOMRect] object providing information about the size of an element and
+  /// its
+  /// position relative to the
+  /// [viewport](https://developer.mozilla.org/en-US/docs/Glossary/Viewport).
+  external DOMRect getBoundingClientRect();
+
+  /// The **`checkVisibility()`** method of the [Element] interface checks
+  /// whether the element is visible.
+  ///
+  /// The method returns `false` in either of the following situations:
+  ///
+  /// - The element doesn't have an associated box, for example because the CSS
+  ///   `display` property is set to
+  ///   [`none`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#none)
+  ///   or
+  ///   [`contents`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#contents).
+  /// - The element is not being rendered because the element or an ancestor
+  ///   element sets the  property to
+  ///   [`hidden`](https://developer.mozilla.org/en-US/docs/Web/CSS/content-visibility#hidden).
+  ///
+  /// The optional parameter enables additional checks to test for other
+  /// interpretations of what "visible" means.
+  /// For example, you can further check whether an element has an opacity of
+  /// `0`, if the value of the element
+  /// [`visibility`](https://developer.mozilla.org/en-US/docs/Web/CSS/visibility)
+  /// property makes it invisible, or if the element  property has a value of
+  /// [`auto`](https://developer.mozilla.org/en-US/docs/Web/CSS/content-visibility#auto)
+  /// and its rendering is currently being skipped.
+  external bool checkVisibility([CheckVisibilityOptions options]);
+
+  /// The [Element] interface's
+  /// **`scrollIntoView()`** method scrolls the element's ancestor
+  /// containers such that the element on which `scrollIntoView()` is called is
+  /// visible to the user.
+  external void scrollIntoView([JSAny arg]);
+
+  /// The **`scroll()`** method of the [Element]
+  /// interface scrolls the element to a particular set of coordinates inside a
+  /// given
+  /// element.
+  external void scroll([
+    JSAny optionsOrX,
+    num y,
+  ]);
+
+  /// The **`scrollTo()`** method of the [Element]
+  /// interface scrolls to a particular set of coordinates inside a given
+  /// element.
+  external void scrollTo([
+    JSAny optionsOrX,
+    num y,
+  ]);
+
+  /// The **`scrollBy()`** method of the [Element]
+  /// interface scrolls an element by the given amount.
+  external void scrollBy([
+    JSAny optionsOrX,
+    num y,
+  ]);
+
   /// The **`Element.requestFullscreen()`**
   /// method issues an asynchronous request to make the element be displayed in
   /// fullscreen
@@ -3592,6 +3592,94 @@ extension type Element._(JSObject _) implements Node, JSObject {
   /// > [Web Animations](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API).
   external JSArray<Animation> getAnimations([GetAnimationsOptions options]);
 
+  /// The **`Element.namespaceURI`** read-only property returns the namespace
+  /// URI of the element, or `null` if the element is not in a namespace.
+  external String? get namespaceURI;
+
+  /// The **`Element.prefix`** read-only property returns the
+  /// namespace prefix of the specified element, or `null` if no prefix is
+  /// specified.
+  external String? get prefix;
+
+  /// The **`Element.localName`** read-only property returns the
+  /// local part of the qualified name of an element.
+  external String get localName;
+
+  /// The **`tagName`** read-only property
+  /// of the [Element] interface returns the tag name of the element on which
+  /// it's called.
+  ///
+  /// For example, if the element is an `img`, its
+  /// `tagName` property is `IMG` (for HTML documents; it may be cased
+  /// differently for XML/XHTML documents). Note: You can use the
+  /// [Element.localName] property
+  /// to access the Element's local name — which for the case in the example is
+  /// `img` (lowercase) .
+  external String get tagName;
+
+  /// The **`id`** property of the [Element] interface
+  /// represents the element's identifier, reflecting the
+  /// [**`id`**](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id)
+  /// global attribute.
+  ///
+  /// If the `id` value is not the empty string, it must be unique in a
+  /// document.
+  ///
+  /// The `id` is often used with [Document.getElementById] to retrieve a
+  /// particular element.
+  /// Another common case is to use an element's
+  /// [ID as a selector](https://developer.mozilla.org/en-US/docs/Web/CSS/ID_selectors)
+  /// when styling the document with
+  /// [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS).
+  ///
+  /// > **Note:** Identifiers are case-sensitive, but you should avoid creating
+  /// > IDs that differ only in the capitalization.
+  external String get id;
+  external set id(String value);
+
+  /// The **`className`** property of the
+  /// [Element] interface gets and sets the value of the
+  /// [`class` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/class)
+  /// of the specified element.
+  external String get className;
+  external set className(String value);
+
+  /// The **`Element.classList`** is a read-only property that
+  /// returns a live [DOMTokenList] collection of the `class`
+  /// attributes of the element. This can then be used to manipulate the class
+  /// list.
+  ///
+  /// Using `classList` is a convenient alternative to accessing an element's
+  /// list
+  /// of classes as a space-delimited string via [element.className].
+  external DOMTokenList get classList;
+
+  /// The **`slot`** property of the [Element] interface
+  /// returns the name of the shadow DOM slot the element is inserted in.
+  ///
+  /// A slot is a placeholder inside a
+  /// [web component](https://developer.mozilla.org/en-US/docs/Web/API/Web_components)
+  /// that users can fill with their own markup (see
+  /// [Using templates and slots](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_templates_and_slots)
+  /// for more information).
+  external String get slot;
+  external set slot(String value);
+
+  /// The **`Element.attributes`** property returns a live collection
+  /// of all attribute nodes registered to the specified node. It is a
+  /// [NamedNodeMap], not an `Array`, so it has no `Array`
+  /// methods and the [Attr] nodes' indexes may differ among browsers. To be
+  /// more
+  /// specific, `attributes` is a key/value pair of strings that represents any
+  /// information regarding that attribute.
+  external NamedNodeMap get attributes;
+
+  /// The `Element.shadowRoot` read-only property
+  /// represents the shadow root hosted by the element.
+  ///
+  /// Use [Element.attachShadow] to add a shadow root to an existing element.
+  external ShadowRoot? get shadowRoot;
+
   /// The **`part`** property of the [Element] interface
   /// represents the part identifier(s) of the element (i.e. set using the
   /// `part`
@@ -3733,94 +3821,6 @@ extension type Element._(JSObject _) implements Node, JSObject {
   /// > **Note:** This property will round the value to an integer. If you need
   /// > a fractional value, use [element.getBoundingClientRect].
   external int get clientHeight;
-
-  /// The **`Element.namespaceURI`** read-only property returns the namespace
-  /// URI of the element, or `null` if the element is not in a namespace.
-  external String? get namespaceURI;
-
-  /// The **`Element.prefix`** read-only property returns the
-  /// namespace prefix of the specified element, or `null` if no prefix is
-  /// specified.
-  external String? get prefix;
-
-  /// The **`Element.localName`** read-only property returns the
-  /// local part of the qualified name of an element.
-  external String get localName;
-
-  /// The **`tagName`** read-only property
-  /// of the [Element] interface returns the tag name of the element on which
-  /// it's called.
-  ///
-  /// For example, if the element is an `img`, its
-  /// `tagName` property is `IMG` (for HTML documents; it may be cased
-  /// differently for XML/XHTML documents). Note: You can use the
-  /// [Element.localName] property
-  /// to access the Element's local name — which for the case in the example is
-  /// `img` (lowercase) .
-  external String get tagName;
-
-  /// The **`id`** property of the [Element] interface
-  /// represents the element's identifier, reflecting the
-  /// [**`id`**](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id)
-  /// global attribute.
-  ///
-  /// If the `id` value is not the empty string, it must be unique in a
-  /// document.
-  ///
-  /// The `id` is often used with [Document.getElementById] to retrieve a
-  /// particular element.
-  /// Another common case is to use an element's
-  /// [ID as a selector](https://developer.mozilla.org/en-US/docs/Web/CSS/ID_selectors)
-  /// when styling the document with
-  /// [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS).
-  ///
-  /// > **Note:** Identifiers are case-sensitive, but you should avoid creating
-  /// > IDs that differ only in the capitalization.
-  external String get id;
-  external set id(String value);
-
-  /// The **`className`** property of the
-  /// [Element] interface gets and sets the value of the
-  /// [`class` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/class)
-  /// of the specified element.
-  external String get className;
-  external set className(String value);
-
-  /// The **`Element.classList`** is a read-only property that
-  /// returns a live [DOMTokenList] collection of the `class`
-  /// attributes of the element. This can then be used to manipulate the class
-  /// list.
-  ///
-  /// Using `classList` is a convenient alternative to accessing an element's
-  /// list
-  /// of classes as a space-delimited string via [element.className].
-  external DOMTokenList get classList;
-
-  /// The **`slot`** property of the [Element] interface
-  /// returns the name of the shadow DOM slot the element is inserted in.
-  ///
-  /// A slot is a placeholder inside a
-  /// [web component](https://developer.mozilla.org/en-US/docs/Web/API/Web_components)
-  /// that users can fill with their own markup (see
-  /// [Using templates and slots](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_templates_and_slots)
-  /// for more information).
-  external String get slot;
-  external set slot(String value);
-
-  /// The **`Element.attributes`** property returns a live collection
-  /// of all attribute nodes registered to the specified node. It is a
-  /// [NamedNodeMap], not an `Array`, so it has no `Array`
-  /// methods and the [Attr] nodes' indexes may differ among browsers. To be
-  /// more
-  /// specific, `attributes` is a key/value pair of strings that represents any
-  /// information regarding that attribute.
-  external NamedNodeMap get attributes;
-
-  /// The `Element.shadowRoot` read-only property
-  /// represents the shadow root hosted by the element.
-  ///
-  /// Use [Element.attachShadow] to add a shadow root to an existing element.
-  external ShadowRoot? get shadowRoot;
   external EventHandler get onfullscreenchange;
   external set onfullscreenchange(EventHandler value);
   external EventHandler get onfullscreenerror;
@@ -4861,24 +4861,6 @@ extension type Range._(JSObject _) implements AbstractRange, JSObject {
 
   static const int END_TO_START = 3;
 
-  /// The **`Range.getClientRects()`** method returns a list of [DOMRect]
-  /// objects representing the area of the screen occupied by the
-  /// [range](https://developer.mozilla.org/en-US/docs/Web/API/Range). This is
-  /// created by aggregating the results of calls to
-  /// [Element.getClientRects] for all the elements in the range.
-  external DOMRectList getClientRects();
-
-  /// The **`Range.getBoundingClientRect()`** method returns a [DOMRect] object
-  /// that bounds the contents of the range; this is a rectangle
-  /// enclosing the union of the bounding rectangles for all the elements in the
-  /// range.
-  ///
-  /// This method is useful for determining the viewport coordinates of the
-  /// cursor or
-  /// selection inside a text box. See [Element.getBoundingClientRect] for
-  /// details on the returned value.
-  external DOMRect getBoundingClientRect();
-
   /// The **`Range.setStart()`** method sets the start position of a
   /// [Range].
   ///
@@ -5073,6 +5055,24 @@ extension type Range._(JSObject _) implements AbstractRange, JSObject {
   /// The **`Range.intersectsNode()`** method returns a boolean
   /// indicating whether the given [Node] intersects the [Range].
   external bool intersectsNode(Node node);
+
+  /// The **`Range.getClientRects()`** method returns a list of [DOMRect]
+  /// objects representing the area of the screen occupied by the
+  /// [range](https://developer.mozilla.org/en-US/docs/Web/API/Range). This is
+  /// created by aggregating the results of calls to
+  /// [Element.getClientRects] for all the elements in the range.
+  external DOMRectList getClientRects();
+
+  /// The **`Range.getBoundingClientRect()`** method returns a [DOMRect] object
+  /// that bounds the contents of the range; this is a rectangle
+  /// enclosing the union of the bounding rectangles for all the elements in the
+  /// range.
+  ///
+  /// This method is useful for determining the viewport coordinates of the
+  /// cursor or
+  /// selection inside a text box. See [Element.getBoundingClientRect] for
+  /// details on the returned value.
+  external DOMRect getBoundingClientRect();
 
   /// The **`Range.createContextualFragment()`** method returns a
   /// [DocumentFragment] by invoking the HTML fragment parsing algorithm or the

--- a/web/lib/src/dom/gamepad.dart
+++ b/web/lib/src/dom/gamepad.dart
@@ -184,13 +184,6 @@ extension type GamepadButton._(JSObject _) implements JSObject {
 /// API documentation sourced from
 /// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/GamepadHapticActuator).
 extension type GamepadHapticActuator._(JSObject _) implements JSObject {
-  /// The **`pulse()`** method of the [GamepadHapticActuator] interface makes
-  /// the hardware pulse at a certain intensity for a specified duration.
-  external JSPromise<JSBoolean> pulse(
-    num value,
-    num duration,
-  );
-
   /// The **`playEffect()`** method of the [GamepadHapticActuator] interface
   /// makes the hardware play a specific vibration pattern.
   external JSPromise<JSString> playEffect(
@@ -198,6 +191,13 @@ extension type GamepadHapticActuator._(JSObject _) implements JSObject {
     GamepadEffectParameters params,
   ]);
   external JSPromise<JSString> reset();
+
+  /// The **`pulse()`** method of the [GamepadHapticActuator] interface makes
+  /// the hardware pulse at a certain intensity for a specified duration.
+  external JSPromise<JSBoolean> pulse(
+    num value,
+    num duration,
+  );
 }
 extension type GamepadEffectParameters._(JSObject _) implements JSObject {
   external factory GamepadEffectParameters({

--- a/web/lib/src/dom/hr_time.dart
+++ b/web/lib/src/dom/hr_time.dart
@@ -186,13 +186,6 @@ extension type Performance._(JSObject _) implements EventTarget, JSObject {
   /// [PerformanceMeasure] objects from the browser's performance timeline.
   external void clearMeasures([String measureName]);
 
-  /// The read-only `performance.eventCounts` property is an [EventCounts] map
-  /// containing the number of events which have been dispatched per event type.
-  ///
-  /// Not all event types are exposed. You can only get counts for event types
-  /// supported by the [PerformanceEventTiming] interface.
-  external EventCounts get eventCounts;
-
   /// The **`timeOrigin`** read-only property of the [Performance] interface
   /// returns the high resolution timestamp that is used as the baseline for
   /// performance-related timestamps.
@@ -210,6 +203,13 @@ extension type Performance._(JSObject _) implements EventTarget, JSObject {
   /// > which current time never decreases and which isn't subject to these
   /// > adjustments.
   external double get timeOrigin;
+
+  /// The read-only `performance.eventCounts` property is an [EventCounts] map
+  /// containing the number of events which have been dispatched per event type.
+  ///
+  /// Not all event types are exposed. You can only get counts for event types
+  /// supported by the [PerformanceEventTiming] interface.
+  external EventCounts get eventCounts;
 
   /// The legacy
   /// **`Performance.timing`** read-only

--- a/web/lib/src/dom/html.dart
+++ b/web/lib/src/dom/html.dart
@@ -501,94 +501,6 @@ extension type HTMLElement._(JSObject _) implements Element, JSObject {
   /// current element.
   external void blur();
 
-  /// The **`HTMLElement.offsetParent`** read-only property returns a
-  /// reference to the element which is the closest (nearest in the containment
-  /// hierarchy)
-  /// positioned ancestor element.
-  ///
-  /// A positioned ancestor is either:
-  ///
-  /// - an element with a non-static position, or
-  /// - `td`, `th`, `table` in case the element itself is static positioned.
-  ///
-  /// If there is no positioned ancestor element, the `body` is returned.
-  ///
-  /// > **Note:** `offsetParent` returns `null` in the following
-  /// > situations:
-  /// >
-  /// > - The element or any ancestor has the `display` property set to
-  /// > `none`.
-  /// > - The element has the `position` property set to `fixed`
-  /// > (Firefox returns `<body>`).
-  /// > - The element is `<body>` or `<html>`.
-  ///
-  /// `offsetParent` is useful because
-  /// [HTMLElement.offsetTop] and
-  /// [HTMLElement.offsetLeft] are relative to its padding edge.
-  external Element? get offsetParent;
-
-  /// The **`HTMLElement.offsetTop`** read-only property returns the
-  /// distance from the outer border of the current element (including its
-  /// margin) to the top padding edge of the [HTMLelement.offsetParent], the
-  /// _closest positioned_
-  /// ancestor element.
-  external int get offsetTop;
-
-  /// The **`HTMLElement.offsetLeft`** read-only property returns the number of
-  /// pixels that the _upper left corner_ of the current element is offset to
-  /// the left within the [HTMLElement.offsetParent] node.
-  ///
-  /// For block-level elements, `offsetTop`, `offsetLeft`, `offsetWidth`, and
-  /// `offsetHeight` describe the border box of an element relative to the
-  /// `offsetParent`.
-  ///
-  /// However, for inline-level elements (such as **span**) that can wrap from
-  /// one line to the next, `offsetTop` and `offsetLeft` describe the positions
-  /// of the _first_ border box (use [Element.getClientRects] to get its width
-  /// and height), while `offsetWidth` and `offsetHeight` describe the
-  /// dimensions of the _bounding_ border box (use
-  /// [Element.getBoundingClientRect] to get its position). Therefore, a box
-  /// with the left, top, width and height of `offsetLeft`, `offsetTop`,
-  /// `offsetWidth` and `offsetHeight` will not be a bounding box for a span
-  /// with wrapped text.
-  external int get offsetLeft;
-
-  /// The **`HTMLElement.offsetWidth`** read-only property returns
-  /// the layout width of an element as an integer.
-  ///
-  /// Typically, `offsetWidth` is a measurement in pixels of the element's CSS
-  /// width, including any borders, padding, and vertical scrollbars (if
-  /// rendered). It does
-  /// not include the width of pseudo-elements such as `::before` or
-  /// `::after`.
-  ///
-  /// If the element is hidden (for example, by setting `style.display` on the
-  /// element or one of its ancestors to `"none"`), then `0` is
-  /// returned.
-  external int get offsetWidth;
-
-  /// The **`HTMLElement.offsetHeight`** read-only property returns
-  /// the height of an element, including vertical padding and borders, as an
-  /// integer.
-  ///
-  /// Typically, `offsetHeight` is a measurement in pixels of the element's CSS
-  /// height, including any borders, padding, and horizontal scrollbars (if
-  /// rendered). It does
-  /// not include the height of pseudo-elements such as `::before` or
-  /// `::after`. For the document body object, the measurement includes total
-  /// linear content height instead of the element's CSS height. Floated
-  /// elements extending
-  /// below other linear content are ignored.
-  ///
-  /// If the element is hidden (for example, by setting `style.display` on the
-  /// element or one of its ancestors to `"none"`), then `0` is
-  /// returned.
-  ///
-  /// > **Note:** This property will round the value to an integer. If you need
-  /// > a fractional value, use
-  /// > [element.getBoundingClientRect].
-  external int get offsetHeight;
-
   /// The **`HTMLElement.title`** property
   /// represents the title of the element: the text usually displayed in a
   /// 'tooltip' popup
@@ -779,25 +691,93 @@ extension type HTMLElement._(JSObject _) implements Element, JSObject {
   external String? get popover;
   external set popover(String? value);
 
-  /// The **`attributeStyleMap`** read-only property of the [HTMLElement]
-  /// interface returns a live [StylePropertyMap] object that contains a list of
-  /// style properties of the element that are defined in the element's inline
-  /// `style` attribute, or assigned using the [HTMLElement.style] property of
-  /// the [HTMLElement] interface via script.
+  /// The **`HTMLElement.offsetParent`** read-only property returns a
+  /// reference to the element which is the closest (nearest in the containment
+  /// hierarchy)
+  /// positioned ancestor element.
   ///
-  /// Shorthand properties are expanded. If you set `border-top: 1px solid
-  /// black`, the longhand properties (, , and ) are set instead.
+  /// A positioned ancestor is either:
   ///
-  /// The main difference between [HTMLElement.style] property and
-  /// `attributeStyleMap` property is that, the `style` property will return a
-  /// [CSSStyleDeclaration] object, while the `attributeStyleMap` property will
-  /// return a [StylePropertyMap] object.
+  /// - an element with a non-static position, or
+  /// - `td`, `th`, `table` in case the element itself is static positioned.
   ///
-  /// Though the property itself is not writable, you could read and write
-  /// inline styles through the [StylePropertyMap] object that it returns, just
-  /// like through the [CSSStyleDeclaration] object that returns via the `style`
-  /// property.
-  external StylePropertyMap get attributeStyleMap;
+  /// If there is no positioned ancestor element, the `body` is returned.
+  ///
+  /// > **Note:** `offsetParent` returns `null` in the following
+  /// > situations:
+  /// >
+  /// > - The element or any ancestor has the `display` property set to
+  /// > `none`.
+  /// > - The element has the `position` property set to `fixed`
+  /// > (Firefox returns `<body>`).
+  /// > - The element is `<body>` or `<html>`.
+  ///
+  /// `offsetParent` is useful because
+  /// [HTMLElement.offsetTop] and
+  /// [HTMLElement.offsetLeft] are relative to its padding edge.
+  external Element? get offsetParent;
+
+  /// The **`HTMLElement.offsetTop`** read-only property returns the
+  /// distance from the outer border of the current element (including its
+  /// margin) to the top padding edge of the [HTMLelement.offsetParent], the
+  /// _closest positioned_
+  /// ancestor element.
+  external int get offsetTop;
+
+  /// The **`HTMLElement.offsetLeft`** read-only property returns the number of
+  /// pixels that the _upper left corner_ of the current element is offset to
+  /// the left within the [HTMLElement.offsetParent] node.
+  ///
+  /// For block-level elements, `offsetTop`, `offsetLeft`, `offsetWidth`, and
+  /// `offsetHeight` describe the border box of an element relative to the
+  /// `offsetParent`.
+  ///
+  /// However, for inline-level elements (such as **span**) that can wrap from
+  /// one line to the next, `offsetTop` and `offsetLeft` describe the positions
+  /// of the _first_ border box (use [Element.getClientRects] to get its width
+  /// and height), while `offsetWidth` and `offsetHeight` describe the
+  /// dimensions of the _bounding_ border box (use
+  /// [Element.getBoundingClientRect] to get its position). Therefore, a box
+  /// with the left, top, width and height of `offsetLeft`, `offsetTop`,
+  /// `offsetWidth` and `offsetHeight` will not be a bounding box for a span
+  /// with wrapped text.
+  external int get offsetLeft;
+
+  /// The **`HTMLElement.offsetWidth`** read-only property returns
+  /// the layout width of an element as an integer.
+  ///
+  /// Typically, `offsetWidth` is a measurement in pixels of the element's CSS
+  /// width, including any borders, padding, and vertical scrollbars (if
+  /// rendered). It does
+  /// not include the width of pseudo-elements such as `::before` or
+  /// `::after`.
+  ///
+  /// If the element is hidden (for example, by setting `style.display` on the
+  /// element or one of its ancestors to `"none"`), then `0` is
+  /// returned.
+  external int get offsetWidth;
+
+  /// The **`HTMLElement.offsetHeight`** read-only property returns
+  /// the height of an element, including vertical padding and borders, as an
+  /// integer.
+  ///
+  /// Typically, `offsetHeight` is a measurement in pixels of the element's CSS
+  /// height, including any borders, padding, and horizontal scrollbars (if
+  /// rendered). It does
+  /// not include the height of pseudo-elements such as `::before` or
+  /// `::after`. For the document body object, the measurement includes total
+  /// linear content height instead of the element's CSS height. Floated
+  /// elements extending
+  /// below other linear content are ignored.
+  ///
+  /// If the element is hidden (for example, by setting `style.display` on the
+  /// element or one of its ancestors to `"none"`), then `0` is
+  /// returned.
+  ///
+  /// > **Note:** This property will round the value to an integer. If you need
+  /// > a fractional value, use
+  /// > [element.getBoundingClientRect].
+  external int get offsetHeight;
 
   /// The read-only **`style`** property of the [HTMLElement] returns the
   /// _inline_ style of an element in the form of a live [CSSStyleDeclaration]
@@ -841,22 +821,26 @@ extension type HTMLElement._(JSObject _) implements Element, JSObject {
   /// > The `style` property has the same priority in the CSS cascade as an
   /// > inline style declaration set via the `style` attribute.
   external CSSStyleDeclaration get style;
-  external EventHandler get onanimationstart;
-  external set onanimationstart(EventHandler value);
-  external EventHandler get onanimationiteration;
-  external set onanimationiteration(EventHandler value);
-  external EventHandler get onanimationend;
-  external set onanimationend(EventHandler value);
-  external EventHandler get onanimationcancel;
-  external set onanimationcancel(EventHandler value);
-  external EventHandler get ontransitionrun;
-  external set ontransitionrun(EventHandler value);
-  external EventHandler get ontransitionstart;
-  external set ontransitionstart(EventHandler value);
-  external EventHandler get ontransitionend;
-  external set ontransitionend(EventHandler value);
-  external EventHandler get ontransitioncancel;
-  external set ontransitioncancel(EventHandler value);
+
+  /// The **`attributeStyleMap`** read-only property of the [HTMLElement]
+  /// interface returns a live [StylePropertyMap] object that contains a list of
+  /// style properties of the element that are defined in the element's inline
+  /// `style` attribute, or assigned using the [HTMLElement.style] property of
+  /// the [HTMLElement] interface via script.
+  ///
+  /// Shorthand properties are expanded. If you set `border-top: 1px solid
+  /// black`, the longhand properties (, , and ) are set instead.
+  ///
+  /// The main difference between [HTMLElement.style] property and
+  /// `attributeStyleMap` property is that, the `style` property will return a
+  /// [CSSStyleDeclaration] object, while the `attributeStyleMap` property will
+  /// return a [StylePropertyMap] object.
+  ///
+  /// Though the property itself is not writable, you could read and write
+  /// inline styles through the [StylePropertyMap] object that it returns, just
+  /// like through the [CSSStyleDeclaration] object that returns via the `style`
+  /// property.
+  external StylePropertyMap get attributeStyleMap;
   external EventHandler get onabort;
   external set onabort(EventHandler value);
   external EventHandler get onauxclick;
@@ -997,6 +981,22 @@ extension type HTMLElement._(JSObject _) implements Element, JSObject {
   external set onwaiting(EventHandler value);
   external EventHandler get onwheel;
   external set onwheel(EventHandler value);
+  external EventHandler get onanimationstart;
+  external set onanimationstart(EventHandler value);
+  external EventHandler get onanimationiteration;
+  external set onanimationiteration(EventHandler value);
+  external EventHandler get onanimationend;
+  external set onanimationend(EventHandler value);
+  external EventHandler get onanimationcancel;
+  external set onanimationcancel(EventHandler value);
+  external EventHandler get ontransitionrun;
+  external set ontransitionrun(EventHandler value);
+  external EventHandler get ontransitionstart;
+  external set ontransitionstart(EventHandler value);
+  external EventHandler get ontransitionend;
+  external set ontransitionend(EventHandler value);
+  external EventHandler get ontransitioncancel;
+  external set ontransitioncancel(EventHandler value);
   external EventHandler get onpointerover;
   external set onpointerover(EventHandler value);
   external EventHandler get onpointerenter;
@@ -1665,10 +1665,6 @@ extension type HTMLBodyElement._(JSObject _) implements HTMLElement, JSObject {
   external set bgColor(String value);
   external String get background;
   external set background(String value);
-  external EventHandler get ongamepadconnected;
-  external set ongamepadconnected(EventHandler value);
-  external EventHandler get ongamepaddisconnected;
-  external set ongamepaddisconnected(EventHandler value);
   external EventHandler get onafterprint;
   external set onafterprint(EventHandler value);
   external EventHandler get onbeforeprint;
@@ -1701,6 +1697,10 @@ extension type HTMLBodyElement._(JSObject _) implements HTMLElement, JSObject {
   external set onunhandledrejection(EventHandler value);
   external EventHandler get onunload;
   external set onunload(EventHandler value);
+  external EventHandler get ongamepadconnected;
+  external set ongamepadconnected(EventHandler value);
+  external EventHandler get ongamepaddisconnected;
+  external set ongamepaddisconnected(EventHandler value);
 }
 
 /// The **`HTMLHeadingElement`** interface represents the different heading
@@ -2486,34 +2486,6 @@ extension type HTMLImageElement._(JSObject _) implements HTMLElement, JSObject {
   /// a delay while the image loads.
   external JSPromise<JSAny?> decode();
 
-  /// The read-only [HTMLImageElement] property
-  /// **`x`** indicates the x-coordinate of the
-  /// `img` element's left border edge relative to the root element's
-  /// origin.
-  ///
-  /// The `x` and [HTMLImageElement.y] properties are only valid
-  /// for an image if its `display` property has the computed value
-  /// `table-column` or `table-column-group`. In other words: it has
-  /// either of those values set explicitly on it, or it has inherited it from a
-  /// containing
-  /// element, or by being located within a column described by either `col`
-  /// or `colgroup`.
-  external int get x;
-
-  /// The read-only [HTMLImageElement] property
-  /// **`y`** indicates the y-coordinate of the
-  /// `img` element's top border edge relative to the root element's
-  /// origin.
-  ///
-  /// The [HTMLImageElement.x] and `y` properties are only valid
-  /// for an image if its `display` property has the computed value
-  /// `table-column` or `table-column-group`. In other words: it has
-  /// either of those values set explicitly on it, or it has inherited it from a
-  /// containing
-  /// element, or by being located within a column described by either
-  /// `col` or `colgroup`.
-  external int get y;
-
   /// The [HTMLImageElement] property **`alt`** provides fallback (alternate)
   /// text to display when the image specified by the `img` element is not
   /// loaded.
@@ -2723,6 +2695,34 @@ extension type HTMLImageElement._(JSObject _) implements HTMLElement, JSObject {
   /// it should prioritize the fetch of the image relative to other images.
   external String get fetchPriority;
   external set fetchPriority(String value);
+
+  /// The read-only [HTMLImageElement] property
+  /// **`x`** indicates the x-coordinate of the
+  /// `img` element's left border edge relative to the root element's
+  /// origin.
+  ///
+  /// The `x` and [HTMLImageElement.y] properties are only valid
+  /// for an image if its `display` property has the computed value
+  /// `table-column` or `table-column-group`. In other words: it has
+  /// either of those values set explicitly on it, or it has inherited it from a
+  /// containing
+  /// element, or by being located within a column described by either `col`
+  /// or `colgroup`.
+  external int get x;
+
+  /// The read-only [HTMLImageElement] property
+  /// **`y`** indicates the y-coordinate of the
+  /// `img` element's top border edge relative to the root element's
+  /// origin.
+  ///
+  /// The [HTMLImageElement.x] and `y` properties are only valid
+  /// for an image if its `display` property has the computed value
+  /// `table-column` or `table-column-group`. In other words: it has
+  /// either of those values set explicitly on it, or it has inherited it from a
+  /// containing
+  /// element, or by being located within a column described by either
+  /// `col` or `colgroup`.
+  external int get y;
 
   /// The [HTMLImageElement]
   /// interface's _deprecated_ **`name`** property specifies
@@ -3321,23 +3321,6 @@ extension type HTMLMediaElement._(JSObject _) implements HTMLElement, JSObject {
 
   static const int HAVE_ENOUGH_DATA = 4;
 
-  /// The **`HTMLMediaElement.setSinkId()`** method of the
-  /// [Audio Output Devices API](https://developer.mozilla.org/en-US/docs/Web/API/Audio_Output_Devices_API)
-  /// sets the ID of the audio device to use for output and returns a `Promise`.
-  ///
-  /// This only works when the application is permitted to use the specified
-  /// device.
-  /// For more information see the
-  /// [security requirements](#security_requirements) below.
-  external JSPromise<JSAny?> setSinkId(String sinkId);
-
-  /// The **`setMediaKeys()`** method of the [HTMLMediaElement] interface sets
-  /// the [MediaKeys] that will be used to decrypt media during playback.
-  ///
-  /// It returns a `Promise` that fulfils if the new keys are successfully set,
-  /// or rejects if keys cannot be set.
-  external JSPromise<JSAny?> setMediaKeys(MediaKeys? mediaKeys);
-
   /// The [HTMLMediaElement] method
   /// **`load()`** resets the media element to its initial state and
   /// begins the process of selecting a media source and loading the media in
@@ -3391,6 +3374,23 @@ extension type HTMLMediaElement._(JSObject _) implements HTMLElement, JSObject {
     String language,
   ]);
 
+  /// The **`HTMLMediaElement.setSinkId()`** method of the
+  /// [Audio Output Devices API](https://developer.mozilla.org/en-US/docs/Web/API/Audio_Output_Devices_API)
+  /// sets the ID of the audio device to use for output and returns a `Promise`.
+  ///
+  /// This only works when the application is permitted to use the specified
+  /// device.
+  /// For more information see the
+  /// [security requirements](#security_requirements) below.
+  external JSPromise<JSAny?> setSinkId(String sinkId);
+
+  /// The **`setMediaKeys()`** method of the [HTMLMediaElement] interface sets
+  /// the [MediaKeys] that will be used to decrypt media during playback.
+  ///
+  /// It returns a `Promise` that fulfils if the new keys are successfully set,
+  /// or rejects if keys cannot be set.
+  external JSPromise<JSAny?> setMediaKeys(MediaKeys? mediaKeys);
+
   /// The **`captureStream()`** method of the [HTMLMediaElement] interface
   /// returns a [MediaStream] object which is streaming a real-time capture of
   /// the content being rendered in the media element.
@@ -3399,27 +3399,6 @@ extension type HTMLMediaElement._(JSObject _) implements HTMLElement, JSObject {
   /// [WebRTC](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API)
   /// [RTCPeerConnection].
   external MediaStream captureStream();
-
-  /// The **`HTMLMediaElement.sinkId`** read-only property of the
-  /// [Audio Output Devices API](https://developer.mozilla.org/en-US/docs/Web/API/Audio_Output_Devices_API)
-  /// returns a string that is the unique ID of the device to be used for
-  /// playing audio output.
-  ///
-  /// This ID should be one of the [MediaDeviceInfo.deviceId] values returned
-  /// from [MediaDevices.enumerateDevices], `id-multimedia`, or
-  /// `id-communications`.
-  /// If the user agent default device is being used, it returns an empty
-  /// string.
-  external String get sinkId;
-
-  /// The read-only **`HTMLMediaElement.mediaKeys`** property returns a
-  /// [MediaKeys] object, that is a set of keys that the element can use for
-  /// decryption of media data during playback.
-  external MediaKeys? get mediaKeys;
-  external EventHandler get onencrypted;
-  external set onencrypted(EventHandler value);
-  external EventHandler get onwaitingforkey;
-  external set onwaitingforkey(EventHandler value);
 
   /// The **`HTMLMediaElement.error`** property is the
   /// [MediaError] object for the most recent error, or `null` if
@@ -3692,6 +3671,27 @@ extension type HTMLMediaElement._(JSObject _) implements HTMLElement, JSObject {
   /// to learn
   /// more about watching for changes to a media element's track list.
   external TextTrackList get textTracks;
+
+  /// The **`HTMLMediaElement.sinkId`** read-only property of the
+  /// [Audio Output Devices API](https://developer.mozilla.org/en-US/docs/Web/API/Audio_Output_Devices_API)
+  /// returns a string that is the unique ID of the device to be used for
+  /// playing audio output.
+  ///
+  /// This ID should be one of the [MediaDeviceInfo.deviceId] values returned
+  /// from [MediaDevices.enumerateDevices], `id-multimedia`, or
+  /// `id-communications`.
+  /// If the user agent default device is being used, it returns an empty
+  /// string.
+  external String get sinkId;
+
+  /// The read-only **`HTMLMediaElement.mediaKeys`** property returns a
+  /// [MediaKeys] object, that is a set of keys that the element can use for
+  /// decryption of media data during playback.
+  external MediaKeys? get mediaKeys;
+  external EventHandler get onencrypted;
+  external set onencrypted(EventHandler value);
+  external EventHandler get onwaitingforkey;
+  external set onwaitingforkey(EventHandler value);
 
   /// The **`remote`** read-only property of the [HTMLMediaElement] interface
   /// returns the [RemotePlayback] object associated with the media element. The
@@ -5607,44 +5607,6 @@ extension type HTMLInputElement._(JSObject _) implements HTMLElement, JSObject {
   /// More generally, this method should ideally display the picker for any
   /// input element on the platform that has a picker.
   external void showPicker();
-
-  /// The **`HTMLInputElement.webkitdirectory`** is a property
-  /// that reflects the
-  /// [`webkitdirectory`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#webkitdirectory)
-  /// HTML attribute
-  /// and indicates that the `input` element should let the user select
-  /// directories instead of files.
-  /// When a directory is selected, the directory and its entire hierarchy of
-  /// contents are included in the set of selected items.
-  /// The selected file system entries can be obtained using the
-  /// [HTMLInputElement.webkitEntries] property.
-  ///
-  /// > **Note:** This property is called `webkitEntries` in the specification
-  /// > due to its
-  /// > origins as a Google Chrome-specific API. It's likely to be renamed
-  /// > someday.
-  external bool get webkitdirectory;
-  external set webkitdirectory(bool value);
-
-  /// The read-only **`webkitEntries`**
-  /// property of the [HTMLInputElement] interface contains an array of file
-  /// system entries (as objects based on [FileSystemEntry]) representing files
-  /// and/or directories selected by the user using an `input` element of
-  /// type `file`, but only if that selection was made using drag-and-drop:
-  /// selecting a file in the dialog will leave the property empty.
-  ///
-  /// The array can only contain directories if the
-  /// [HTMLInputElement.webkitdirectory] property is
-  /// `true`. This means the `<input>` element was configured to
-  /// let the user choose directories.
-  ///
-  /// > **Note:** This property is called `webkitEntries` in the specification
-  /// > due to its
-  /// > origins as a Google Chrome-specific API. It's likely to be renamed
-  /// > someday.
-  external JSArray<FileSystemEntry> get webkitEntries;
-  external String get capture;
-  external set capture(String value);
   external String get accept;
   external set accept(String value);
   external String get alt;
@@ -5791,6 +5753,44 @@ extension type HTMLInputElement._(JSObject _) implements HTMLElement, JSObject {
   /// the text.
   external String? get selectionDirection;
   external set selectionDirection(String? value);
+
+  /// The **`HTMLInputElement.webkitdirectory`** is a property
+  /// that reflects the
+  /// [`webkitdirectory`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#webkitdirectory)
+  /// HTML attribute
+  /// and indicates that the `input` element should let the user select
+  /// directories instead of files.
+  /// When a directory is selected, the directory and its entire hierarchy of
+  /// contents are included in the set of selected items.
+  /// The selected file system entries can be obtained using the
+  /// [HTMLInputElement.webkitEntries] property.
+  ///
+  /// > **Note:** This property is called `webkitEntries` in the specification
+  /// > due to its
+  /// > origins as a Google Chrome-specific API. It's likely to be renamed
+  /// > someday.
+  external bool get webkitdirectory;
+  external set webkitdirectory(bool value);
+
+  /// The read-only **`webkitEntries`**
+  /// property of the [HTMLInputElement] interface contains an array of file
+  /// system entries (as objects based on [FileSystemEntry]) representing files
+  /// and/or directories selected by the user using an `input` element of
+  /// type `file`, but only if that selection was made using drag-and-drop:
+  /// selecting a file in the dialog will leave the property empty.
+  ///
+  /// The array can only contain directories if the
+  /// [HTMLInputElement.webkitdirectory] property is
+  /// `true`. This means the `<input>` element was configured to
+  /// let the user choose directories.
+  ///
+  /// > **Note:** This property is called `webkitEntries` in the specification
+  /// > due to its
+  /// > origins as a Google Chrome-specific API. It's likely to be renamed
+  /// > someday.
+  external JSArray<FileSystemEntry> get webkitEntries;
+  external String get capture;
+  external set capture(String value);
   external String get align;
   external set align(String value);
   external String get useMap;
@@ -9914,17 +9914,6 @@ extension type DataTransferItemList._(JSObject _) implements JSObject {
 /// API documentation sourced from
 /// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem).
 extension type DataTransferItem._(JSObject _) implements JSObject {
-  /// If the item described by the [DataTransferItem] is a file,
-  /// `webkitGetAsEntry()` returns a [FileSystemFileEntry] or
-  /// [FileSystemDirectoryEntry] representing it. If the item isn't a file,
-  /// `null` is returned.
-  ///
-  /// > **Note:** This function is implemented as `webkitGetAsEntry()` in
-  /// > non-WebKit browsers including Firefox at this time; it may be renamed to
-  /// > `getAsEntry()` in the future, so you should code defensively, looking
-  /// > for both.
-  external FileSystemEntry? webkitGetAsEntry();
-
   /// The **`DataTransferItem.getAsString()`** method invokes the given callback
   /// with the drag data item's string data as the argument if the item's
   /// [DataTransferItem.kind] is a _Plain unicode string_ (i.e. `kind` is
@@ -9935,6 +9924,17 @@ extension type DataTransferItem._(JSObject _) implements JSObject {
   /// returns the drag data item's [File] object.
   /// If the item is not a file, this method returns `null`.
   external File? getAsFile();
+
+  /// If the item described by the [DataTransferItem] is a file,
+  /// `webkitGetAsEntry()` returns a [FileSystemFileEntry] or
+  /// [FileSystemDirectoryEntry] representing it. If the item isn't a file,
+  /// `null` is returned.
+  ///
+  /// > **Note:** This function is implemented as `webkitGetAsEntry()` in
+  /// > non-WebKit browsers including Firefox at this time; it may be renamed to
+  /// > `getAsEntry()` in the future, so you should code defensively, looking
+  /// > for both.
+  external FileSystemEntry? webkitGetAsEntry();
 
   /// The read-only **`DataTransferItem.kind`** property returns the kind–a
   /// string or a file–of the [DataTransferItem] object representing the _drag
@@ -10046,88 +10046,6 @@ external Window get window;
 /// API documentation sourced from
 /// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/Window).
 extension type Window._(JSObject _) implements EventTarget, JSObject {
-  /// The [Window] interface's **`matchMedia()`** method
-  /// returns a new [MediaQueryList] object that can then be used to determine
-  /// if
-  /// the [document] matches the
-  /// [media query](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries)
-  /// string,
-  /// as well as to monitor the document to detect when it matches (or stops
-  /// matching) that
-  /// media query.
-  external MediaQueryList matchMedia(String query);
-
-  /// The **`moveTo()`** method of the [Window]
-  /// interface moves the current window to the specified coordinates.
-  ///
-  /// > **Note:** This function moves the window to an absolute location. In
-  /// > contrast, [window.moveBy] moves the window relative to its current
-  /// > location.
-  external void moveTo(
-    int x,
-    int y,
-  );
-
-  /// The **`moveBy()`** method of the [Window]
-  /// interface moves the current window by a specified amount.
-  ///
-  /// > **Note:** This function moves the window relative to its current
-  /// > location. In contrast, [window.moveTo] moves the window to an absolute
-  /// > location.
-  external void moveBy(
-    int x,
-    int y,
-  );
-
-  /// The **`Window.resizeTo()`** method dynamically resizes the
-  /// window.
-  external void resizeTo(
-    int width,
-    int height,
-  );
-
-  /// The **`Window.resizeBy()`** method resizes the current window
-  /// by a specified amount.
-  external void resizeBy(
-    int x,
-    int y,
-  );
-
-  /// The **`Window.scroll()`** method scrolls the window to a
-  /// particular place in the document.
-  external void scroll([
-    JSAny optionsOrX,
-    num y,
-  ]);
-
-  /// **`Window.scrollTo()`** scrolls to a particular set of
-  /// coordinates in the document.
-  external void scrollTo([
-    JSAny optionsOrX,
-    num y,
-  ]);
-
-  /// The **`Window.scrollBy()`** method scrolls the document in the
-  /// window by the given amount.
-  external void scrollBy([
-    JSAny optionsOrX,
-    num y,
-  ]);
-
-  /// The
-  /// **`Window.getComputedStyle()`** method returns an object
-  /// containing the values of all CSS properties of an element, after applying
-  /// active
-  /// stylesheets and resolving any basic computation those values may contain.
-  ///
-  /// Individual CSS property values are accessed through APIs provided by the
-  /// object, or by
-  /// indexing with CSS property names.
-  external CSSStyleDeclaration getComputedStyle(
-    Element elt, [
-    String? pseudoElt,
-  ]);
-
   /// The **`Window.close()`** method closes the current window, or
   /// the window on which it was called.
   ///
@@ -10251,6 +10169,88 @@ extension type Window._(JSObject _) implements EventTarget, JSObject {
     JSArray<JSObject> transfer,
   ]);
 
+  /// The [Window] interface's **`matchMedia()`** method
+  /// returns a new [MediaQueryList] object that can then be used to determine
+  /// if
+  /// the [document] matches the
+  /// [media query](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries)
+  /// string,
+  /// as well as to monitor the document to detect when it matches (or stops
+  /// matching) that
+  /// media query.
+  external MediaQueryList matchMedia(String query);
+
+  /// The **`moveTo()`** method of the [Window]
+  /// interface moves the current window to the specified coordinates.
+  ///
+  /// > **Note:** This function moves the window to an absolute location. In
+  /// > contrast, [window.moveBy] moves the window relative to its current
+  /// > location.
+  external void moveTo(
+    int x,
+    int y,
+  );
+
+  /// The **`moveBy()`** method of the [Window]
+  /// interface moves the current window by a specified amount.
+  ///
+  /// > **Note:** This function moves the window relative to its current
+  /// > location. In contrast, [window.moveTo] moves the window to an absolute
+  /// > location.
+  external void moveBy(
+    int x,
+    int y,
+  );
+
+  /// The **`Window.resizeTo()`** method dynamically resizes the
+  /// window.
+  external void resizeTo(
+    int width,
+    int height,
+  );
+
+  /// The **`Window.resizeBy()`** method resizes the current window
+  /// by a specified amount.
+  external void resizeBy(
+    int x,
+    int y,
+  );
+
+  /// The **`Window.scroll()`** method scrolls the window to a
+  /// particular place in the document.
+  external void scroll([
+    JSAny optionsOrX,
+    num y,
+  ]);
+
+  /// **`Window.scrollTo()`** scrolls to a particular set of
+  /// coordinates in the document.
+  external void scrollTo([
+    JSAny optionsOrX,
+    num y,
+  ]);
+
+  /// The **`Window.scrollBy()`** method scrolls the document in the
+  /// window by the given amount.
+  external void scrollBy([
+    JSAny optionsOrX,
+    num y,
+  ]);
+
+  /// The
+  /// **`Window.getComputedStyle()`** method returns an object
+  /// containing the values of all CSS properties of an element, after applying
+  /// active
+  /// stylesheets and resolving any basic computation those values may contain.
+  ///
+  /// Individual CSS property values are accessed through APIs provided by the
+  /// object, or by
+  /// indexing with CSS property names.
+  external CSSStyleDeclaration getComputedStyle(
+    Element elt, [
+    String? pseudoElt,
+  ]);
+
   /// The **`Window.captureEvents()`** method does nothing.
   ///
   /// > **Note:** This is an method long removed from the specification. It is
@@ -10293,10 +10293,6 @@ extension type Window._(JSObject _) implements EventTarget, JSObject {
   /// [Selection] object representing the range of text selected by the user or
   /// the current position of the caret.
   external Selection? getSelection();
-  external JSPromise<Response> fetch(
-    RequestInfo input, [
-    RequestInit init,
-  ]);
   external void reportError(JSAny? e);
 
   /// The **`btoa()`** method of the [Window] interface creates a
@@ -10348,6 +10344,10 @@ extension type Window._(JSObject _) implements EventTarget, JSObject {
     JSAny? value, [
     StructuredSerializeOptions options,
   ]);
+  external JSPromise<Response> fetch(
+    RequestInfo input, [
+    RequestInit init,
+  ]);
 
   /// The **`window.requestAnimationFrame()`** method tells the
   /// browser you wish to perform an animation. It requests the browser to call
@@ -10382,150 +10382,6 @@ extension type Window._(JSObject _) implements EventTarget, JSObject {
   /// animation frame request previously scheduled through a call to
   /// [window.requestAnimationFrame].
   external void cancelAnimationFrame(int handle);
-
-  /// Returns the orientation in degrees (in 90-degree increments) of the
-  /// viewport relative to the device's natural orientation.
-  ///
-  /// Its only possible values are `-90`, `0`, `90`, and `180`. Positive values
-  /// are counterclockwise; negative values are clockwise.
-  ///
-  /// This property is deprecated. Use the [Screen.orientation] property
-  /// instead, available on the [window.screen] property.
-  external int get orientation;
-  external EventHandler get onorientationchange;
-  external set onorientationchange(EventHandler value);
-
-  /// The [Window] property **`screen`** returns a
-  /// reference to the screen object associated with the window. The `screen`
-  /// object, implementing the [Screen] interface, is a special object for
-  /// inspecting properties of the screen on which the current window is being
-  /// rendered.
-  external Screen get screen;
-
-  /// The **`visualViewport`** read-only property of the [Window] interface
-  /// returns a [VisualViewport] object representing the visual viewport for a
-  /// given window, or `null` if current document is not fully active.
-  external VisualViewport? get visualViewport;
-
-  /// The read-only [Window] property **`innerWidth`** returns the interior
-  /// width of the window in pixels (that is, the width of the window's ). That
-  /// includes the width of the vertical scroll bar, if one is present.
-  ///
-  /// Similarly, the interior height of the window (that is, the height of the
-  /// layout viewport) can be obtained using the [Window.innerHeight] property.
-  /// That measurement also accounts for the height of the horizontal scroll
-  /// bar, if it is visible.
-  external int get innerWidth;
-
-  /// The read-only **`innerHeight`** property of the
-  /// [Window] interface returns the interior height of the window in pixels,
-  /// including the height of the horizontal scroll bar, if present.
-  ///
-  /// The value of `innerHeight` is taken from the height of the window's
-  /// . The width can be obtained using the
-  /// [Window.innerWidth] property.
-  external int get innerHeight;
-
-  /// The read-only **`scrollX`** property of the [Window] interface returns the
-  /// number of pixels by which the document is currently scrolled horizontally.
-  /// This value is subpixel precise in modern browsers, meaning that it isn't
-  /// necessarily a whole number. You can get the number of pixels the document
-  /// is scrolled vertically from the [Window.scrollY] property.
-  external double get scrollX;
-
-  /// The read-only **`scrollY`** property of the [Window] interface returns the
-  /// number of pixels by which the document is currently scrolled vertically.
-  /// This value is subpixel precise in modern browsers, meaning that it isn't
-  /// necessarily a whole number. You can get the number of pixels the document
-  /// is scrolled horizontally from the [Window.scrollX] property.
-  external double get scrollY;
-
-  /// The **`Window.screenX`** read-only property returns the
-  /// horizontal distance, in CSS pixels, of the left border of the user's
-  /// browser viewport to
-  /// the left side of the screen.
-  ///
-  /// > **Note:** An alias of `screenX` was implemented across modern
-  /// > browsers in more recent times — [Window.screenLeft]. This was originally
-  /// > supported only in IE but was introduced everywhere due to popularity.
-  external int get screenX;
-
-  /// The **`Window.screenLeft`** read-only property returns the
-  /// horizontal distance, in CSS pixels, from the left border of the user's
-  /// browser viewport
-  /// to the left side of the screen.
-  ///
-  /// > **Note:** `screenLeft` is an alias of the older
-  /// > [Window.screenX] property. `screenLeft` was originally
-  /// > supported only in IE but was introduced everywhere due to popularity.
-  external int get screenLeft;
-
-  /// The **`Window.screenY`** read-only property returns the vertical distance,
-  /// in CSS pixels, of the top border of the user's browser viewport to the top
-  /// edge of the screen.
-  ///
-  /// > **Note:** An alias of `screenY` was implemented across modern browsers
-  /// > in more recent times — [Window.screenTop]. This was originally supported
-  /// > only in IE but was introduced everywhere due to popularity.
-  external int get screenY;
-
-  /// The **`Window.screenTop`** read-only property returns the
-  /// vertical distance, in CSS pixels, from the top border of the user's
-  /// browser viewport to
-  /// the top side of the screen.
-  ///
-  /// > **Note:** `screenTop` is an alias of the older
-  /// > [Window.screenY] property. `screenTop` was originally
-  /// > supported only in IE but was introduced everywhere due to popularity.
-  external int get screenTop;
-
-  /// **`Window.outerWidth`** read-only property returns the width of the
-  /// outside of the browser window. It represents the width of the whole
-  /// browser window including sidebar (if expanded), window chrome and window
-  /// resizing borders/handles.
-  external int get outerWidth;
-
-  /// The **`Window.outerHeight`** read-only property returns the height in
-  /// pixels of the whole browser window, including any sidebar, window chrome,
-  /// and window-resizing borders/handles.
-  external int get outerHeight;
-
-  /// The **`devicePixelRatio`** of
-  /// [Window] interface returns the ratio of the resolution in _physical
-  /// pixels_ to the resolution in _CSS pixels_ for the current display
-  /// device.
-  ///
-  /// This value could also be interpreted as the ratio of pixel sizes: the
-  /// size of one _CSS pixel_ to the size of one _physical pixel_. In simpler
-  /// terms, this tells the browser how many of the screen's actual pixels
-  /// should be used to
-  /// draw a single CSS pixel.
-  ///
-  /// This is useful when dealing with the difference between rendering on a
-  /// standard display
-  /// versus a HiDPI or Retina display, which use more screen pixels to draw the
-  /// same objects,
-  /// resulting in a sharper image.
-  ///
-  /// You can use [Window.matchMedia] to check if the
-  /// value of `devicePixelRatio` changes (which can happen, for example, if the
-  /// user drags the window to a display with a different pixel density). See
-  /// [the example below](#monitoring_screen_resolution_or_zoom_level_changes).
-  external double get devicePixelRatio;
-
-  /// The read-only [Window] property **`event`** returns the [Event] which is
-  /// currently being handled by the site's code. Outside the context of an
-  /// event handler, the value is always `undefined`.
-  ///
-  /// You _should_ avoid using this property in new code, and should instead use
-  /// the [Event] passed into the event handler function. This property is not
-  /// universally supported and even when supported introduces potential
-  /// fragility to your code.
-  ///
-  /// > **Note:** This property can be fragile, in that there may be situations
-  /// > in which the returned `Event` is not the expected value. In addition,
-  /// > `Window.event` is not accurate for events dispatched within .
-  external Event? get event;
 
   /// The **`window`** property of a [Window] object points to the window object
   /// itself.
@@ -10759,6 +10615,150 @@ extension type Window._(JSObject _) implements EventTarget, JSObject {
   /// the application running the script.
   external Navigator get navigator;
 
+  /// Returns the orientation in degrees (in 90-degree increments) of the
+  /// viewport relative to the device's natural orientation.
+  ///
+  /// Its only possible values are `-90`, `0`, `90`, and `180`. Positive values
+  /// are counterclockwise; negative values are clockwise.
+  ///
+  /// This property is deprecated. Use the [Screen.orientation] property
+  /// instead, available on the [window.screen] property.
+  external int get orientation;
+  external EventHandler get onorientationchange;
+  external set onorientationchange(EventHandler value);
+
+  /// The [Window] property **`screen`** returns a
+  /// reference to the screen object associated with the window. The `screen`
+  /// object, implementing the [Screen] interface, is a special object for
+  /// inspecting properties of the screen on which the current window is being
+  /// rendered.
+  external Screen get screen;
+
+  /// The **`visualViewport`** read-only property of the [Window] interface
+  /// returns a [VisualViewport] object representing the visual viewport for a
+  /// given window, or `null` if current document is not fully active.
+  external VisualViewport? get visualViewport;
+
+  /// The read-only [Window] property **`innerWidth`** returns the interior
+  /// width of the window in pixels (that is, the width of the window's ). That
+  /// includes the width of the vertical scroll bar, if one is present.
+  ///
+  /// Similarly, the interior height of the window (that is, the height of the
+  /// layout viewport) can be obtained using the [Window.innerHeight] property.
+  /// That measurement also accounts for the height of the horizontal scroll
+  /// bar, if it is visible.
+  external int get innerWidth;
+
+  /// The read-only **`innerHeight`** property of the
+  /// [Window] interface returns the interior height of the window in pixels,
+  /// including the height of the horizontal scroll bar, if present.
+  ///
+  /// The value of `innerHeight` is taken from the height of the window's
+  /// . The width can be obtained using the
+  /// [Window.innerWidth] property.
+  external int get innerHeight;
+
+  /// The read-only **`scrollX`** property of the [Window] interface returns the
+  /// number of pixels by which the document is currently scrolled horizontally.
+  /// This value is subpixel precise in modern browsers, meaning that it isn't
+  /// necessarily a whole number. You can get the number of pixels the document
+  /// is scrolled vertically from the [Window.scrollY] property.
+  external double get scrollX;
+
+  /// The read-only **`scrollY`** property of the [Window] interface returns the
+  /// number of pixels by which the document is currently scrolled vertically.
+  /// This value is subpixel precise in modern browsers, meaning that it isn't
+  /// necessarily a whole number. You can get the number of pixels the document
+  /// is scrolled horizontally from the [Window.scrollX] property.
+  external double get scrollY;
+
+  /// The **`Window.screenX`** read-only property returns the
+  /// horizontal distance, in CSS pixels, of the left border of the user's
+  /// browser viewport to
+  /// the left side of the screen.
+  ///
+  /// > **Note:** An alias of `screenX` was implemented across modern
+  /// > browsers in more recent times — [Window.screenLeft]. This was originally
+  /// > supported only in IE but was introduced everywhere due to popularity.
+  external int get screenX;
+
+  /// The **`Window.screenLeft`** read-only property returns the
+  /// horizontal distance, in CSS pixels, from the left border of the user's
+  /// browser viewport
+  /// to the left side of the screen.
+  ///
+  /// > **Note:** `screenLeft` is an alias of the older
+  /// > [Window.screenX] property. `screenLeft` was originally
+  /// > supported only in IE but was introduced everywhere due to popularity.
+  external int get screenLeft;
+
+  /// The **`Window.screenY`** read-only property returns the vertical distance,
+  /// in CSS pixels, of the top border of the user's browser viewport to the top
+  /// edge of the screen.
+  ///
+  /// > **Note:** An alias of `screenY` was implemented across modern browsers
+  /// > in more recent times — [Window.screenTop]. This was originally supported
+  /// > only in IE but was introduced everywhere due to popularity.
+  external int get screenY;
+
+  /// The **`Window.screenTop`** read-only property returns the
+  /// vertical distance, in CSS pixels, from the top border of the user's
+  /// browser viewport to
+  /// the top side of the screen.
+  ///
+  /// > **Note:** `screenTop` is an alias of the older
+  /// > [Window.screenY] property. `screenTop` was originally
+  /// > supported only in IE but was introduced everywhere due to popularity.
+  external int get screenTop;
+
+  /// **`Window.outerWidth`** read-only property returns the width of the
+  /// outside of the browser window. It represents the width of the whole
+  /// browser window including sidebar (if expanded), window chrome and window
+  /// resizing borders/handles.
+  external int get outerWidth;
+
+  /// The **`Window.outerHeight`** read-only property returns the height in
+  /// pixels of the whole browser window, including any sidebar, window chrome,
+  /// and window-resizing borders/handles.
+  external int get outerHeight;
+
+  /// The **`devicePixelRatio`** of
+  /// [Window] interface returns the ratio of the resolution in _physical
+  /// pixels_ to the resolution in _CSS pixels_ for the current display
+  /// device.
+  ///
+  /// This value could also be interpreted as the ratio of pixel sizes: the
+  /// size of one _CSS pixel_ to the size of one _physical pixel_. In simpler
+  /// terms, this tells the browser how many of the screen's actual pixels
+  /// should be used to
+  /// draw a single CSS pixel.
+  ///
+  /// This is useful when dealing with the difference between rendering on a
+  /// standard display
+  /// versus a HiDPI or Retina display, which use more screen pixels to draw the
+  /// same objects,
+  /// resulting in a sharper image.
+  ///
+  /// You can use [Window.matchMedia] to check if the
+  /// value of `devicePixelRatio` changes (which can happen, for example, if the
+  /// user drags the window to a display with a different pixel density). See
+  /// [the example below](#monitoring_screen_resolution_or_zoom_level_changes).
+  external double get devicePixelRatio;
+
+  /// The read-only [Window] property **`event`** returns the [Event] which is
+  /// currently being handled by the site's code. Outside the context of an
+  /// event handler, the value is always `undefined`.
+  ///
+  /// You _should_ avoid using this property in new code, and should instead use
+  /// the [Event] passed into the event handler function. This property is not
+  /// universally supported and even when supported introduces potential
+  /// fragility to your code.
+  ///
+  /// > **Note:** This property can be fragile, in that there may be situations
+  /// > in which the returned `Event` is not the expected value. In addition,
+  /// > `Window.event` is not accurate for events dispatched within .
+  external Event? get event;
+
   /// The `external` property of the [Window] API returns an instance of the
   /// `External` interface, which was intended to contain functions related to
   /// adding external search providers to the browser. However, this is now
@@ -10781,22 +10781,6 @@ extension type Window._(JSObject _) implements EventTarget, JSObject {
   /// [Web Speech API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API)
   /// speech synthesis functionality.
   external SpeechSynthesis get speechSynthesis;
-  external EventHandler get onanimationstart;
-  external set onanimationstart(EventHandler value);
-  external EventHandler get onanimationiteration;
-  external set onanimationiteration(EventHandler value);
-  external EventHandler get onanimationend;
-  external set onanimationend(EventHandler value);
-  external EventHandler get onanimationcancel;
-  external set onanimationcancel(EventHandler value);
-  external EventHandler get ontransitionrun;
-  external set ontransitionrun(EventHandler value);
-  external EventHandler get ontransitionstart;
-  external set ontransitionstart(EventHandler value);
-  external EventHandler get ontransitionend;
-  external set ontransitionend(EventHandler value);
-  external EventHandler get ontransitioncancel;
-  external set ontransitioncancel(EventHandler value);
   external EventHandler get onabort;
   external set onabort(EventHandler value);
   external EventHandler get onauxclick;
@@ -10937,6 +10921,22 @@ extension type Window._(JSObject _) implements EventTarget, JSObject {
   external set onwaiting(EventHandler value);
   external EventHandler get onwheel;
   external set onwheel(EventHandler value);
+  external EventHandler get onanimationstart;
+  external set onanimationstart(EventHandler value);
+  external EventHandler get onanimationiteration;
+  external set onanimationiteration(EventHandler value);
+  external EventHandler get onanimationend;
+  external set onanimationend(EventHandler value);
+  external EventHandler get onanimationcancel;
+  external set onanimationcancel(EventHandler value);
+  external EventHandler get ontransitionrun;
+  external set ontransitionrun(EventHandler value);
+  external EventHandler get ontransitionstart;
+  external set ontransitionstart(EventHandler value);
+  external EventHandler get ontransitionend;
+  external set ontransitionend(EventHandler value);
+  external EventHandler get ontransitioncancel;
+  external set ontransitioncancel(EventHandler value);
   external EventHandler get onpointerover;
   external set onpointerover(EventHandler value);
   external EventHandler get onpointerenter;
@@ -10969,10 +10969,6 @@ extension type Window._(JSObject _) implements EventTarget, JSObject {
   external set ontouchmove(EventHandler value);
   external EventHandler get ontouchcancel;
   external set ontouchcancel(EventHandler value);
-  external EventHandler get ongamepadconnected;
-  external set ongamepadconnected(EventHandler value);
-  external EventHandler get ongamepaddisconnected;
-  external set ongamepaddisconnected(EventHandler value);
   external EventHandler get onafterprint;
   external set onafterprint(EventHandler value);
   external EventHandler get onbeforeprint;
@@ -11005,6 +11001,36 @@ extension type Window._(JSObject _) implements EventTarget, JSObject {
   external set onunhandledrejection(EventHandler value);
   external EventHandler get onunload;
   external set onunload(EventHandler value);
+  external EventHandler get ongamepadconnected;
+  external set ongamepadconnected(EventHandler value);
+  external EventHandler get ongamepaddisconnected;
+  external set ongamepaddisconnected(EventHandler value);
+
+  /// The **`origin`** read-only property of the [Window] interface returns the
+  /// origin of the global scope, serialized as a string.
+  external String get origin;
+
+  /// The **`isSecureContext`** read-only property of the [Window] interface
+  /// returns a boolean indicating whether the current
+  /// [context is secure](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts)
+  /// (`true`) or not (`false`).
+  external bool get isSecureContext;
+
+  /// The **`crossOriginIsolated`** read-only property of the [Window] interface
+  /// returns a boolean value that
+  /// indicates whether the website is in a cross-origin isolation state. That
+  /// state mitigates the risk of side-channel attacks and unlocks a few
+  /// capabilities:
+  ///
+  /// - `SharedArrayBuffer` can be created and sent via a [Window.postMessage]
+  ///   or a [MessagePort.postMessage] call.
+  /// - [Performance.now] offers better precision.
+  /// - [Performance.measureUserAgentSpecificMemory] can be accessed.
+  ///
+  /// A website is in a cross-origin isolated state, when the response header
+  /// has the value `same-origin` and the  header has the value `require-corp`
+  /// or `credentialless`.
+  external bool get crossOriginIsolated;
 
   /// The **`indexedDB`** read-only property of the [Window] interface provides
   /// a mechanism for applications to
@@ -11034,32 +11060,6 @@ extension type Window._(JSObject _) implements EventTarget, JSObject {
   /// thread (or other worker), you cannot see it in a worker thread, and vice
   /// versa.
   external Performance get performance;
-
-  /// The **`origin`** read-only property of the [Window] interface returns the
-  /// origin of the global scope, serialized as a string.
-  external String get origin;
-
-  /// The **`isSecureContext`** read-only property of the [Window] interface
-  /// returns a boolean indicating whether the current
-  /// [context is secure](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts)
-  /// (`true`) or not (`false`).
-  external bool get isSecureContext;
-
-  /// The **`crossOriginIsolated`** read-only property of the [Window] interface
-  /// returns a boolean value that
-  /// indicates whether the website is in a cross-origin isolation state. That
-  /// state mitigates the risk of side-channel attacks and unlocks a few
-  /// capabilities:
-  ///
-  /// - `SharedArrayBuffer` can be created and sent via a [Window.postMessage]
-  ///   or a [MessagePort.postMessage] call.
-  /// - [Performance.now] offers better precision.
-  /// - [Performance.measureUserAgentSpecificMemory] can be accessed.
-  ///
-  /// A website is in a cross-origin isolated state, when the response header
-  /// has the value `same-origin` and the  header has the value `require-corp`
-  /// or `credentialless`.
-  external bool get crossOriginIsolated;
 
   /// The **`scheduler`** read-only property of the [Window] interface is the
   /// entry point for using the
@@ -12776,10 +12776,6 @@ extension type WorkerGlobalScope._(JSObject _)
   /// The **`importScripts()`** method of the [WorkerGlobalScope] interface
   /// synchronously imports one or more scripts into the worker's scope.
   external void importScripts(JSAny urls);
-  external JSPromise<Response> fetch(
-    RequestInfo input, [
-    RequestInit init,
-  ]);
   external void reportError(JSAny? e);
 
   /// The **`btoa()`** method of the [WorkerGlobalScope] interface creates a
@@ -12831,6 +12827,10 @@ extension type WorkerGlobalScope._(JSObject _)
     JSAny? value, [
     StructuredSerializeOptions options,
   ]);
+  external JSPromise<Response> fetch(
+    RequestInfo input, [
+    RequestInit init,
+  ]);
 
   /// The **`self`** read-only property of the [WorkerGlobalScope] interface
   /// returns a reference to the `WorkerGlobalScope` itself. Most of the time it
@@ -12868,6 +12868,33 @@ extension type WorkerGlobalScope._(JSObject _)
   /// This property is part of the
   /// [CSS Font Loading API](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Font_Loading_API).
   external FontFaceSet get fonts;
+
+  /// The **`origin`** read-only property of the [WorkerGlobalScope] interface
+  /// returns the origin of the global scope, serialized as a string.
+  external String get origin;
+
+  /// The **`isSecureContext`** read-only property of the [WorkerGlobalScope]
+  /// interface returns a boolean indicating whether the current
+  /// [context is secure](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts)
+  /// (`true`) or not (`false`).
+  external bool get isSecureContext;
+
+  /// The **`crossOriginIsolated`** read-only property of the
+  /// [WorkerGlobalScope] interface returns a boolean value that
+  /// indicates whether the website is in a cross-origin isolation state. That
+  /// state mitigates the risk of side-channel attacks and unlocks a few
+  /// capabilities:
+  ///
+  /// - `SharedArrayBuffer` can be created and sent via a
+  ///   [DedicatedWorkerGlobalScope.postMessage] or a [MessagePort.postMessage]
+  ///   call.
+  /// - [Performance.now] offers better precision.
+  /// - [Performance.measureUserAgentSpecificMemory] can be accessed.
+  ///
+  /// A website is in a cross-origin isolated state, when the response header
+  /// has the value `same-origin` and the  header has the value `require-corp`
+  /// or `credentialless`.
+  external bool get crossOriginIsolated;
 
   /// The **`indexedDB`** read-only property of the [WorkerGlobalScope]
   /// interface provides a mechanism for workers to
@@ -12908,33 +12935,6 @@ extension type WorkerGlobalScope._(JSObject _)
   /// - [PerformanceResourceTiming]
   /// - [PerformanceServerTiming]
   external Performance get performance;
-
-  /// The **`origin`** read-only property of the [WorkerGlobalScope] interface
-  /// returns the origin of the global scope, serialized as a string.
-  external String get origin;
-
-  /// The **`isSecureContext`** read-only property of the [WorkerGlobalScope]
-  /// interface returns a boolean indicating whether the current
-  /// [context is secure](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts)
-  /// (`true`) or not (`false`).
-  external bool get isSecureContext;
-
-  /// The **`crossOriginIsolated`** read-only property of the
-  /// [WorkerGlobalScope] interface returns a boolean value that
-  /// indicates whether the website is in a cross-origin isolation state. That
-  /// state mitigates the risk of side-channel attacks and unlocks a few
-  /// capabilities:
-  ///
-  /// - `SharedArrayBuffer` can be created and sent via a
-  ///   [DedicatedWorkerGlobalScope.postMessage] or a [MessagePort.postMessage]
-  ///   call.
-  /// - [Performance.now] offers better precision.
-  /// - [Performance.measureUserAgentSpecificMemory] can be accessed.
-  ///
-  /// A website is in a cross-origin isolated state, when the response header
-  /// has the value `same-origin` and the  header has the value `require-corp`
-  /// or `credentialless`.
-  external bool get crossOriginIsolated;
 
   /// The **`scheduler`** read-only property of the [WorkerGlobalScope]
   /// interface is the entry point for using the
@@ -13700,10 +13700,6 @@ extension type HTMLFrameSetElement._(JSObject _)
   external set cols(String value);
   external String get rows;
   external set rows(String value);
-  external EventHandler get ongamepadconnected;
-  external set ongamepadconnected(EventHandler value);
-  external EventHandler get ongamepaddisconnected;
-  external set ongamepaddisconnected(EventHandler value);
   external EventHandler get onafterprint;
   external set onafterprint(EventHandler value);
   external EventHandler get onbeforeprint;
@@ -13736,6 +13732,10 @@ extension type HTMLFrameSetElement._(JSObject _)
   external set onunhandledrejection(EventHandler value);
   external EventHandler get onunload;
   external set onunload(EventHandler value);
+  external EventHandler get ongamepadconnected;
+  external set ongamepadconnected(EventHandler value);
+  external EventHandler get ongamepaddisconnected;
+  external set ongamepaddisconnected(EventHandler value);
 }
 extension type HTMLFrameElement._(JSObject _) implements HTMLElement, JSObject {
   /// Creates an [HTMLFrameElement] using the tag 'frame'.

--- a/web/lib/src/dom/mathml_core.dart
+++ b/web/lib/src/dom/mathml_core.dart
@@ -241,26 +241,6 @@ extension type MathMLElement._(JSObject _) implements Element, JSObject {
   external void focus([FocusOptions options]);
   external void blur();
 
-  /// The **`attributeStyleMap`** read-only property of the [MathMLElement]
-  /// interface returns a live [StylePropertyMap] object that contains a list of
-  /// style properties of the element that are defined in the element's inline
-  /// `style` attribute, or assigned using the [MathMLElement.style] property of
-  /// the [MathMLElement] interface via script.
-  ///
-  /// Shorthand properties are expanded. If you set `border-top: 1px solid
-  /// black`, the longhand properties (, , and ) are set instead.
-  ///
-  /// The main difference between [MathMLElement.style] property and
-  /// `attributeStyleMap` property is that, the `style` property will return a
-  /// [CSSStyleDeclaration] object, while the `attributeStyleMap` property will
-  /// return a [StylePropertyMap] object.
-  ///
-  /// Though the property itself is not writable, you could read and write
-  /// inline styles through the [StylePropertyMap] object that it returns, just
-  /// like through the [CSSStyleDeclaration] object that returns via the `style`
-  /// property.
-  external StylePropertyMap get attributeStyleMap;
-
   /// The read-only **`style`** property of the [MathMLElement] returns the
   /// _inline_ style of an element in the form of a live [CSSStyleDeclaration]
   /// object that contains a list of all styles properties for that element with
@@ -301,22 +281,26 @@ extension type MathMLElement._(JSObject _) implements Element, JSObject {
   /// > The `style` property has the same priority in the CSS cascade as an
   /// > inline style declaration set via the `style` attribute.
   external CSSStyleDeclaration get style;
-  external EventHandler get onanimationstart;
-  external set onanimationstart(EventHandler value);
-  external EventHandler get onanimationiteration;
-  external set onanimationiteration(EventHandler value);
-  external EventHandler get onanimationend;
-  external set onanimationend(EventHandler value);
-  external EventHandler get onanimationcancel;
-  external set onanimationcancel(EventHandler value);
-  external EventHandler get ontransitionrun;
-  external set ontransitionrun(EventHandler value);
-  external EventHandler get ontransitionstart;
-  external set ontransitionstart(EventHandler value);
-  external EventHandler get ontransitionend;
-  external set ontransitionend(EventHandler value);
-  external EventHandler get ontransitioncancel;
-  external set ontransitioncancel(EventHandler value);
+
+  /// The **`attributeStyleMap`** read-only property of the [MathMLElement]
+  /// interface returns a live [StylePropertyMap] object that contains a list of
+  /// style properties of the element that are defined in the element's inline
+  /// `style` attribute, or assigned using the [MathMLElement.style] property of
+  /// the [MathMLElement] interface via script.
+  ///
+  /// Shorthand properties are expanded. If you set `border-top: 1px solid
+  /// black`, the longhand properties (, , and ) are set instead.
+  ///
+  /// The main difference between [MathMLElement.style] property and
+  /// `attributeStyleMap` property is that, the `style` property will return a
+  /// [CSSStyleDeclaration] object, while the `attributeStyleMap` property will
+  /// return a [StylePropertyMap] object.
+  ///
+  /// Though the property itself is not writable, you could read and write
+  /// inline styles through the [StylePropertyMap] object that it returns, just
+  /// like through the [CSSStyleDeclaration] object that returns via the `style`
+  /// property.
+  external StylePropertyMap get attributeStyleMap;
   external EventHandler get onabort;
   external set onabort(EventHandler value);
   external EventHandler get onauxclick;
@@ -457,6 +441,22 @@ extension type MathMLElement._(JSObject _) implements Element, JSObject {
   external set onwaiting(EventHandler value);
   external EventHandler get onwheel;
   external set onwheel(EventHandler value);
+  external EventHandler get onanimationstart;
+  external set onanimationstart(EventHandler value);
+  external EventHandler get onanimationiteration;
+  external set onanimationiteration(EventHandler value);
+  external EventHandler get onanimationend;
+  external set onanimationend(EventHandler value);
+  external EventHandler get onanimationcancel;
+  external set onanimationcancel(EventHandler value);
+  external EventHandler get ontransitionrun;
+  external set ontransitionrun(EventHandler value);
+  external EventHandler get ontransitionstart;
+  external set ontransitionstart(EventHandler value);
+  external EventHandler get ontransitionend;
+  external set ontransitionend(EventHandler value);
+  external EventHandler get ontransitioncancel;
+  external set ontransitioncancel(EventHandler value);
   external EventHandler get onpointerover;
   external set onpointerover(EventHandler value);
   external EventHandler get onpointerenter;

--- a/web/lib/src/dom/permissions.dart
+++ b/web/lib/src/dom/permissions.dart
@@ -30,16 +30,16 @@ typedef PermissionState = String;
 /// API documentation sourced from
 /// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/Permissions).
 extension type Permissions._(JSObject _) implements JSObject {
+  /// The **`query()`** method of the [Permissions] interface returns the state
+  /// of a user permission on the global scope.
+  external JSPromise<PermissionStatus> query(JSObject permissionDesc);
+
   /// The **`revoke()`** method of the
   /// [Permissions] interface reverts a currently set permission back to its
   /// default state, which is usually `prompt`.
   /// This method is called on the global [Permissions] object
   /// [navigator.permissions].
   external JSPromise<PermissionStatus> revoke(JSObject permissionDesc);
-
-  /// The **`query()`** method of the [Permissions] interface returns the state
-  /// of a user permission on the global scope.
-  external JSPromise<PermissionStatus> query(JSObject permissionDesc);
 }
 
 /// The **`PermissionStatus`** interface of the

--- a/web/lib/src/dom/service_workers.dart
+++ b/web/lib/src/dom/service_workers.dart
@@ -116,27 +116,6 @@ extension type ServiceWorker._(JSObject _) implements EventTarget, JSObject {
 /// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration).
 extension type ServiceWorkerRegistration._(JSObject _)
     implements EventTarget, JSObject {
-  /// The **`showNotification()`** method of the
-  /// [ServiceWorkerRegistration] interface creates a notification on an active
-  /// service worker.
-  external JSPromise<JSAny?> showNotification(
-    String title, [
-    NotificationOptions options,
-  ]);
-
-  /// The **`getNotifications()`** method of
-  /// the [ServiceWorkerRegistration] interface returns a list of the
-  /// notifications in the order that they were created from the current origin
-  /// via the
-  /// current service worker registration. Origins can have many active but
-  /// differently-scoped service worker registrations. Notifications created by
-  /// one service
-  /// worker on the same origin will not be available to other active service
-  /// workers on
-  /// that same origin.
-  external JSPromise<JSArray<Notification>> getNotifications(
-      [GetNotificationOptions filter]);
-
   /// The **`update()`** method of the
   /// [ServiceWorkerRegistration] interface attempts to update the service
   /// worker. It fetches the worker's script URL, and if the new worker is not
@@ -158,19 +137,26 @@ extension type ServiceWorkerRegistration._(JSObject _)
   /// unregistered.
   external JSPromise<JSBoolean> unregister();
 
-  /// The **`sync`** read-only property of the
-  /// [ServiceWorkerRegistration] interface returns a reference to the
-  /// [SyncManager] interface, which manages background synchronization
-  /// processes.
-  external SyncManager get sync;
+  /// The **`showNotification()`** method of the
+  /// [ServiceWorkerRegistration] interface creates a notification on an active
+  /// service worker.
+  external JSPromise<JSAny?> showNotification(
+    String title, [
+    NotificationOptions options,
+  ]);
 
-  /// The **`pushManager`** read-only property of the
-  /// [ServiceWorkerRegistration] interface returns a reference to the
-  /// [PushManager] interface for managing push subscriptions; this includes
-  /// support for subscribing, getting an active subscription, and accessing
-  /// push permission
-  /// status.
-  external PushManager get pushManager;
+  /// The **`getNotifications()`** method of
+  /// the [ServiceWorkerRegistration] interface returns a list of the
+  /// notifications in the order that they were created from the current origin
+  /// via the
+  /// current service worker registration. Origins can have many active but
+  /// differently-scoped service worker registrations. Notifications created by
+  /// one service
+  /// worker on the same origin will not be available to other active service
+  /// workers on
+  /// that same origin.
+  external JSPromise<JSArray<Notification>> getNotifications(
+      [GetNotificationOptions filter]);
 
   /// The **`installing`** read-only property of the
   /// [ServiceWorkerRegistration] interface returns a service worker whose
@@ -223,6 +209,20 @@ extension type ServiceWorkerRegistration._(JSObject _)
   external ServiceWorkerUpdateViaCache get updateViaCache;
   external EventHandler get onupdatefound;
   external set onupdatefound(EventHandler value);
+
+  /// The **`sync`** read-only property of the
+  /// [ServiceWorkerRegistration] interface returns a reference to the
+  /// [SyncManager] interface, which manages background synchronization
+  /// processes.
+  external SyncManager get sync;
+
+  /// The **`pushManager`** read-only property of the
+  /// [ServiceWorkerRegistration] interface returns a reference to the
+  /// [PushManager] interface for managing push subscriptions; this includes
+  /// support for subscribing, getting an active subscription, and accessing
+  /// push permission
+  /// status.
+  external PushManager get pushManager;
 }
 
 /// The **`ServiceWorkerContainer`** interface of the
@@ -434,16 +434,6 @@ extension type ServiceWorkerGlobalScope._(JSObject _)
   /// underlying service worker take effect immediately for both the current
   /// client and all other active clients.
   external JSPromise<JSAny?> skipWaiting();
-  external EventHandler get onsync;
-  external set onsync(EventHandler value);
-  external EventHandler get onnotificationclick;
-  external set onnotificationclick(EventHandler value);
-  external EventHandler get onnotificationclose;
-  external set onnotificationclose(EventHandler value);
-  external EventHandler get onpush;
-  external set onpush(EventHandler value);
-  external EventHandler get onpushsubscriptionchange;
-  external set onpushsubscriptionchange(EventHandler value);
 
   /// @AvailableInWorkers("service")
   ///
@@ -477,6 +467,16 @@ extension type ServiceWorkerGlobalScope._(JSObject _)
   external set onmessage(EventHandler value);
   external EventHandler get onmessageerror;
   external set onmessageerror(EventHandler value);
+  external EventHandler get onsync;
+  external set onsync(EventHandler value);
+  external EventHandler get onnotificationclick;
+  external set onnotificationclick(EventHandler value);
+  external EventHandler get onnotificationclose;
+  external set onnotificationclose(EventHandler value);
+  external EventHandler get onpush;
+  external set onpush(EventHandler value);
+  external EventHandler get onpushsubscriptionchange;
+  external set onpushsubscriptionchange(EventHandler value);
 }
 
 /// @AvailableInWorkers("service")

--- a/web/lib/src/dom/storage.dart
+++ b/web/lib/src/dom/storage.dart
@@ -28,13 +28,6 @@ import 'fs.dart';
 /// API documentation sourced from
 /// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/StorageManager).
 extension type StorageManager._(JSObject _) implements JSObject {
-  /// The **`getDirectory()`** method of the [StorageManager] interface is used
-  /// to obtain a reference to a [FileSystemDirectoryHandle] object allowing
-  /// access to a directory and its contents, stored in the
-  /// [origin private file system](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system)
-  /// (OPFS).
-  external JSPromise<FileSystemDirectoryHandle> getDirectory();
-
   /// The **`persisted()`** method of the [StorageManager] interface returns a
   /// `Promise` that resolves to `true` if your site's storage bucket is
   /// persistent.
@@ -61,6 +54,13 @@ extension type StorageManager._(JSObject _) implements JSObject {
   /// resolves once the information is available. The promise's fulfillment
   /// handler is called with an object containing the usage and quota data.
   external JSPromise<StorageEstimate> estimate();
+
+  /// The **`getDirectory()`** method of the [StorageManager] interface is used
+  /// to obtain a reference to a [FileSystemDirectoryHandle] object allowing
+  /// access to a directory and its contents, stored in the
+  /// [origin private file system](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system)
+  /// (OPFS).
+  external JSPromise<FileSystemDirectoryHandle> getDirectory();
 }
 extension type StorageEstimate._(JSObject _) implements JSObject {
   external factory StorageEstimate({

--- a/web/lib/src/dom/svg.dart
+++ b/web/lib/src/dom/svg.dart
@@ -33,22 +33,6 @@ extension type SVGElement._(JSObject _) implements Element, JSObject {
   external void blur();
   external SVGSVGElement? get ownerSVGElement;
   external SVGElement? get viewportElement;
-  external EventHandler get onanimationstart;
-  external set onanimationstart(EventHandler value);
-  external EventHandler get onanimationiteration;
-  external set onanimationiteration(EventHandler value);
-  external EventHandler get onanimationend;
-  external set onanimationend(EventHandler value);
-  external EventHandler get onanimationcancel;
-  external set onanimationcancel(EventHandler value);
-  external EventHandler get ontransitionrun;
-  external set ontransitionrun(EventHandler value);
-  external EventHandler get ontransitionstart;
-  external set ontransitionstart(EventHandler value);
-  external EventHandler get ontransitionend;
-  external set ontransitionend(EventHandler value);
-  external EventHandler get ontransitioncancel;
-  external set ontransitioncancel(EventHandler value);
   external EventHandler get onabort;
   external set onabort(EventHandler value);
   external EventHandler get onauxclick;
@@ -189,6 +173,22 @@ extension type SVGElement._(JSObject _) implements Element, JSObject {
   external set onwaiting(EventHandler value);
   external EventHandler get onwheel;
   external set onwheel(EventHandler value);
+  external EventHandler get onanimationstart;
+  external set onanimationstart(EventHandler value);
+  external EventHandler get onanimationiteration;
+  external set onanimationiteration(EventHandler value);
+  external EventHandler get onanimationend;
+  external set onanimationend(EventHandler value);
+  external EventHandler get onanimationcancel;
+  external set onanimationcancel(EventHandler value);
+  external EventHandler get ontransitionrun;
+  external set ontransitionrun(EventHandler value);
+  external EventHandler get ontransitionstart;
+  external set ontransitionstart(EventHandler value);
+  external EventHandler get ontransitionend;
+  external set ontransitionend(EventHandler value);
+  external EventHandler get ontransitioncancel;
+  external set ontransitioncancel(EventHandler value);
   external EventHandler get onpointerover;
   external set onpointerover(EventHandler value);
   external EventHandler get onpointerenter;
@@ -238,26 +238,6 @@ extension type SVGElement._(JSObject _) implements Element, JSObject {
   external int get tabIndex;
   external set tabIndex(int value);
 
-  /// The **`attributeStyleMap`** read-only property of the [SVGElement]
-  /// interface returns a live [StylePropertyMap] object that contains a list of
-  /// style properties of the element that are defined in the element's inline
-  /// `style` attribute, or assigned using the [SVGElement.style] property of
-  /// the [SVGElement] interface via script.
-  ///
-  /// Shorthand properties are expanded. If you set `border-top: 1px solid
-  /// black`, the longhand properties (, , and ) are set instead.
-  ///
-  /// The main difference between [SVGElement.style] property and
-  /// `attributeStyleMap` property is that, the `style` property will return a
-  /// [CSSStyleDeclaration] object, while the `attributeStyleMap` property will
-  /// return a [StylePropertyMap] object.
-  ///
-  /// Though the property itself is not writable, you could read and write
-  /// inline styles through the [StylePropertyMap] object that it returns, just
-  /// like through the [CSSStyleDeclaration] object that returns via the `style`
-  /// property.
-  external StylePropertyMap get attributeStyleMap;
-
   /// The read-only **`style`** property of the [SVGElement] returns the
   /// _inline_ style of an element in the form of a live [CSSStyleDeclaration]
   /// object that contains a list of all styles properties for that element with
@@ -298,6 +278,26 @@ extension type SVGElement._(JSObject _) implements Element, JSObject {
   /// > The `style` property has the same priority in the CSS cascade as an
   /// > inline style declaration set via the `style` attribute.
   external CSSStyleDeclaration get style;
+
+  /// The **`attributeStyleMap`** read-only property of the [SVGElement]
+  /// interface returns a live [StylePropertyMap] object that contains a list of
+  /// style properties of the element that are defined in the element's inline
+  /// `style` attribute, or assigned using the [SVGElement.style] property of
+  /// the [SVGElement] interface via script.
+  ///
+  /// Shorthand properties are expanded. If you set `border-top: 1px solid
+  /// black`, the longhand properties (, , and ) are set instead.
+  ///
+  /// The main difference between [SVGElement.style] property and
+  /// `attributeStyleMap` property is that, the `style` property will return a
+  /// [CSSStyleDeclaration] object, while the `attributeStyleMap` property will
+  /// return a [StylePropertyMap] object.
+  ///
+  /// Though the property itself is not writable, you could read and write
+  /// inline styles through the [StylePropertyMap] object that it returns, just
+  /// like through the [CSSStyleDeclaration] object that returns via the `style`
+  /// property.
+  external StylePropertyMap get attributeStyleMap;
 }
 
 extension SVGElementExtension on SVGElement {
@@ -848,10 +848,6 @@ extension type SVGSVGElement._(JSObject _)
   external DOMPointReadOnly get currentTranslate;
   external SVGAnimatedRect get viewBox;
   external SVGAnimatedPreserveAspectRatio get preserveAspectRatio;
-  external EventHandler get ongamepadconnected;
-  external set ongamepadconnected(EventHandler value);
-  external EventHandler get ongamepaddisconnected;
-  external set ongamepaddisconnected(EventHandler value);
   external EventHandler get onafterprint;
   external set onafterprint(EventHandler value);
   external EventHandler get onbeforeprint;
@@ -884,6 +880,10 @@ extension type SVGSVGElement._(JSObject _)
   external set onunhandledrejection(EventHandler value);
   external EventHandler get onunload;
   external set onunload(EventHandler value);
+  external EventHandler get ongamepadconnected;
+  external set ongamepadconnected(EventHandler value);
+  external EventHandler get ongamepaddisconnected;
+  external set ongamepaddisconnected(EventHandler value);
 }
 
 /// The **`SVGGElement`** interface corresponds to the  element.

--- a/web/lib/src/dom/uievents.dart
+++ b/web/lib/src/dom/uievents.dart
@@ -242,88 +242,6 @@ extension type MouseEvent._(JSObject _) implements UIEvent, JSObject {
     EventTarget? relatedTargetArg,
   ]);
 
-  /// The **`pageX`** read-only property of the [MouseEvent] interface returns
-  /// the X (horizontal) coordinate (in pixels) at which the mouse was clicked,
-  /// relative to the left edge of the entire document.
-  /// This includes any portion of the document not currently visible.
-  ///
-  /// Being based on the edge of the document as it is, this property takes into
-  /// account any horizontal scrolling of the page.
-  /// For example, if the page is scrolled such that 200 pixels of the left side
-  /// of the document are scrolled out of view, and the mouse is clicked 100
-  /// pixels inward from the left edge of the view, the value returned by
-  /// `pageX` will be 300.
-  ///
-  /// Originally, this property was defined as a `long` integer. The
-  /// [CSSOM View Module](https://developer.mozilla.org/en-US/docs/Web/CSS/CSSOM_view)
-  /// redefined it as a
-  /// `double` float. See the [Browser compatibility](#browser_compatibility)
-  /// section for
-  /// details.
-  ///
-  /// See
-  /// [Coordinate systems](https://developer.mozilla.org/en-US/docs/Web/CSS/CSSOM_view/Coordinate_systems#page)
-  /// for additional information about coordinates specified in this fashion.
-  external double get pageX;
-
-  /// The **`pageY`** read-only property of the [MouseEvent] interface returns
-  /// the Y (vertical) coordinate (in pixels) at which the mouse was clicked,
-  /// relative to the top edge of the entire document.
-  /// This includes any portion of the document not currently visible.
-  ///
-  /// See [MouseEvent.pageX] for more information.
-  external double get pageY;
-
-  /// The **`MouseEvent.x`** property is an alias for the [MouseEvent.clientX]
-  /// property.
-  external double get x;
-
-  /// The **`MouseEvent.y`** property is an alias for the [MouseEvent.clientY]
-  /// property.
-  external double get y;
-
-  /// The **`offsetX`** read-only property of the [MouseEvent] interface
-  /// provides the offset in the X coordinate of the mouse pointer between that
-  /// event and the padding edge of the target node.
-  external double get offsetX;
-
-  /// The **`offsetY`** read-only property of the [MouseEvent] interface
-  /// provides the offset in the Y coordinate of the mouse pointer between that
-  /// event and the padding edge of the target node.
-  external double get offsetY;
-
-  /// The **`movementX`** read-only property of the [MouseEvent] interface
-  /// provides the difference in the X coordinate of the mouse pointer between
-  /// the given event and the previous [Element.mousemove_event] event.
-  /// In other words, the value of the property is computed like this:
-  /// `currentEvent.movementX = currentEvent.screenX - previousEvent.screenX`.
-  ///
-  /// > **Warning:** Browsers [use different units for `movementX` and
-  /// > [MouseEvent.screenX]](https://github.com/w3c/pointerlock/issues/42) than
-  /// > what the specification defines. Depending on the browser and operating
-  /// > system, the `movementX` units may be a physical pixel, a logical pixel,
-  /// > or a CSS pixel. You may want to avoid the movement properties, and
-  /// > instead calculate the delta between the current client values
-  /// > ([MouseEvent.screenX], [MouseEvent.screenY]) and the previous client
-  /// > values.
-  external double get movementX;
-
-  /// The **`movementY`** read-only property of the [MouseEvent] interface
-  /// provides the difference in the Y coordinate of the mouse pointer between
-  /// the given event and the previous [Element.mousemove_event] event.
-  /// In other words, the value of the property is computed like this:
-  /// `currentEvent.movementY = currentEvent.screenY - previousEvent.screenY`.
-  ///
-  /// > **Warning:** Browsers [use different units for `movementY` and
-  /// > [MouseEvent.screenY]](https://github.com/w3c/pointerlock/issues/42) than
-  /// > what the specification defines. Depending on the browser and operating
-  /// > system, the `movementY` units may be a physical pixel, a logical pixel,
-  /// > or a CSS pixel. You may want to avoid the movement properties, and
-  /// > instead calculate the delta between the current client values
-  /// > ([MouseEvent.screenX], [MouseEvent.screenY]) and the previous client
-  /// > values.
-  external double get movementY;
-
   /// The **`screenX`** read-only property of the [MouseEvent] interface
   /// provides the horizontal coordinate (offset) of the mouse pointer in
   /// [screen coordinates](https://developer.mozilla.org/en-US/docs/Web/CSS/CSSOM_view/Coordinate_systems#screen).
@@ -514,6 +432,88 @@ extension type MouseEvent._(JSObject _) implements UIEvent, JSObject {
   ///
   /// [FocusEvent.relatedTarget] is a similar property for focus events.
   external EventTarget? get relatedTarget;
+
+  /// The **`pageX`** read-only property of the [MouseEvent] interface returns
+  /// the X (horizontal) coordinate (in pixels) at which the mouse was clicked,
+  /// relative to the left edge of the entire document.
+  /// This includes any portion of the document not currently visible.
+  ///
+  /// Being based on the edge of the document as it is, this property takes into
+  /// account any horizontal scrolling of the page.
+  /// For example, if the page is scrolled such that 200 pixels of the left side
+  /// of the document are scrolled out of view, and the mouse is clicked 100
+  /// pixels inward from the left edge of the view, the value returned by
+  /// `pageX` will be 300.
+  ///
+  /// Originally, this property was defined as a `long` integer. The
+  /// [CSSOM View Module](https://developer.mozilla.org/en-US/docs/Web/CSS/CSSOM_view)
+  /// redefined it as a
+  /// `double` float. See the [Browser compatibility](#browser_compatibility)
+  /// section for
+  /// details.
+  ///
+  /// See
+  /// [Coordinate systems](https://developer.mozilla.org/en-US/docs/Web/CSS/CSSOM_view/Coordinate_systems#page)
+  /// for additional information about coordinates specified in this fashion.
+  external double get pageX;
+
+  /// The **`pageY`** read-only property of the [MouseEvent] interface returns
+  /// the Y (vertical) coordinate (in pixels) at which the mouse was clicked,
+  /// relative to the top edge of the entire document.
+  /// This includes any portion of the document not currently visible.
+  ///
+  /// See [MouseEvent.pageX] for more information.
+  external double get pageY;
+
+  /// The **`MouseEvent.x`** property is an alias for the [MouseEvent.clientX]
+  /// property.
+  external double get x;
+
+  /// The **`MouseEvent.y`** property is an alias for the [MouseEvent.clientY]
+  /// property.
+  external double get y;
+
+  /// The **`offsetX`** read-only property of the [MouseEvent] interface
+  /// provides the offset in the X coordinate of the mouse pointer between that
+  /// event and the padding edge of the target node.
+  external double get offsetX;
+
+  /// The **`offsetY`** read-only property of the [MouseEvent] interface
+  /// provides the offset in the Y coordinate of the mouse pointer between that
+  /// event and the padding edge of the target node.
+  external double get offsetY;
+
+  /// The **`movementX`** read-only property of the [MouseEvent] interface
+  /// provides the difference in the X coordinate of the mouse pointer between
+  /// the given event and the previous [Element.mousemove_event] event.
+  /// In other words, the value of the property is computed like this:
+  /// `currentEvent.movementX = currentEvent.screenX - previousEvent.screenX`.
+  ///
+  /// > **Warning:** Browsers [use different units for `movementX` and
+  /// > [MouseEvent.screenX]](https://github.com/w3c/pointerlock/issues/42) than
+  /// > what the specification defines. Depending on the browser and operating
+  /// > system, the `movementX` units may be a physical pixel, a logical pixel,
+  /// > or a CSS pixel. You may want to avoid the movement properties, and
+  /// > instead calculate the delta between the current client values
+  /// > ([MouseEvent.screenX], [MouseEvent.screenY]) and the previous client
+  /// > values.
+  external double get movementX;
+
+  /// The **`movementY`** read-only property of the [MouseEvent] interface
+  /// provides the difference in the Y coordinate of the mouse pointer between
+  /// the given event and the previous [Element.mousemove_event] event.
+  /// In other words, the value of the property is computed like this:
+  /// `currentEvent.movementY = currentEvent.screenY - previousEvent.screenY`.
+  ///
+  /// > **Warning:** Browsers [use different units for `movementY` and
+  /// > [MouseEvent.screenY]](https://github.com/w3c/pointerlock/issues/42) than
+  /// > what the specification defines. Depending on the browser and operating
+  /// > system, the `movementY` units may be a physical pixel, a logical pixel,
+  /// > or a CSS pixel. You may want to avoid the movement properties, and
+  /// > instead calculate the delta between the current client values
+  /// > ([MouseEvent.screenX], [MouseEvent.screenY]) and the previous client
+  /// > values.
+  external double get movementY;
 }
 extension type MouseEventInit._(JSObject _)
     implements EventModifierInit, JSObject {
@@ -798,13 +798,6 @@ extension type InputEvent._(JSObject _) implements UIEvent, JSObject {
   /// </table>
   external JSArray<StaticRange> getTargetRanges();
 
-  /// The **`dataTransfer`** read-only property of the
-  /// [InputEvent] interface returns a [DataTransfer] object
-  /// containing information about richtext or plaintext data being added to or
-  /// removed from
-  /// editable content.
-  external DataTransfer? get dataTransfer;
-
   /// The **`data`** read-only property of the
   /// [InputEvent] interface returns a string with inserted
   /// characters. This may be an empty string if the change doesn't insert text,
@@ -824,6 +817,13 @@ extension type InputEvent._(JSObject _) implements UIEvent, JSObject {
   /// Possible changes include for example inserting, deleting, and formatting
   /// text.
   external String get inputType;
+
+  /// The **`dataTransfer`** read-only property of the
+  /// [InputEvent] interface returns a [DataTransfer] object
+  /// containing information about richtext or plaintext data being added to or
+  /// removed from
+  /// editable content.
+  external DataTransfer? get dataTransfer;
 }
 extension type InputEventInit._(JSObject _) implements UIEventInit, JSObject {
   external factory InputEventInit({

--- a/web/lib/src/dom/url.dart
+++ b/web/lib/src/dom/url.dart
@@ -38,6 +38,37 @@ extension type URL._(JSObject _) implements JSObject {
     String base,
   ]);
 
+  /// The **`URL.parse()`** static method of the [URL] interface returns a newly
+  /// created [URL] object representing the URL defined by the parameters.
+  ///
+  /// If the given base URL or the resulting URL are not parsable and valid
+  /// URLs, `null` is returned.
+  /// This is an alternative to using the [URL.URL] constructor to construct a
+  /// `URL` within a
+  /// [try...catch](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch)
+  /// block, or using [URL.canParse_static] to check the parameters and
+  /// returning `null` if the method returns `false`.
+  external static URL? parse(
+    String url, [
+    String base,
+  ]);
+
+  /// The **`URL.canParse()`** static method of the [URL] interface returns a
+  /// boolean indicating whether or not an absolute URL, or a relative URL
+  /// combined with a base URL, are parsable and valid.
+  ///
+  /// This is a fast and easy alternative to constructing a `URL` within a
+  /// [try...catch](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch)
+  /// block.
+  /// It returns `true` for the same values for which the [`URL()`
+  /// constructor](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL)
+  /// would succeed, and `false` for the values that would cause the constructor
+  /// to throw.
+  external static bool canParse(
+    String url, [
+    String base,
+  ]);
+
   /// @AvailableInWorkers("window_and_worker_except_service")
   ///
   /// The **`createObjectURL()`** static method of the [URL] interface
@@ -74,37 +105,6 @@ extension type URL._(JSObject _) implements JSObject {
   /// > issues with the [Blob] interface's life cycle and the potential for
   /// > leaks.
   external static void revokeObjectURL(String url);
-
-  /// The **`URL.parse()`** static method of the [URL] interface returns a newly
-  /// created [URL] object representing the URL defined by the parameters.
-  ///
-  /// If the given base URL or the resulting URL are not parsable and valid
-  /// URLs, `null` is returned.
-  /// This is an alternative to using the [URL.URL] constructor to construct a
-  /// `URL` within a
-  /// [try...catch](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch)
-  /// block, or using [URL.canParse_static] to check the parameters and
-  /// returning `null` if the method returns `false`.
-  external static URL? parse(
-    String url, [
-    String base,
-  ]);
-
-  /// The **`URL.canParse()`** static method of the [URL] interface returns a
-  /// boolean indicating whether or not an absolute URL, or a relative URL
-  /// combined with a base URL, are parsable and valid.
-  ///
-  /// This is a fast and easy alternative to constructing a `URL` within a
-  /// [try...catch](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch)
-  /// block.
-  /// It returns `true` for the same values for which the [`URL()`
-  /// constructor](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL)
-  /// would succeed, and `false` for the values that would cause the constructor
-  /// to throw.
-  external static bool canParse(
-    String url, [
-    String base,
-  ]);
 
   /// The **`toJSON()`** method of the [URL] interface
   /// returns a string containing a serialized version of the URL,

--- a/web/lib/src/dom/web_animations.dart
+++ b/web/lib/src/dom/web_animations.dart
@@ -177,27 +177,6 @@ extension type Animation._(JSObject _) implements EventTarget, JSObject {
   /// attribute, where they can be modified and replaced as normal.
   external void commitStyles();
 
-  /// The **`Animation.startTime`** property of the [Animation] interface is a
-  /// double-precision floating-point value which indicates the scheduled time
-  /// when an animation's playback should begin.
-  ///
-  /// An animation's **start time** is the time value of its [DocumentTimeline]
-  /// when its target [KeyframeEffect] is scheduled to begin playback. An
-  /// animation's **start time** is initially unresolved (meaning that it's
-  /// `null` because it has no value).
-  external CSSNumberish? get startTime;
-  external set startTime(CSSNumberish? value);
-
-  /// The **`Animation.currentTime`** property of the
-  /// [Web Animations API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API)
-  /// returns and sets the current time value of the animation in milliseconds,
-  /// whether running or paused.
-  ///
-  /// If the animation lacks a [AnimationTimeline], is inactive, or hasn't been
-  /// played yet, `currentTime`'s return value is `null`.
-  external CSSNumberish? get currentTime;
-  external set currentTime(CSSNumberish? value);
-
   /// The **`Animation.id`** property of the
   /// [Web Animations API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API)
   /// returns or sets a string used to identify the animation.
@@ -277,6 +256,27 @@ extension type Animation._(JSObject _) implements EventTarget, JSObject {
   external set oncancel(EventHandler value);
   external EventHandler get onremove;
   external set onremove(EventHandler value);
+
+  /// The **`Animation.startTime`** property of the [Animation] interface is a
+  /// double-precision floating-point value which indicates the scheduled time
+  /// when an animation's playback should begin.
+  ///
+  /// An animation's **start time** is the time value of its [DocumentTimeline]
+  /// when its target [KeyframeEffect] is scheduled to begin playback. An
+  /// animation's **start time** is initially unresolved (meaning that it's
+  /// `null` because it has no value).
+  external CSSNumberish? get startTime;
+  external set startTime(CSSNumberish? value);
+
+  /// The **`Animation.currentTime`** property of the
+  /// [Web Animations API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API)
+  /// returns and sets the current time value of the animation in milliseconds,
+  /// whether running or paused.
+  ///
+  /// If the animation lacks a [AnimationTimeline], is inactive, or hasn't been
+  /// played yet, `currentTime`'s return value is `null`.
+  external CSSNumberish? get currentTime;
+  external set currentTime(CSSNumberish? value);
 }
 
 /// The `AnimationEffect` interface of the
@@ -447,12 +447,6 @@ extension type KeyframeEffect._(JSObject _)
   /// keyframes.
   external void setKeyframes(JSObject? keyframes);
 
-  /// The **`iterationComposite`** property of a [KeyframeEffect] resolves how
-  /// the animation's property value changes accumulate or override each other
-  /// upon each of the animation's iterations.
-  external IterationCompositeOperation get iterationComposite;
-  external set iterationComposite(IterationCompositeOperation value);
-
   /// The **`target`** property of a [KeyframeEffect] interface represents the
   /// element or pseudo-element being animated. It may be `null` for animations
   /// that do not target a specific element. It performs as both a getter and a
@@ -476,6 +470,12 @@ extension type KeyframeEffect._(JSObject _)
   /// element's animation impacts its underlying property values.
   external CompositeOperation get composite;
   external set composite(CompositeOperation value);
+
+  /// The **`iterationComposite`** property of a [KeyframeEffect] resolves how
+  /// the animation's property value changes accumulate or override each other
+  /// upon each of the animation's iterations.
+  external IterationCompositeOperation get iterationComposite;
+  external set iterationComposite(IterationCompositeOperation value);
 }
 extension type KeyframeEffectOptions._(JSObject _)
     implements EffectTiming, JSObject {

--- a/web/lib/src/dom/webrtc.dart
+++ b/web/lib/src/dom/webrtc.dart
@@ -132,32 +132,6 @@ extension type RTCPeerConnection._(JSObject _)
   external static JSPromise<RTCCertificate> generateCertificate(
       AlgorithmIdentifier keygenAlgorithm);
 
-  /// The **`setIdentityProvider()`** method of the [RTCPeerConnection]
-  /// interface sets the Identity Provider (IdP) to the triplet given in
-  /// parameter: its name, the protocol used to communicate with it (optional)
-  /// and an optional username.
-  /// The IdP will be used only when an assertion is needed.
-  ///
-  /// If the [RTCPeerConnection.signalingState] is set to `"closed"`, an
-  /// `InvalidStateError` is raised.
-  external void setIdentityProvider(
-    String provider, [
-    RTCIdentityProviderOptions options,
-  ]);
-
-  /// The **`getIdentityAssertion()`** method of the [RTCPeerConnection]
-  /// interface initiates the gathering of an identity assertion.
-  /// This has an effect only if the [RTCPeerConnection.signalingState] is not
-  /// `"closed"`.
-  ///
-  /// The method returns a JavaScript `Promise` which resolves to an identity
-  /// assertion encoded as a string.
-  ///
-  /// It is not expected for the application dealing with the
-  /// `RTCPeerConnection`: this is automatically done; an explicit call only
-  /// allows to anticipate the need.
-  external JSPromise<JSString> getIdentityAssertion();
-
   /// The **`createOffer()`** method of the [RTCPeerConnection] interface
   /// initiates the creation of an  offer for the purpose of starting a new
   /// WebRTC connection to a remote peer.
@@ -350,6 +324,32 @@ extension type RTCPeerConnection._(JSObject _)
   /// current peer connection.
   external void close();
 
+  /// The **`setIdentityProvider()`** method of the [RTCPeerConnection]
+  /// interface sets the Identity Provider (IdP) to the triplet given in
+  /// parameter: its name, the protocol used to communicate with it (optional)
+  /// and an optional username.
+  /// The IdP will be used only when an assertion is needed.
+  ///
+  /// If the [RTCPeerConnection.signalingState] is set to `"closed"`, an
+  /// `InvalidStateError` is raised.
+  external void setIdentityProvider(
+    String provider, [
+    RTCIdentityProviderOptions options,
+  ]);
+
+  /// The **`getIdentityAssertion()`** method of the [RTCPeerConnection]
+  /// interface initiates the gathering of an identity assertion.
+  /// This has an effect only if the [RTCPeerConnection.signalingState] is not
+  /// `"closed"`.
+  ///
+  /// The method returns a JavaScript `Promise` which resolves to an identity
+  /// assertion encoded as a string.
+  ///
+  /// It is not expected for the application dealing with the
+  /// `RTCPeerConnection`: this is automatically done; an explicit call only
+  /// allows to anticipate the need.
+  external JSPromise<JSString> getIdentityAssertion();
+
   /// The **`getSenders()`** method of the [RTCPeerConnection] interface returns
   /// an array of [RTCRtpSender] objects, each of which represents the RTP
   /// sender responsible for transmitting one track's data.
@@ -426,16 +426,6 @@ extension type RTCPeerConnection._(JSObject _)
   /// promise which resolves with data providing statistics about either the
   /// overall connection or about the specified [MediaStreamTrack].
   external JSPromise<RTCStatsReport> getStats([MediaStreamTrack? selector]);
-
-  /// The **`peerIdentity`** read-only property of the [RTCPeerConnection]
-  /// interface returns a JavaScript `Promise` that resolves to an
-  /// [RTCIdentityAssertion] which contains a string identifying the remote
-  /// peer.
-  /// Once this promise resolves successfully, the resulting identity is the
-  /// **target peer identity** and cannot change for the duration of the
-  /// connection.
-  external JSPromise<JSObject> get peerIdentity;
-  external String? get idpLoginUrl;
 
   /// The **`localDescription`** read-only property of the [RTCPeerConnection]
   /// interface returns an [RTCSessionDescription] describing the session for
@@ -632,6 +622,16 @@ extension type RTCPeerConnection._(JSObject _)
   external set onicegatheringstatechange(EventHandler value);
   external EventHandler get onconnectionstatechange;
   external set onconnectionstatechange(EventHandler value);
+
+  /// The **`peerIdentity`** read-only property of the [RTCPeerConnection]
+  /// interface returns a JavaScript `Promise` that resolves to an
+  /// [RTCIdentityAssertion] which contains a string identifying the remote
+  /// peer.
+  /// Once this promise resolves successfully, the resulting identity is the
+  /// **target peer identity** and cannot change for the duration of the
+  /// connection.
+  external JSPromise<JSObject> get peerIdentity;
+  external String? get idpLoginUrl;
   external EventHandler get ontrack;
   external set ontrack(EventHandler value);
 
@@ -1150,6 +1150,22 @@ extension type RTCRtpSender._(JSObject _) implements JSObject {
   /// which is fulfilled when the results are available.
   external JSPromise<RTCStatsReport> getStats();
 
+  /// The **`track`** read-only property of
+  /// the [RTCRtpSender] interface returns the [MediaStreamTrack]
+  /// which is being handled by the `RTCRtpSender`.
+  external MediaStreamTrack? get track;
+
+  /// The read-only **`transport`** property of an
+  /// [RTCRtpSender] object provides the [RTCDtlsTransport] object
+  /// used to interact with the underlying transport over which the sender is
+  /// exchanging
+  /// Real-time Transport Control Protocol () packets.
+  ///
+  /// This transport is responsible for receiving the data for the media on the
+  /// sender's
+  /// [RTCRtpReceiver.track].
+  external RTCDtlsTransport? get transport;
+
   /// The **`transform`** property of the [RTCRtpSender] object is used to
   /// insert a transform stream ([TransformStream]) running in a worker thread
   /// into the sender pipeline.
@@ -1168,22 +1184,6 @@ extension type RTCRtpSender._(JSObject _) implements JSObject {
   /// sender has no associated transform stream.
   external RTCRtpTransform? get transform;
   external set transform(RTCRtpTransform? value);
-
-  /// The **`track`** read-only property of
-  /// the [RTCRtpSender] interface returns the [MediaStreamTrack]
-  /// which is being handled by the `RTCRtpSender`.
-  external MediaStreamTrack? get track;
-
-  /// The read-only **`transport`** property of an
-  /// [RTCRtpSender] object provides the [RTCDtlsTransport] object
-  /// used to interact with the underlying transport over which the sender is
-  /// exchanging
-  /// Real-time Transport Control Protocol () packets.
-  ///
-  /// This transport is responsible for receiving the data for the media on the
-  /// sender's
-  /// [RTCRtpReceiver.track].
-  external RTCDtlsTransport? get transport;
 
   /// The read-only **`dtmf`** property on the
   /// **[RTCRtpSender]** interface returns a
@@ -1387,27 +1387,6 @@ extension type RTCRtpReceiver._(JSObject _) implements JSObject {
   /// handler will be called once the results are available.
   external JSPromise<RTCStatsReport> getStats();
 
-  /// The **`transform`** property of the [RTCRtpReceiver] object is used to
-  /// insert a transform stream ([TransformStream]) running in a worker thread
-  /// into the receiver pipeline.
-  /// This allows stream transforms to be applied to encoded video and audio
-  /// frames as they arrive from the packetizer (before they are
-  /// played/rendered).
-  ///
-  /// The transform that is to be added is defined using an
-  /// [RTCRtpScriptTransform] and its associated [Worker].
-  /// If the transform is set in the peer connection
-  /// [`track` event](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/track_event)
-  /// handler, the transform stream will receive the first full incoming frame
-  /// for the track.
-  ///
-  /// ### Value
-  ///
-  /// A [RTCRtpScriptTransform]<!-- or [SFrameTransform] -->, or `null` if the
-  /// receiver has no associated transform stream.
-  external RTCRtpTransform? get transform;
-  external set transform(RTCRtpTransform? value);
-
   /// The **`track`** read-only property of the
   /// [RTCRtpReceiver] interface returns the [MediaStreamTrack]
   /// associated with the current [RTCRtpReceiver] instance.
@@ -1434,6 +1413,27 @@ extension type RTCRtpReceiver._(JSObject _) implements JSObject {
   /// jitter.
   external double? get jitterBufferTarget;
   external set jitterBufferTarget(DOMHighResTimeStamp? value);
+
+  /// The **`transform`** property of the [RTCRtpReceiver] object is used to
+  /// insert a transform stream ([TransformStream]) running in a worker thread
+  /// into the receiver pipeline.
+  /// This allows stream transforms to be applied to encoded video and audio
+  /// frames as they arrive from the packetizer (before they are
+  /// played/rendered).
+  ///
+  /// The transform that is to be added is defined using an
+  /// [RTCRtpScriptTransform] and its associated [Worker].
+  /// If the transform is set in the peer connection
+  /// [`track` event](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/track_event)
+  /// handler, the transform stream will receive the first full incoming frame
+  /// for the track.
+  ///
+  /// ### Value
+  ///
+  /// A [RTCRtpScriptTransform]<!-- or [SFrameTransform] -->, or `null` if the
+  /// receiver has no associated transform stream.
+  external RTCRtpTransform? get transform;
+  external set transform(RTCRtpTransform? value);
 }
 extension type RTCRtpContributingSource._(JSObject _) implements JSObject {
   external factory RTCRtpContributingSource({
@@ -1650,10 +1650,6 @@ extension type RTCIceTransport._(JSObject _) implements EventTarget, JSObject {
   /// delivered to the transport when the client calls
   /// [RTCPeerConnection.setRemoteDescription].
   external RTCIceParameters? getRemoteParameters();
-  external EventHandler get onerror;
-  external set onerror(EventHandler value);
-  external EventHandler get onicecandidate;
-  external set onicecandidate(EventHandler value);
 
   /// The **`role`** read-only property of the [RTCIceTransport] interface
   /// indicates which  role the transport is fulfilling: that of the controlling
@@ -1693,6 +1689,10 @@ extension type RTCIceTransport._(JSObject _) implements EventTarget, JSObject {
   external set ongatheringstatechange(EventHandler value);
   external EventHandler get onselectedcandidatepairchange;
   external set onselectedcandidatepairchange(EventHandler value);
+  external EventHandler get onerror;
+  external set onerror(EventHandler value);
+  external EventHandler get onicecandidate;
+  external set onicecandidate(EventHandler value);
 }
 
 /// The **`RTCIceParameters`** dictionary specifies the username fragment and
@@ -2295,8 +2295,6 @@ extension type RTCError._(JSObject _) implements DOMException, JSObject {
     String message,
   ]);
 
-  external int? get httpRequestStatusCode;
-
   /// The [RTCError] interface's read-only
   /// **`errorDetail`** property is a string indicating the
   /// [WebRTC](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API)-specific
@@ -2324,6 +2322,7 @@ extension type RTCError._(JSObject _) implements DOMException, JSObject {
   /// while sending data to the remote peer, if the error represents an outbound
   /// DTLS error.
   external int? get sentAlert;
+  external int? get httpRequestStatusCode;
 }
 extension type RTCErrorInit._(JSObject _) implements JSObject {
   external factory RTCErrorInit({

--- a/web/lib/src/dom/webxr.dart
+++ b/web/lib/src/dom/webxr.dart
@@ -338,33 +338,6 @@ extension type XRViewerPose._(JSObject _) implements XRPose, JSObject {
 /// API documentation sourced from
 /// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/XRInputSource).
 extension type XRInputSource._(JSObject _) implements JSObject {
-  /// The read-only [XRInputSource] property **`gamepad`** returns a [Gamepad]
-  /// object describing the state of the buttons and axes on the XR input
-  /// source, if it is a gamepad or comparable device. If the device isn't a
-  /// gamepad-like device, this property's value is `null`.
-  ///
-  /// The [Gamepad] instance returned behaves as described by the
-  /// [Gamepad API](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad_API).
-  /// However, there are a few things to note:
-  ///
-  /// - `Gamepad` instances belonging to `XRInputSource` are not included in the
-  ///   array returned by [navigator.getGamepads]. Gamepads are strictly
-  ///   associated with the WebXR hardware and are not general-purpose gaming
-  ///   devices.
-  /// - [Gamepad.id] is an empty string (`""`)
-  /// - [Gamepad.index] is `-1`
-  /// - [Gamepad.connected] is `true` until the `XRInputSource` is removed from
-  ///   the list of active XR input sources or the [XRSession] is ended.
-  /// - If an axis reported by [Gamepad.axes] represents an axis of a touchpad,
-  ///   the value is 0 when the associated [GamepadButton.touched] property is
-  ///   `false`.
-  /// - [Gamepad.mapping] returns "xr-standard".
-  external Gamepad? get gamepad;
-
-  /// The read-only **`hand`** property of the [XRInputSource] interface is a
-  /// [XRHand] object providing access to a hand-tracking device.
-  external XRHand? get hand;
-
   /// The read-only [XRInputSource] property
   /// **`handedness`** indicates which of the user's hands the WebXR
   /// input source is associated with, or if it's not associated with a hand at
@@ -425,6 +398,33 @@ extension type XRInputSource._(JSObject _) implements JSObject {
   /// > **Note:** The `profiles` list is always empty when the WebXR
   /// > session is in inline mode.
   external JSArray<JSString> get profiles;
+
+  /// The read-only [XRInputSource] property **`gamepad`** returns a [Gamepad]
+  /// object describing the state of the buttons and axes on the XR input
+  /// source, if it is a gamepad or comparable device. If the device isn't a
+  /// gamepad-like device, this property's value is `null`.
+  ///
+  /// The [Gamepad] instance returned behaves as described by the
+  /// [Gamepad API](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad_API).
+  /// However, there are a few things to note:
+  ///
+  /// - `Gamepad` instances belonging to `XRInputSource` are not included in the
+  ///   array returned by [navigator.getGamepads]. Gamepads are strictly
+  ///   associated with the WebXR hardware and are not general-purpose gaming
+  ///   devices.
+  /// - [Gamepad.id] is an empty string (`""`)
+  /// - [Gamepad.index] is `-1`
+  /// - [Gamepad.connected] is `true` until the `XRInputSource` is removed from
+  ///   the list of active XR input sources or the [XRSession] is ended.
+  /// - If an axis reported by [Gamepad.axes] represents an axis of a touchpad,
+  ///   the value is 0 when the associated [GamepadButton.touched] property is
+  ///   `false`.
+  /// - [Gamepad.mapping] returns "xr-standard".
+  external Gamepad? get gamepad;
+
+  /// The read-only **`hand`** property of the [XRInputSource] interface is a
+  /// [XRHand] object providing access to a hand-tracking device.
+  external XRHand? get hand;
 }
 
 /// The

--- a/web_generator/lib/src/generate_bindings.dart
+++ b/web_generator/lib/src/generate_bindings.dart
@@ -83,6 +83,6 @@ Future<TranslationResult> generateBindings(
     final ast = entry[1] as JSArray<webidl.Node>;
     translator.collect(shortname, ast);
   }
-  translator.setOrUpdateInterfacesAndNamespaces();
+  translator.addInterfacesAndNamespaces();
   return translator.translate();
 }

--- a/web_generator/lib/src/translator.dart
+++ b/web_generator/lib/src/translator.dart
@@ -26,9 +26,7 @@ class _Library {
   final String url;
   // Contains both IDL `interface`s and `namespace`s.
   final List<idl.Interfacelike> interfacelikes = [];
-  final List<idl.Interfacelike> partialInterfaces = [];
   final List<idl.Interfacelike> interfaceMixins = [];
-  final List<idl.Interfacelike> partialInterfaceMixins = [];
   final List<idl.Typedef> typedefs = [];
   final List<idl.Enum> enums = [];
   final List<idl.Callback> callbacks = [];
@@ -63,8 +61,6 @@ class _Library {
         // well.
         final isMixin = type == 'interface mixin';
         final interfaceList = isMixin ? interfaceMixins : interfacelikes;
-        final partialInterfaceList =
-            isMixin ? partialInterfaceMixins : partialInterfaces;
         final interfacelike = node as idl.Interfacelike;
         if (!node.partial) {
           _addNamed<idl.Interfacelike>(node, interfaceList);
@@ -72,14 +68,16 @@ class _Library {
           translator._typeToPartials
               .putIfAbsent(interfacelike.name, () => [])
               .add(interfacelike);
-          partialInterfaceList.add(interfacelike);
         }
         break;
       case 'typedef':
         _addNamed<idl.Typedef>(node, typedefs);
         break;
       case 'includes':
-        translator._includes.add(node as idl.Includes);
+        final includes = node as idl.Includes;
+        translator._includes
+            .putIfAbsent(includes.target, () => [])
+            .add(includes.includes);
         break;
       case 'enum':
         _addNamed<idl.Enum>(node, enums);
@@ -655,7 +653,7 @@ class Translator {
   final _typeToPartials = <String, List<idl.Interfacelike>>{};
   final _typeToLibrary = <String, _Library>{};
   final _interfacelikes = <String, _PartialInterfacelike>{};
-  final _includes = <idl.Includes>[];
+  final _includes = <String, List<String>>{};
   final _usedTypes = <idl.Node>{};
 
   late String _currentlyTranslatingUrl;
@@ -685,7 +683,7 @@ class Translator {
     }
   }
 
-  /// Set or update interfaces and namespaces so we can have a unified interface
+  /// Add interfaces and namespaces so we can have a unified interface
   /// representation.
   ///
   /// Note that this is done after the initial pass on the AST. This is because
@@ -693,34 +691,18 @@ class Translator {
   /// types.
   ///
   /// This method only adds the interfaces and namespaces that the browser
-  /// compat data claims should be generated. It also does not add any
-  /// dictionaries, as those are handled by [markTypeAsUsed] because they don't
-  /// have any compat data and are emitted only if used.
-  void setOrUpdateInterfacesAndNamespaces() {
-    final mixins = <String, Set<idl.Interfacelike>>{};
+  /// compat data claims should be generated. It also only adds dictionaries if
+  /// [BrowserCompatData.generateAll] is true and are otherwise handled by
+  /// [markTypeAsUsed] because they don't have any compat data and are emitted
+  /// only if used.
+  void addInterfacesAndNamespaces() {
     for (final library in _libraries.values) {
-      for (final interfacelike in [
-        ...library.interfacelikes,
-        ...library.partialInterfaces
-      ]) {
+      for (final interfacelike in library.interfacelikes) {
         final name = interfacelike.name;
         switch (interfacelike.type) {
           case 'interface':
-            if (browserCompatData.shouldGenerateInterface(name)) {
-              _addOrUpdateInterfaceLike(interfacelike);
-              _usedTypes.add(interfacelike);
-            }
-            break;
           case 'namespace':
-            // Browser compat data doesn't document namespaces that only contain
-            // constants.
-            // https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/api.md#namespaces
-            if (browserCompatData.shouldGenerateInterface(name) ||
-                interfacelike.members.toDart
-                    .every((member) => member.type == 'const')) {
-              _addOrUpdateInterfaceLike(interfacelike);
-              _usedTypes.add(interfacelike);
-            }
+            markTypeAsUsed(name);
             break;
           case 'dictionary':
             if (Translator.instance!.browserCompatData.generateAll) {
@@ -732,34 +714,41 @@ class Translator {
                 'Unexpected interfacelike type ${interfacelike.type}');
         }
       }
-      for (final interfacelike in [
-        ...library.interfaceMixins,
-        ...library.partialInterfaceMixins
-      ]) {
-        final name = interfacelike.name;
-        mixins.putIfAbsent(name, () => {}).add(interfacelike);
-      }
     }
-    for (final include in _includes) {
-      final target = include.target;
-      final includes = include.includes;
+  }
 
-      // Incorporate mixins into the interfaces that include them.
-      if (_interfacelikes.containsKey(target) && mixins.containsKey(includes)) {
-        for (final partial in mixins[includes]!) {
-          _interfacelikes[target]!.update(partial);
-        }
+  /// Given an [interfacelikeName], combines its interfacelike declaration, its
+  /// partial interfacelikes, and any mixins it includes in that order.
+  ///
+  /// Mixins are applied by applying the mixin interface first and then its
+  /// partial interfaces.
+  void _combineInterfacelikes(String interfacelikeName) {
+    final decl = _typeToDeclaration[interfacelikeName]! as idl.Interfacelike;
+    for (final interfacelike in [
+      decl,
+      ..._typeToPartials[interfacelikeName] ?? <idl.Interfacelike>[]
+    ]) {
+      _addOrUpdateInterfaceLike(interfacelike);
+    }
+    final mixins = _includes[interfacelikeName];
+    if (mixins == null) return;
+    for (final mixin in mixins) {
+      for (final interfacelike in [
+        _typeToDeclaration[mixin] as idl.Interfacelike,
+        ..._typeToPartials[mixin] ?? <idl.Interfacelike>[]
+      ]) {
+        _interfacelikes[interfacelikeName]!.update(interfacelike);
       }
     }
   }
 
-  /// Given a [type] that corresponds to an IDL type, marks it as a used type
-  /// and marks any types its declaration uses.
+  /// Given a [type] that corresponds to an IDL type, marks it as a used type,
+  /// processes the type if needed, and marks any types its declaration uses.
   ///
-  /// If the type is an interface, this function doesn't mark it as used, as
-  /// that determination is handled by [setOrUpdateInterfacesAndNamespaces].
+  /// If the type is an interface, this function only marks it used if the
+  /// browser compat data says it should be.
   ///
-  /// If the type is a dictionary, this function emits it.
+  /// If the type is a dictionary, this function always marks it as used.
   ///
   /// If the type is a type that is treated like a typedef, marks the type it is
   /// aliased to as used.
@@ -768,26 +757,17 @@ class Translator {
   bool markTypeAsUsed(String type) {
     final decl = _typeToDeclaration[type];
     if (decl == null) return false;
+    if (_usedTypes.contains(decl)) return true;
     switch (decl.type) {
       case 'dictionary':
-        if (!_usedTypes.contains(decl)) {
-          _usedTypes.add(decl);
-          final dictionary = decl as idl.Interfacelike;
-          final name = dictionary.name;
-          for (final interfacelike in [
-            dictionary,
-            ..._typeToPartials[name] ?? <idl.Interfacelike>[]
-          ]) {
-            _addOrUpdateInterfaceLike(interfacelike);
-          }
-        }
+        final name = (decl as idl.Interfacelike).name;
+        _usedTypes.add(decl);
+        _combineInterfacelikes(name);
         return true;
       case 'typedef':
-        if (!_usedTypes.contains(decl)) {
-          _usedTypes.add(decl);
-          final desugaredType = _desugarTypedef(_RawType(type, false))!.type;
-          markTypeAsUsed(desugaredType);
-        }
+        _usedTypes.add(decl);
+        final desugaredType = _desugarTypedef(_RawType(type, false))!.type;
+        markTypeAsUsed(desugaredType);
         return true;
       case 'enum':
       case 'callback interface':
@@ -795,14 +775,34 @@ class Translator {
         _usedTypes.add(decl);
         return true;
       case 'interface':
-        // Interfaces can only be marked as used depending on their compat data.
-        return browserCompatData
-            .shouldGenerateInterface((decl as idl.Interfacelike).name);
-      case 'interface mixin':
+        // Interfaces and namespaces can only be marked as used depending on
+        // their compat data.
+        final name = (decl as idl.Interfacelike).name;
+        if (browserCompatData.shouldGenerateInterface(name)) {
+          _usedTypes.add(decl);
+          _combineInterfacelikes(name);
+          return true;
+        }
+        return false;
       case 'namespace':
-      // Mixins and namespaces should never appear in types.
+        // Browser compat data doesn't document namespaces that only contain
+        // constants.
+        // https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/api.md#namespaces
+        final namespace = decl as idl.Interfacelike;
+        final name = namespace.name;
+        if (browserCompatData.shouldGenerateInterface(name) ||
+            namespace.members.toDart
+                .every((member) => member.type == 'const')) {
+          _usedTypes.add(decl);
+          _combineInterfacelikes(name);
+          return true;
+        }
+        return false;
+      case 'interface mixin':
+      // Mixins should never appear as types.
       default:
-        throw Exception('Unexpected node type to be marked as used: $type');
+        throw Exception(
+            'Unexpected node type to be marked as used: ${decl.type}');
     }
   }
 

--- a/web_generator/lib/src/translator.dart
+++ b/web_generator/lib/src/translator.dart
@@ -726,7 +726,7 @@ class Translator {
     final decl = _typeToDeclaration[interfacelikeName]! as idl.Interfacelike;
     for (final interfacelike in [
       decl,
-      ..._typeToPartials[interfacelikeName] ?? <idl.Interfacelike>[]
+      ...?_typeToPartials[interfacelikeName]
     ]) {
       _addOrUpdateInterfaceLike(interfacelike);
     }
@@ -735,7 +735,7 @@ class Translator {
     for (final mixin in mixins) {
       for (final interfacelike in [
         _typeToDeclaration[mixin] as idl.Interfacelike,
-        ..._typeToPartials[mixin] ?? <idl.Interfacelike>[]
+        ...?_typeToPartials[mixin]
       ]) {
         _interfacelikes[interfacelikeName]!.update(interfacelike);
       }


### PR DESCRIPTION
Currently, the generator adds members to interfacelikes as we process various IDL files. This may lead to partial interfaces being added before the interface definition. Instead, this CL adds partials after the interface definition, and then applies mixins. It also dedups some logic around browser compatibility so that we only check compatibility and process in one location.

While there is a diff in the generated files, it is functionally the same because all we do is move members around in the same extension type.