### PR TITLE
[interop] Add Support for Enums

### DIFF
--- a/web_generator/lib/src/ast/types.dart
+++ b/web_generator/lib/src/ast/types.dart
@@ -24,8 +24,11 @@ class ReferredType<T extends Declaration> extends Type {
 
   @override
   Reference emit([TypeOptions? options]) {
-    // TODO: implement emit
-    throw UnimplementedError();
+    // TODO: Support referred types imported from URL
+    return TypeReference((t) => t
+      ..symbol = declaration.name
+      ..types.addAll(typeParams.map((t) => t.emit(options)))
+      ..isNullable = options?.nullable);
   }
 }
 

--- a/web_generator/lib/src/interop_gen/transform.dart
+++ b/web_generator/lib/src/interop_gen/transform.dart
@@ -32,7 +32,10 @@ class TransformResult {
           final Type _ => null,
         };
       }).whereType<Spec>();
-      final lib = Library((l) => l..body.addAll(specs));
+      final lib = Library((l) => l
+        ..ignoreForFile.addAll(
+            ['constant_identifier_names', 'non_constant_identifier_names'])
+        ..body.addAll(specs));
       return MapEntry(file, formatter.format('${lib.accept(emitter)}'));
     });
   }

--- a/web_generator/lib/src/js/typescript.types.dart
+++ b/web_generator/lib/src/js/typescript.types.dart
@@ -25,6 +25,11 @@ extension type const TSSyntaxKind._(num _) {
   static const TSSyntaxKind FunctionDeclaration = TSSyntaxKind._(262);
   static const TSSyntaxKind ExportDeclaration = TSSyntaxKind._(278);
   static const TSSyntaxKind Parameter = TSSyntaxKind._(169);
+  static const TSSyntaxKind EnumDeclaration = TSSyntaxKind._(266);
+
+  /// expressions
+  static const TSSyntaxKind NumericLiteral = TSSyntaxKind._(9);
+  static const TSSyntaxKind StringLiteral = TSSyntaxKind._(11);
 
   /// keywords
   static const TSSyntaxKind ExportKeyword = TSSyntaxKind._(95);
@@ -98,8 +103,31 @@ extension type TSTypeReferenceNode._(JSObject _) implements TSTypeNode {
   external TSNodeArray<TSTypeNode>? get typeArguments;
 }
 
+@JS('Expression')
+extension type TSExpression._(JSObject _) implements TSNode {}
+
+@JS('LiteralExpression')
+extension type TSLiteralExpression._(JSObject _) implements TSExpression {
+  external String text;
+  external bool? isUnterminated;
+}
+
 @JS('Declaration')
 extension type TSDeclaration._(JSObject _) implements TSNode {}
+
+@JS('NumericLiteral')
+extension type TSNumericLiteral._(JSObject _)
+    implements TSLiteralExpression, TSDeclaration {
+  @redeclare
+  TSSyntaxKind get kind => TSSyntaxKind.NumericLiteral;
+}
+
+@JS('StringLiteral')
+extension type TSStringLiteral._(JSObject _)
+    implements TSLiteralExpression, TSDeclaration {
+  @redeclare
+  TSSyntaxKind get kind => TSSyntaxKind.StringLiteral;
+}
 
 @JS('Statement')
 extension type TSStatement._(JSObject _) implements TSNode {}
@@ -150,6 +178,20 @@ extension type TSTypeParameterDeclaration._(JSObject _)
     implements TSDeclaration {
   external TSIdentifier get name;
   external TSTypeNode? get constraint;
+}
+
+@JS('EnumDeclaration')
+extension type TSEnumDeclaration._(JSObject _)
+    implements TSDeclaration, TSStatement {
+  external TSIdentifier get name;
+  external TSNodeArray<TSNode>? get modifiers;
+  external TSNodeArray<TSEnumMember> get members;
+}
+
+@JS('EnumMember')
+extension type TSEnumMember._(JSObject _) implements TSDeclaration {
+  external TSIdentifier get name;
+  external TSExpression? get initializer;
 }
 
 @JS('NodeArray')

--- a/web_generator/test/integration/interop_gen/enum_expected.dart
+++ b/web_generator/test/integration/interop_gen/enum_expected.dart
@@ -1,0 +1,91 @@
+// ignore_for_file: constant_identifier_names, non_constant_identifier_names
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:js_interop' as _i1;
+
+extension type const Direction._(num _) {
+  static const Direction Up = Direction._(0);
+
+  static const Direction Down = Direction._(1);
+
+  static const Direction Left = Direction._(2);
+
+  static const Direction Right = Direction._(3);
+}
+extension type const ResponseCode._(num _) {
+  static const ResponseCode Success = ResponseCode._(200);
+
+  static const ResponseCode NotFound = ResponseCode._(404);
+
+  static const ResponseCode ServerError = ResponseCode._(500);
+}
+extension type const LogLevel._(String _) {
+  static const LogLevel Info = LogLevel._('INFO');
+
+  static const LogLevel Warn = LogLevel._('WARN');
+
+  static const LogLevel Error = LogLevel._('ERROR');
+
+  static const LogLevel Debug = LogLevel._('DEBUG');
+}
+extension type const HttpMethod._(String _) {
+  static const HttpMethod GET = HttpMethod._('GET');
+
+  static const HttpMethod POST = HttpMethod._('POST');
+
+  static const HttpMethod DELETE = HttpMethod._('DELETE');
+}
+extension type BooleanLike._(_i1.JSAny? _) {
+  static final BooleanLike No = BooleanLike._(0.toJS);
+
+  static final BooleanLike Yes = BooleanLike._('YES'.toJS);
+}
+extension type MathConstants._(_i1.JSNumber _) {
+  static final MathConstants PI = MathConstants._(3.14.toJS);
+
+  static final MathConstants TwoPI = MathConstants._(6.28.toJS);
+
+  external static MathConstants Random;
+
+  external static MathConstants Length;
+}
+extension type const Status._(num _) {
+  static const Status Active = Status._(1);
+
+  static const Status Inactive = Status._(0);
+
+  static const Status Pending = Status._(2);
+}
+@_i1.JS()
+external Status get statusFromName;
+@_i1.JS()
+external void logStatus(Status status);
+@_i1.JS()
+external String handleDirection(Direction dir);
+extension type const HttpStatus._(num _) {
+  static const HttpStatus OK = HttpStatus._(200);
+
+  static const HttpStatus BadRequest = HttpStatus._(400);
+
+  static const HttpStatus Unauthorized = HttpStatus._(401);
+
+  static const HttpStatus Forbidden = HttpStatus._(403);
+}
+@_i1.JS()
+external HttpStatus get statusCode;
+extension type const Permissions._(num _) {
+  static const Permissions Read = Permissions._(1);
+
+  static const Permissions Write = Permissions._(2);
+
+  static const Permissions Execute = Permissions._(4);
+
+  static const Permissions All = Permissions._(7);
+}
+@_i1.JS()
+external bool hasPermission(
+  Permissions perm,
+  Permissions flag,
+);
+@_i1.JS()
+external Permissions get userPermissions;

--- a/web_generator/test/integration/interop_gen/enum_input.d.ts
+++ b/web_generator/test/integration/interop_gen/enum_input.d.ts
@@ -1,0 +1,66 @@
+export declare enum Direction {
+    Up = 0,
+    Down = 1,
+    Left = 2,
+    Right = 3
+}
+export declare enum ResponseCode {
+    Success = 200,
+    NotFound = 404,
+    ServerError = 500
+}
+export declare enum LogLevel {
+    Info = "INFO",
+    Warn = "WARN",
+    Error = "ERROR",
+    Debug = "DEBUG"
+}
+export declare enum HttpMethod {
+  GET = "GET",
+  POST = "POST",
+  DELETE = "DELETE"
+}
+export declare enum BooleanLike {
+    No = 0,
+    Yes = "YES"
+}
+export declare enum MathConstants {
+    PI = 3.14,// constant
+    TwoPI = 6.28,// computed
+    Random,// computed at compile time
+    Length
+}
+export declare enum Status {
+    Active = 1,
+    Inactive = 0,
+    Pending = 2
+}
+declare const nameOfStatus: string;
+export declare const statusFromName: Status;
+export declare function logStatus(status: Status): void;
+export declare function handleDirection(dir: Direction): string;
+export declare const enum HttpStatus {
+    OK = 200,
+    BadRequest = 400,
+    Unauthorized = 401,
+    Forbidden = 403
+}
+export declare const statusCode: HttpStatus;
+declare enum ExternalLibResult {
+    OK = 0,
+    FAIL = 1
+}
+declare enum DuplicateValues {
+    A = 1,
+    B = 2,
+    C = 1
+}
+declare const statusKeys: string[];
+export declare enum Permissions {
+    Read = 1,// 0001
+    Write = 2,// 0010
+    Execute = 4,// 0100
+    All = 7
+}
+export declare function hasPermission(perm: Permissions, flag: Permissions): boolean;
+export declare const userPermissions: Permissions;

--- a/web_generator/test/integration/interop_gen/functions_expected.dart
+++ b/web_generator/test/integration/interop_gen/functions_expected.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: constant_identifier_names, non_constant_identifier_names
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:js_interop' as _i1;
 

--- a/web_generator/test/integration/interop_gen/variables_expected.dart
+++ b/web_generator/test/integration/interop_gen/variables_expected.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: constant_identifier_names, non_constant_identifier_names
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:js_interop' as _i1;
 


### PR DESCRIPTION
Closes #393 

This PR adds support for enumerations in the Dart JS Interop Interface Gen project.
Enums in TS with the `enum` keyword are mapped to (constant) Dart extension types with the values being static properties.
Therefore:
```ts
export declare enum Direction {
  Up = 0,
  Down = 1
}
```
Turns into:
```dart
extension type const Direction._(num _) {
  static const Direction Up = Direction._(0);
  static const Direction Down = Direction._(1);
}
```

This enum pattern is used to represent TS Syntax Kinds in the generator.
Although the vast majority of enums declared with the `enum` keyword are homogenous with defined number or string values:
- If an enum value is computed and does not have a default value, it is declared external (and the rep type becomes a JS-compatible rep type)
- If an enum is heterogenous, then the rep type becomes `JSAny`
- If the rep type of an enum is a JS type, then the enum properties can no longer be constant due to literal conversions.

## TODO (to be considered)
- [ ] Supporting Homogenous Union Types as Enums
  ```ts
  export declare const myVar: "UP" | "DOWN";
  ```