### PR TITLE
[web_generator] Bug Fixes in Entrypoint `gen_interop_bindings.dart`

### DIFF
--- a/web_generator/bin/gen_interop_bindings.dart
+++ b/web_generator/bin/gen_interop_bindings.dart
@@ -62,8 +62,10 @@ $_usage''');
   final outputFile = argResult['output'] as String? ??
       p.join(p.current, inputFile.replaceAll('.d.ts', '.dart'));
   final defaultWebGenConfigPath = p.join(p.current, 'webgen.yaml');
-  final configFile =
-      argResult['config'] as String? ?? (File(defaultWebGenConfigPath).existsSync() ? defaultWebGenConfigPath : null);
+  final configFile = argResult['config'] as String? ??
+      (File(defaultWebGenConfigPath).existsSync()
+          ? defaultWebGenConfigPath
+          : null);
   final relativeOutputPath =
       p.relative(outputFile, from: bindingsGeneratorPath);
   // Run app with `node`.


### PR DESCRIPTION
- removed duplicate `help` option
- added support for no-config when running