### PR TITLE
Skip ts_bindings_test and run web_generator tests with VM

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -340,6 +340,42 @@ jobs:
       - job_004
       - job_005
   job_010:
+    name: "unit_test; Dart dev; PKG: web_generator; `dart test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:web_generator;commands:test_2"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:web_generator
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
+        with:
+          sdk: dev
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - id: web_generator_pub_upgrade
+        name: web_generator; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: web_generator
+      - name: "web_generator; dart test --test-randomize-ordering-seed=random"
+        run: "dart test --test-randomize-ordering-seed=random"
+        if: "always() && steps.web_generator_pub_upgrade.conclusion == 'success'"
+        working-directory: web_generator
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_011:
     name: "generate_and_analyze; Dart dev; PKG: web_generator; `dart pub -C ../web get && dart bin/update_idl_bindings.dart && dart analyze --fatal-infos ../web`"
     runs-on: ubuntu-latest
     steps:
@@ -379,7 +415,8 @@ jobs:
       - job_007
       - job_008
       - job_009
-  job_011:
+      - job_010
+  job_012:
     name: "generate_all_and_analyze; Dart dev; PKG: web_generator; `dart pub -C ../web get && dart bin/update_idl_bindings.dart --generate-all && dart analyze --fatal-infos ../web`"
     runs-on: ubuntu-latest
     steps:
@@ -420,7 +457,8 @@ jobs:
       - job_008
       - job_009
       - job_010
-  job_012:
+      - job_011
+  job_013:
     name: "dart_fixes; Dart main; PKG: web; `dart fix --compare-to-golden test_fixes`"
     runs-on: ubuntu-latest
     steps:
@@ -462,3 +500,4 @@ jobs:
       - job_009
       - job_010
       - job_011
+      - job_012

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -91,6 +91,10 @@ for PKG in ${PKGS}; do
         echo 'dart test --test-randomize-ordering-seed=random -p chrome -c dart2wasm'
         dart test --test-randomize-ordering-seed=random -p chrome -c dart2wasm || EXIT_CODE=$?
         ;;
+      test_2)
+        echo 'dart test --test-randomize-ordering-seed=random'
+        dart test --test-randomize-ordering-seed=random || EXIT_CODE=$?
+        ;;
       *)
         echo -e "\033[31mUnknown TASK '${TASK}' - TERMINATING JOB\033[0m"
         exit 64

--- a/web_generator/mono_pkg.yaml
+++ b/web_generator/mono_pkg.yaml
@@ -8,6 +8,7 @@ stages:
 - unit_test:
   - test: --test-randomize-ordering-seed=random -p chrome
   - test: --test-randomize-ordering-seed=random -p chrome -c dart2wasm
+  - test: --test-randomize-ordering-seed=random
 - generate_and_analyze:
   - command:
     - dart pub -C ../web get

--- a/web_generator/test/ts_bindings_test.dart
+++ b/web_generator/test/ts_bindings_test.dart
@@ -1,5 +1,6 @@
 @TestOn('vm')
 @Tags(['node'])
+@Skip('https://github.com/dart-lang/web/issues/372')
 library;
 
 import 'dart:io';
@@ -15,7 +16,7 @@ void main() {
   group('Web Generator TS Bindings Integration Test', () {
     final inputDir = Directory(testGenDTSFiles);
 
-    setUp(() async {
+    setUpAll(() async {
       // set up npm
       await runProc('npm', ['install'],
           workingDirectory: bindingsGeneratorPath, detached: true);


### PR DESCRIPTION
It looks like we were silently skipping scrape_mdn_test.dart before because we never ran the tests in this package with the VM.
