### PR TITLE
[web_generator] Add support for passing files as globs

### DIFF
--- a/web_generator/lib/src/_js_supertypes_src.dart
+++ b/web_generator/lib/src/_js_supertypes_src.dart
@@ -1,0 +1,4 @@
+import 'dart:js_interop';
+
+@JS()
+external JSPromise get promise;

--- a/web_generator/lib/src/config.dart
+++ b/web_generator/lib/src/config.dart
@@ -2,10 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:js_interop';
+
 import 'package:dart_style/dart_style.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart';
+
+import 'js/filesystem_api.dart';
 
 class FunctionConfig {
   /// The number of variable arguments
@@ -154,10 +158,13 @@ class YamlConfig implements Config {
       throw TypeError();
     }
 
+    final allFiles = fs.globSync(inputFiles.map((i) => i.toJS).toList().toJS,
+        FSGlobSyncOptions(cwd: p.dirname(filename).toJS));
+
     return YamlConfig._(
         filename: Uri.file(filename),
-        input: inputFiles
-            .map((file) => p.join(p.dirname(filename), file))
+        input: allFiles.toDart
+            .map((file) => p.join(p.dirname(filename), file.toDart))
             .toList(),
         output:
             p.join(p.dirname(filename), (yaml['output'] ?? output) as String),

--- a/web_generator/lib/src/config.dart
+++ b/web_generator/lib/src/config.dart
@@ -158,8 +158,12 @@ class YamlConfig implements Config {
       throw TypeError();
     }
 
-    final allFiles = fs.globSync(inputFiles.map((i) => i.toJS).toList().toJS,
-        FSGlobSyncOptions(cwd: p.dirname(filename).toJS));
+    final allFiles = fs.globSync(
+        inputFiles.map((i) => i.toJS).toList().toJS,
+        FSGlobSyncOptions(
+            cwd: p.dirname(filename).toJS,
+            exclude:
+                excludeFileEntryFunc('.d.ts').toJS as FSGlobSyncExcludeFunc));
 
     return YamlConfig._(
         filename: Uri.file(filename),
@@ -180,4 +184,15 @@ class YamlConfig implements Config {
                 .toList() ??
             []);
   }
+}
+
+/// Creates the `exclude` function for [FSGlobSyncOptions]'s `exclude` option
+/// to exclude all files not ending with the given extension
+///
+/// This helps support passing dir globs.
+bool Function(FSDirent entry) excludeFileEntryFunc(String extension) {
+  return (FSDirent entry) {
+    if (entry.isFile()) return !entry.name.endsWith(extension);
+    return true;
+  };
 }

--- a/web_generator/lib/src/dart_main.dart
+++ b/web_generator/lib/src/dart_main.dart
@@ -146,7 +146,7 @@ Future<void> generateIDLBindings({
             input.map((i) => i.toJS).toList().toJS,
             FSGlobSyncOptions(
                 cwd: p.current.toJS,
-                exclude: excludeFileEntryFunc('.d.ts').toJS
+                exclude: excludeFileEntryFunc('.idl').toJS
                     as FSGlobSyncExcludeFunc))
         .toDart
         .map((i) => i.toDart)

--- a/web_generator/lib/src/dart_main.dart
+++ b/web_generator/lib/src/dart_main.dart
@@ -55,13 +55,11 @@ void main(List<String> args) async {
       );
     } else {
       final allInputFiles = fs.globSync(
-        (argResult['input'] as List<String>)
-          .map((i) => i.toJS)
-          .toList().toJS,
-        FSGlobSyncOptions(
-          cwd: p.current.toJS
-        )
-      );
+          (argResult['input'] as List<String>).map((i) => i.toJS).toList().toJS,
+          FSGlobSyncOptions(
+              cwd: p.current.toJS,
+              exclude:
+                  excludeFileEntryFunc('.d.ts').toJS as FSGlobSyncExcludeFunc));
       config = Config(
         input: allInputFiles.toDart.map((i) => i.toDart).toList(),
         output: argResult['output'] as String,
@@ -143,9 +141,16 @@ Future<void> generateIDLBindings({
       fs.writeFileSync('$output/$libraryPath'.toJS, contents);
     }
   } else {
-    final allInputFiles = fs.globSync(input.map((i) => i.toJS).toList().toJS, 
-      FSGlobSyncOptions(cwd: p.current.toJS)
-    ).toDart.map((i) => i.toDart).toList();
+    final allInputFiles = fs
+        .globSync(
+            input.map((i) => i.toJS).toList().toJS,
+            FSGlobSyncOptions(
+                cwd: p.current.toJS,
+                exclude: excludeFileEntryFunc('.d.ts').toJS
+                    as FSGlobSyncExcludeFunc))
+        .toDart
+        .map((i) => i.toDart)
+        .toList();
     // parse individual files
     ensureDirectoryExists(output);
 

--- a/web_generator/lib/src/dart_main.dart
+++ b/web_generator/lib/src/dart_main.dart
@@ -36,7 +36,7 @@ void main(List<String> args) async {
     await generateIDLBindings(
       input: (argResult['input'] as List<String>).isEmpty
           ? null
-          : argResult['input'] as Iterable<String>,
+          : argResult['input'] as List<String>,
       output: argResult['output'] as String,
       generateAll: argResult['generate-all'] as bool,
       languageVersion: Version.parse(languageVersionString),
@@ -54,8 +54,16 @@ void main(List<String> args) async {
         filename: filename,
       );
     } else {
+      final allInputFiles = fs.globSync(
+        (argResult['input'] as List<String>)
+          .map((i) => i.toJS)
+          .toList().toJS,
+        FSGlobSyncOptions(
+          cwd: p.current.toJS
+        )
+      );
       config = Config(
-        input: argResult['input'] as List<String>,
+        input: allInputFiles.toDart.map((i) => i.toDart).toList(),
         output: argResult['output'] as String,
         languageVersion: Version.parse(languageVersionString),
       );
@@ -135,11 +143,14 @@ Future<void> generateIDLBindings({
       fs.writeFileSync('$output/$libraryPath'.toJS, contents);
     }
   } else {
+    final allInputFiles = fs.globSync(input.map((i) => i.toJS).toList().toJS, 
+      FSGlobSyncOptions(cwd: p.current.toJS)
+    ).toDart.map((i) => i.toDart).toList();
     // parse individual files
     ensureDirectoryExists(output);
 
     final bindings = await generateBindingsForFiles({
-      for (final file in input)
+      for (final file in allInputFiles)
         file: (fs.readFileSync(
                     file.toJS, JSReadFileOptions(encoding: 'utf-8'.toJS))
                 as JSString)

--- a/web_generator/lib/src/js/filesystem_api.dart
+++ b/web_generator/lib/src/js/filesystem_api.dart
@@ -40,4 +40,25 @@ extension type FileSystem._(JSObject _) implements JSObject {
   external JSAny readFileSync(JSString path, [JSReadFileOptions options]);
 
   external void writeFileSync(JSString path, JSString contents);
+
+  external JSArray<JSString> globSync(JSArray<JSString> patterns,
+      [FSGlobSyncOptions? options]);
+}
+
+extension type FSGlobSyncOptions._(JSObject _) implements JSObject {
+  external FSGlobSyncOptions({JSString cwd, FSGlobSyncExcludeFunc? exclude});
+
+  external JSString get cwd;
+  external JSArray<JSString>? get exclude;
+}
+
+extension type FSGlobSyncExcludeFunc._(JSObject _) implements JSObject {
+  external bool call(FSDirent entry);
+}
+
+extension type FSDirent._(JSObject _) implements JSObject {
+  external String name;
+  external String parentPath;
+  external bool isFile();
+  external bool isDirectory();
 }

--- a/web_generator/test/assets/config.yaml
+++ b/web_generator/test/assets/config.yaml
@@ -4,7 +4,7 @@ preamble: |
   // GENERATED FILE: DO NOT EDIT
   // 
   // Created by `web_generator`
-input: test.d.ts
+input: '*.d.ts'
 output: '../../.dart_tool/test_config.dart'
 include:
   - APP_NAME


### PR DESCRIPTION
This PR adds support to passing files as globs for both the IDL generator and the TS Declarations generator via Node's [`fs.globSync`](https://nodejs.org/api/fs.html#fsglobsyncpattern-options) function. 