### PR TITLE
[interop] Add Support for `keyof` and `readonly` type operators

### DIFF
--- a/web_generator/lib/src/ast/types.dart
+++ b/web_generator/lib/src/ast/types.dart
@@ -283,6 +283,18 @@ class ObjectLiteralType extends DeclarationType<TypeDeclaration> {
   @override
   final ID id;
 
+  bool readonly = false;
+
+  String? _dartName;
+
+  @override
+  String? get dartName => _dartName;
+
+  @override
+  set dartName(String? value) {
+    _dartName = value;
+  }
+
   ObjectLiteralType(
       {required String name,
       required this.id,
@@ -290,12 +302,15 @@ class ObjectLiteralType extends DeclarationType<TypeDeclaration> {
       this.methods = const [],
       this.constructors = const [],
       this.operators = const [],
-      this.isNullable = false})
-      : declarationName = name;
+      this.isNullable = false,
+      String? declarationDartName})
+      : declarationName = name,
+        _dartName = declarationDartName;
 
   @override
   TypeDeclaration get declaration => InterfaceDeclaration(
       name: declarationName,
+      dartName: dartName,
       exported: true,
       id: ID(type: 'interface', name: id.name),
       objectLiteralConstructor: true,
@@ -314,6 +329,45 @@ class ObjectLiteralType extends DeclarationType<TypeDeclaration> {
       ..symbol = declarationName
       ..isNullable = options?.nullable ?? isNullable
       ..types.addAll(getGenericTypes(this).map((t) => t.emit(options))));
+  }
+}
+
+/// An object representation of a typescript enum, usually used
+/// either from a `typeof` expression, or a direct assignment.
+class EnumObjectType extends DeclarationType {
+  final EnumDeclaration enumeration;
+
+  String? _dartName;
+
+  @override
+  String? get dartName => _dartName;
+
+  @override
+  set dartName(String? value) {
+    _dartName = value;
+  }
+
+  @override
+  bool isNullable;
+
+  EnumObjectType(this.enumeration, {String? dartName, this.isNullable = false})
+      : _dartName = dartName ?? enumeration.dartName;
+
+  @override
+  ID get id => ID(type: 'type', name: '${enumeration.name}_EnumType');
+
+  @override
+  Declaration get declaration => _EnumObjDeclaration(
+      name: declarationName, dartName: dartName, reference: enumeration);
+
+  @override
+  String get declarationName => '${enumeration.name}_EnumType';
+
+  @override
+  Reference emit([covariant TypeOptions? options]) {
+    return TypeReference((t) => t
+      ..symbol = declarationName
+      ..isNullable = options?.nullable ?? isNullable);
   }
 }
 
@@ -599,4 +653,57 @@ class _UnionDeclaration extends NamedDeclaration
         });
       })));
   }
+}
+
+class _EnumObjDeclaration extends NamedDeclaration
+    implements ExportableDeclaration {
+  @override
+  bool get exported => true;
+
+  @override
+  String? dartName;
+
+  @override
+  String name;
+
+  EnumDeclaration reference;
+
+  _EnumObjDeclaration(
+      {required this.name, this.dartName, required this.reference});
+
+  @override
+  Spec emit([covariant DeclarationOptions? options]) {
+    final repType = BuiltinType.primitiveType(PrimitiveType.object);
+    return ExtensionType((e) => e
+      ..name = dartName ?? name
+      ..annotations.addAll([
+        if (dartName != null && dartName != name) generateJSAnnotation(name)
+      ])
+      ..primaryConstructorName = '_'
+      ..representationDeclaration = RepresentationDeclaration((r) => r
+        ..declaredRepresentationType = repType.emit(options?.toTypeOptions())
+        ..name = '_')
+      ..implements.add(repType.emit(options?.toTypeOptions()))
+      ..fields.addAll(reference.members.map((mem) => mem.emit()))
+      ..methods.addAll(reference.members.map((mem) {
+        return mem.value == null
+            ? null
+            : Method((m) => m
+              ..name =
+                  mem.value is int ? '\$${mem.value}' : mem.value.toString()
+              ..annotations.addAll([
+                if (mem.value is int)
+                  refer('JS', 'dart:js_interop')
+                      .call([literalString(mem.value.toString())])
+              ])
+              ..type = MethodType.getter
+              ..returns = refer('String')
+              ..lambda = true
+              ..static = true
+              ..body = literalString(mem.name).code);
+      }).nonNulls));
+  }
+
+  @override
+  ID get id => ID(type: 'enum-rep', name: name);
 }

--- a/web_generator/lib/src/js/typescript.types.dart
+++ b/web_generator/lib/src/js/typescript.types.dart
@@ -61,13 +61,15 @@ extension type const TSSyntaxKind._(num _) {
   static const TSSyntaxKind WithKeyword = TSSyntaxKind._(118);
   static const TSSyntaxKind AssertKeyword = TSSyntaxKind._(132);
   static const TSSyntaxKind AbstractKeyword = TSSyntaxKind._(128);
+  static const TSSyntaxKind KeyOfKeyword = TSSyntaxKind._(143);
+  static const TSSyntaxKind UniqueKeyword = TSSyntaxKind._(158);
+  static const TSSyntaxKind ReadonlyKeyword = TSSyntaxKind._(148);
 
   // keywords for scope
   static const TSSyntaxKind PrivateKeyword = TSSyntaxKind._(123);
   static const TSSyntaxKind ProtectedKeyword = TSSyntaxKind._(124);
   static const TSSyntaxKind PublicKeyword = TSSyntaxKind._(125);
   static const TSSyntaxKind StaticKeyword = TSSyntaxKind._(126);
-  static const TSSyntaxKind ReadonlyKeyword = TSSyntaxKind._(148);
 
   // types that are keywords
   static const TSSyntaxKind StringKeyword = TSSyntaxKind._(154);
@@ -95,6 +97,7 @@ extension type const TSSyntaxKind._(num _) {
   static const TSSyntaxKind TypeLiteral = TSSyntaxKind._(187);
   static const TSSyntaxKind FunctionType = TSSyntaxKind._(184);
   static const TSSyntaxKind ConstructorType = TSSyntaxKind._(185);
+  static const TSSyntaxKind TypeOperator = TSSyntaxKind._(198);
 
   // Other
   static const TSSyntaxKind Identifier = TSSyntaxKind._(80);
@@ -207,6 +210,12 @@ extension type TSNamedTupleMember._(JSObject _)
 extension type TSTypeLiteralNode._(JSObject _)
     implements TSTypeNode, TSDeclaration {
   external TSNodeArray<TSTypeElement> get members;
+}
+
+@JS('TypeOperatorNode')
+extension type TSTypeOperatorNode._(JSObject _) implements TSTypeNode {
+  external TSSyntaxKind operator;
+  external TSTypeNode type;
 }
 
 @JS('FunctionOrConstructorTypeNodeBase')

--- a/web_generator/test/integration/interop_gen/ts_typing_expected.dart
+++ b/web_generator/test/integration/interop_gen/ts_typing_expected.dart
@@ -33,13 +33,21 @@ extension type const MyEnum._(int _) {
 
   static const MyEnum D = MyEnum._(4);
 }
+@_i1.JS()
+external MyEnum_EnumType get myEnumKeys;
+@_i1.JS()
+external AnonymousUnion_3852877 userKeys;
+@_i1.JS()
+external AnonymousUnion_7177924 alphabeticLetter;
+@_i1.JS()
+external MyEnum_EnumType get myEnumType;
 typedef Transformer<T extends _i1.JSAny?> = _AnonymousFunction_5293571<T>;
 @_i1.JS()
 external _i1.JSFunction copyOfmyEnclosingFunction;
 @_i1.JS()
 external MyEnum get myEnumValue;
 @_i1.JS()
-external MyEnum get myEnumValue2;
+external MyEnum_EnumType get myEnumValue2;
 @_i1.JS()
 external _i1.JSFunction myFunctionAlias;
 @_i1.JS()
@@ -62,6 +70,8 @@ external bool? get booleanOrUndefined;
 external AnonymousUnion_6216705? get image;
 @_i1.JS()
 external _i2.JSTuple2<_i1.JSString, _i1.JSNumber> get myTuple;
+@_i1.JS()
+external _i2.JSTuple2<_i1.JSString, _i1.JSNumber> get myReadonlyTuple;
 @_i1.JS()
 external _i2.JSTuple2<_i1.JSString, _i1.JSString> get mySecondTuple;
 @_i1.JS()
@@ -112,6 +122,48 @@ extension type AnonymousType_9143117<T extends _i1.JSAny?>._(_i1.JSObject _)
   external double id;
 
   external T value;
+}
+extension type MyEnum_EnumType._(_i1.JSObject _) implements _i1.JSObject {
+  static const MyEnum A = MyEnum._(0);
+
+  static const MyEnum B = MyEnum._(1);
+
+  static const MyEnum C = MyEnum._(2);
+
+  static const MyEnum D = MyEnum._(4);
+
+  @_i1.JS('0')
+  static String get $0 => 'A';
+
+  @_i1.JS('1')
+  static String get $1 => 'B';
+
+  @_i1.JS('2')
+  static String get $2 => 'C';
+
+  @_i1.JS('4')
+  static String get $4 => 'D';
+}
+extension type const AnonymousUnion_3852877._(String _) {
+  static const AnonymousUnion_3852877 name = AnonymousUnion_3852877._('name');
+
+  static const AnonymousUnion_3852877 key = AnonymousUnion_3852877._('key');
+
+  static const AnonymousUnion_3852877 id = AnonymousUnion_3852877._('id');
+
+  static const AnonymousUnion_3852877 birthTimestamp =
+      AnonymousUnion_3852877._('birthTimestamp');
+
+  static const AnonymousUnion_3852877 email = AnonymousUnion_3852877._('email');
+}
+extension type const AnonymousUnion_7177924._(String _) {
+  static const AnonymousUnion_7177924 A = AnonymousUnion_7177924._('A');
+
+  static const AnonymousUnion_7177924 B = AnonymousUnion_7177924._('B');
+
+  static const AnonymousUnion_7177924 C = AnonymousUnion_7177924._('C');
+
+  static const AnonymousUnion_7177924 D = AnonymousUnion_7177924._('D');
 }
 extension type _AnonymousFunction_5293571<T extends _i1.JSAny?>._(
     _i1.JSFunction _) implements _i1.JSFunction {

--- a/web_generator/test/integration/interop_gen/ts_typing_input.d.ts
+++ b/web_generator/test/integration/interop_gen/ts_typing_input.d.ts
@@ -8,9 +8,20 @@ export declare enum MyEnum {
     C = 2,
     D = 4
 }
+export declare const myEnumKeys: typeof MyEnum;
 interface ComposedType<T = any> {
     enclosed: T;
 }
+interface User {
+    name: string;
+    key: string;
+    id: string;
+    birthTimestamp: number;
+    email: string
+}
+export declare let userKeys: keyof User;
+export declare let alphabeticLetter: keyof typeof MyEnum;
+export declare const myEnumType: typeof MyEnum;
 export type Transformer<T> = (object: T) => ComposedType<T>;
 export declare let copyOfmyEnclosingFunction: typeof myEnclosingFunction;
 export declare const myEnumValue: MyEnum;
@@ -29,6 +40,7 @@ export declare const mySecondUnion: number | string | MyEnum | ComposedType;
 export declare const booleanOrUndefined: boolean | undefined;
 export declare const image: string | URL | null;
 export declare const myTuple: [string, number];
+export declare const myReadonlyTuple: readonly [string, number];
 export declare const mySecondTuple: [string, string];
 export declare const myCloneTuple: [string, string];
 export declare const typesAsTuple: [string, number, boolean, symbol];


### PR DESCRIPTION
This PR adds support for type operators used on various TS types, including
- `readonly` (supported for Tuples)
- `keyof` (supported on enums, interfaces, object literals)
- `unique` (dormant, not supported on Dart end)

Equivalent dart declarations are generated for them
