### PR TITLE
Add missing FileReader event getters

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -17,6 +17,8 @@
   `HTMLIFrameElement.contentWindowCrossOrigin`, `Window.openCrossOrigin`,
   `Window.openerCrossOrigin`, `Window.topCrossOrigin`,
   and `Window.parentCrossOrigin`.
+- Added missing `FileReader` event getters: `onAbort`, `onError`, `onLoad`,
+  `onLoadStart`, `onProgress`.
 
 ## 1.0.0
 

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0-wip
+- Added missing `FileReader` event getters: `onAbort`, `onError`, `onLoad`,
+  `onLoadStart`, `onProgress`.
+
 ## 1.1.0
 
 - Added `HttpStatus` class that declares http status codes. This is a copy of 
@@ -17,8 +21,6 @@
   `HTMLIFrameElement.contentWindowCrossOrigin`, `Window.openCrossOrigin`,
   `Window.openerCrossOrigin`, `Window.topCrossOrigin`,
   and `Window.parentCrossOrigin`.
-- Added missing `FileReader` event getters: `onAbort`, `onError`, `onLoad`,
-  `onLoadStart`, `onProgress`.
 
 ## 1.0.0
 

--- a/web/lib/src/helpers/events/events.dart
+++ b/web/lib/src/helpers/events/events.dart
@@ -243,9 +243,19 @@ extension EventSourceEventGetters on EventSource {
   Stream<Event> get onOpen => EventStreamProviders.openEvent.forTarget(this);
 }
 
-extension FileReaderEventGEtters on FileReader {
+extension FileReaderEventGetters on FileReader {
+  Stream<ProgressEvent> get onAbort =>
+      EventStreamProviders.abortEvent.forTarget(this);
+  Stream<ProgressEvent> get onError =>
+      EventStreamProviders.errorEvent.forTarget(this);
+  Stream<ProgressEvent> get onLoad =>
+      EventStreamProviders.loadEvent.forTarget(this);
   Stream<ProgressEvent> get onLoadEnd =>
       EventStreamProviders.loadEndEvent.forTarget(this);
+  Stream<ProgressEvent> get onLoadStart =>
+      EventStreamProviders.loadStartEvent.forTarget(this);
+  Stream<ProgressEvent> get onProgress =>
+      EventStreamProviders.progressEvent.forTarget(this);
 }
 
 extension AutoElementEventGetters on AudioNode {

--- a/web/pubspec.yaml
+++ b/web/pubspec.yaml
@@ -1,5 +1,5 @@
 name: web
-version: 1.1.0
+version: 1.2.0-wip
 description: Lightweight browser API bindings built around JS interop.
 repository: https://github.com/dart-lang/web
 


### PR DESCRIPTION
#330 

add `onLoad` event and [some other events shown on MDN](https://developer.mozilla.org/en-US/docs/Web/API/FileReader/load_event), such as `onLoadStart`, `onProgress` etc.

minor detail: fix the extension method name typo `FileReaderEventGEtters`

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
