### PR TITLE
[interop] Add support for Conditional and Predicate Types

### DIFF
--- a/web_generator/lib/src/ast/helpers.dart
+++ b/web_generator/lib/src/ast/helpers.dart
@@ -259,6 +259,8 @@ Type desugarTypeAliases(Type t) {
   if (t case final ReferredType ref
       when ref.declaration is TypeAliasDeclaration) {
     return desugarTypeAliases((ref.declaration as TypeAliasDeclaration).type);
+  } else if (t case ReferredDeclarationType(type: final actualType)) {
+    return desugarTypeAliases(actualType);
   }
   return t;
 }

--- a/web_generator/lib/src/js/typescript.types.dart
+++ b/web_generator/lib/src/js/typescript.types.dart
@@ -100,6 +100,8 @@ extension type const TSSyntaxKind._(num _) {
   static const TSSyntaxKind FunctionType = TSSyntaxKind._(184);
   static const TSSyntaxKind ConstructorType = TSSyntaxKind._(185);
   static const TSSyntaxKind TypeOperator = TSSyntaxKind._(198);
+  static const TSSyntaxKind TypePredicate = TSSyntaxKind._(182);
+  static const TSSyntaxKind ConditionalType = TSSyntaxKind._(194);
 
   // Other
   static const TSSyntaxKind Identifier = TSSyntaxKind._(80);
@@ -200,6 +202,24 @@ extension type TSParenthesizedTypeNode._(JSObject _) implements TSTypeNode {
   @redeclare
   TSSyntaxKind get kind => TSSyntaxKind.ParenthesizedType;
   external TSTypeNode get type;
+}
+
+@JS('TypePredicateNode')
+extension type TSTypePredicateNode._(JSObject _) implements TSTypeNode {
+  @redeclare
+  TSSyntaxKind get kind => TSSyntaxKind.TypePredicate;
+  external TSIdentifier get parameterName;
+  external TSTypeNode? get type;
+}
+
+@JS('ConditionalTypeNode')
+extension type TSConditionalTypeNode._(JSObject _) implements TSTypeNode {
+  @redeclare
+  TSSyntaxKind get kind => TSSyntaxKind.ConditionalType;
+  external TSTypeNode get checkType;
+  external TSTypeNode get extendsType;
+  external TSTypeNode get trueType;
+  external TSTypeNode get falseType;
 }
 
 @JS('TupleTypeNode')

--- a/web_generator/test/integration/interop_gen/ts_typing_expected.dart
+++ b/web_generator/test/integration/interop_gen/ts_typing_expected.dart
@@ -15,6 +15,15 @@ external String myFunction(String param);
 @_i1.JS()
 external String myEnclosingFunction(_i1.JSFunction func);
 @_i1.JS()
+external bool objectIsProduct(_i1.JSObject obj);
+@_i1.JS()
+external AnonymousType_2194029 get randomNonTypedProduct;
+@_i1.JS()
+external ProductOrrandomNonTypedProduct objectAsProduct(
+  _i1.JSObject obj,
+  bool structured,
+);
+@_i1.JS()
 external _i1.JSArray<AnonymousType_9143117<T>>
     indexedArray<T extends _i1.JSAny?>(_i1.JSArray<T> arr);
 @_i1.JS()
@@ -84,8 +93,6 @@ external _i2.JSTuple4<_i1.JSString, _i1.JSNumber, _i1.JSBoolean, _i1.JSSymbol>
 @_i1.JS()
 external AnonymousUnion_7503220 get eightOrSixteen;
 @_i1.JS()
-external AnonymousType_2194029 get randomNonTypedProduct;
-@_i1.JS()
 external AnonymousType_1358595 get config;
 extension type MyProduct._(_i1.JSObject _) implements Product {
   external MyProduct(
@@ -125,6 +132,26 @@ external _i1.JSAny? get someIntersection;
 external AnonymousIntersection_4895242 get myThirdIntersection;
 @_i1.JS()
 external AnonymousIntersection_1711585 get myTypeGymnastic;
+extension type AnonymousType_2194029._(_i1.JSObject _) implements _i1.JSObject {
+  external AnonymousType_2194029({
+    double id,
+    String name,
+    double price,
+  });
+
+  external double id;
+
+  external String name;
+
+  external double price;
+}
+typedef Product = AnonymousType_2194029;
+extension type ProductOrrandomNonTypedProduct._(AnonymousType_2194029 _)
+    implements AnonymousType_2194029 {
+  Product get asProduct => _;
+
+  AnonymousType_2194029 get asRandomNonTypedProduct => _;
+}
 extension type AnonymousType_9143117<T extends _i1.JSAny?>._(_i1.JSObject _)
     implements _i1.JSObject {
   external AnonymousType_9143117({
@@ -210,19 +237,6 @@ extension type AnonymousUnion_7503220._(_i1.JSTypedArray _)
 
   _i1.JSUint16Array get asJSUint16Array => (_ as _i1.JSUint16Array);
 }
-extension type AnonymousType_2194029._(_i1.JSObject _) implements _i1.JSObject {
-  external AnonymousType_2194029({
-    double id,
-    String name,
-    double price,
-  });
-
-  external double id;
-
-  external String name;
-
-  external double price;
-}
 extension type AnonymousType_1358595._(_i1.JSObject _) implements _i1.JSObject {
   external AnonymousType_1358595({
     double discountRate,
@@ -233,7 +247,6 @@ extension type AnonymousType_1358595._(_i1.JSObject _) implements _i1.JSObject {
 
   external double taxRate;
 }
-typedef Product = AnonymousType_2194029;
 extension type AnonymousType_2773310._(_i1.JSObject _) implements _i1.JSObject {
   external AnonymousType_2773310({
     String id,

--- a/web_generator/test/integration/interop_gen/ts_typing_input.d.ts
+++ b/web_generator/test/integration/interop_gen/ts_typing_input.d.ts
@@ -29,7 +29,6 @@ export declare const myEnumValue2: typeof MyEnum;
 export declare function myFunction(param: string): string;
 export declare let myFunctionAlias: typeof myFunction;
 export declare let myFunctionAlias2: typeof myFunctionAlias;
-// export declare let myPreClone: typeof myComposedType;
 export declare function myEnclosingFunction(func: typeof myFunction): string;
 export declare const myEnclosingFunctionAlias: typeof myEnclosingFunction;
 export declare const myComposedType: ComposedType;
@@ -65,7 +64,9 @@ export declare class MyProduct implements Product {
     price: number;
     constructor(id: number, name: string, price: number);
 }
-export function indexedArray<T>(arr: T[]): { id: number, value: T }[];
+export declare function objectIsProduct(obj: object): obj is Product;
+export declare function objectAsProduct(obj: object, structured: boolean): (typeof structured) extends true ? Product : typeof randomNonTypedProduct;
+export declare function indexedArray<T>(arr: T[]): { id: number, value: T }[];
 export const responseObject: {
     id: string;
     value: any;


### PR DESCRIPTION
Fixes #464 
Fixes #463

This PR adds support for transforming conditional types (`t extends a ? b : c`) and predicate types (`t is a`), and generates Dart alternatives to these types.

Predicate types are converted to booleans, while conditional types are converted to unions, since the result can either be one or the other. There currently isn't a way (afaik) to introspect into parameter values to give a specific result depending on the parameter result.

We could be smart, however, and wrap such methods with other methods to do the casting for us in the case of conditional types, and could _try_ to do similar in predicate types (via `assert` checks and more).

