### PR TITLE
Add catch and finally to bannedNames

### DIFF
--- a/web_generator/lib/src/banned_names.dart
+++ b/web_generator/lib/src/banned_names.dart
@@ -5,9 +5,11 @@
 const bannedNames = <String>{
   'assert',
   'break',
+  'catch',
   'continue',
-  'extends',
   'default',
+  'extends',
+  'finally',
   'in',
   'is',
   'var',


### PR DESCRIPTION
Generating all the bindings generates codes with these keywords, leading to analysis errors. Members with this name will be renamed using `@JS`.
