### PR TITLE
Remove the deprecated `package_api_docs` lint

### DIFF
--- a/web/analysis_options.yaml
+++ b/web/analysis_options.yaml
@@ -33,7 +33,6 @@ linter:
   - literal_only_boolean_expressions
   - no_adjacent_strings_in_list
   - no_runtimeType_toString
-  - package_api_docs
   - prefer_const_declarations
   - prefer_final_locals
   - unnecessary_await_in_return

--- a/web_generator/analysis_options.yaml
+++ b/web_generator/analysis_options.yaml
@@ -19,7 +19,6 @@ linter:
   - literal_only_boolean_expressions
   - no_adjacent_strings_in_list
   - no_runtimeType_toString
-  - package_api_docs
   - prefer_const_declarations
   - prefer_final_locals
   - unnecessary_await_in_return


### PR DESCRIPTION
Reference: https://github.com/dart-lang/linter/issues/5107