### PR TITLE
fix: clarify documentation for Blob type property to specify MIME type

### DIFF
--- a/web/lib/src/dom/fileapi.dart
+++ b/web/lib/src/dom/fileapi.dart
@@ -76,8 +76,8 @@ extension type Blob._(JSObject _) implements JSObject {
   /// the size of the [Blob] or [File] in bytes.
   external int get size;
 
-  /// The **`type`** read-only property of the [Blob] interface returns the  of
-  /// the file.
+  /// The **`type`** read-only property of the [Blob] interface returns the MIME
+  /// type of the file.
   ///
   /// > [!NOTE]
   /// > Based on the current implementation, browsers won't actually read the


### PR DESCRIPTION
- Fix incomplete documentation for Blob 'type' property

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
