### PR TITLE
fix(web_generator): resolve infinite recursion for self-referential class types

### DIFF
--- a/web_generator/lib/src/interop_gen/transform/transformer.dart
+++ b/web_generator/lib/src/interop_gen/transform/transformer.dart
@@ -59,6 +59,10 @@ class Transformer {
   /// A map of declarations
   final NodeMap<Declaration> nodeMap = NodeMap();
 
+  /// Declarations currently being transformed, used to prevent infinite
+  /// recursion when a member's type references the class being built.
+  final Map<TSNode, TypeDeclaration> _pendingTypes = {};
+
   /// A map of types
   final TypeMap typeMap = TypeMap();
 
@@ -499,84 +503,90 @@ class Transformer {
             documentation: _parseAndTransformDocumentation(typeDecl),
           );
 
-    final typeNamer = ScopedUniqueNamer({'get', 'set'});
+    _pendingTypes[typeDecl] = outputType;
+    try {
+      final typeNamer = ScopedUniqueNamer({'get', 'set'});
 
-    for (final member in typeDecl.members.toDart) {
-      switch (member.kind) {
-        case TSSyntaxKind.PropertySignature || TSSyntaxKind.PropertyDeclaration:
-          final prop = _transformProperty(
-            member as TSPropertyEntity,
-            parentNamer: typeNamer,
-            parent: outputType,
-          );
-          if (prop != null) outputType.properties.add(prop);
-          break;
-        // TODO: Support methods with computed and string property names
-        //  (e.g) [Symbol.iterator], "foo-bar"
-        case TSSyntaxKind.MethodSignature || TSSyntaxKind.MethodDeclaration
-            when (member as TSMethodEntity).name.kind ==
-                TSSyntaxKind.Identifier:
-          final method = _transformMethod(
-            member,
-            parentNamer: typeNamer,
-            parent: outputType,
-          );
-          outputType.methods.add(method);
-          break;
-        case TSSyntaxKind.IndexSignature:
-          final (opGet, opSetOrNull) = _transformIndexer(
-            member as TSIndexSignatureDeclaration,
-            parent: outputType,
-          );
-          outputType.operators.add(opGet);
-          if (opSetOrNull case final opSet?) {
-            outputType.operators.add(opSet);
-          }
-          break;
-        case TSSyntaxKind.CallSignature:
-          final callSignature = _transformCallSignature(
-            member as TSCallSignatureDeclaration,
-            parentNamer: typeNamer,
-            parent: outputType,
-          );
-          outputType.methods.add(callSignature);
-          break;
-        case TSSyntaxKind.ConstructSignature:
-          final constructor = _transformConstructor(
-            member as TSConstructSignatureDeclaration,
-            parentNamer: typeNamer,
-          );
-          constructor.parent = outputType;
-          outputType.constructors.add(constructor);
-          break;
-        case TSSyntaxKind.Constructor:
-          final constructor = _transformConstructor(
-            member as TSConstructorDeclaration,
-            parentNamer: typeNamer,
-          );
-          constructor.parent = outputType;
-          outputType.constructors.add(constructor);
-          break;
-        case TSSyntaxKind.GetAccessor:
-          final getter = _transformGetter(
-            member as TSGetAccessorDeclaration,
-            parentNamer: typeNamer,
-            parent: outputType,
-          );
-          outputType.methods.add(getter);
-          break;
-        case TSSyntaxKind.SetAccessor:
-          final setter = _transformSetter(
-            member as TSSetAccessorDeclaration,
-            parentNamer: typeNamer,
-            parent: outputType,
-          );
-          outputType.methods.add(setter);
-          break;
-        default:
-          // skipping
-          break;
+      for (final member in typeDecl.members.toDart) {
+        switch (member.kind) {
+          case TSSyntaxKind.PropertySignature ||
+              TSSyntaxKind.PropertyDeclaration:
+            final prop = _transformProperty(
+              member as TSPropertyEntity,
+              parentNamer: typeNamer,
+              parent: outputType,
+            );
+            if (prop != null) outputType.properties.add(prop);
+            break;
+          // TODO: Support methods with computed and string property names
+          //  (e.g) [Symbol.iterator], "foo-bar"
+          case TSSyntaxKind.MethodSignature || TSSyntaxKind.MethodDeclaration
+              when (member as TSMethodEntity).name.kind ==
+                  TSSyntaxKind.Identifier:
+            final method = _transformMethod(
+              member,
+              parentNamer: typeNamer,
+              parent: outputType,
+            );
+            outputType.methods.add(method);
+            break;
+          case TSSyntaxKind.IndexSignature:
+            final (opGet, opSetOrNull) = _transformIndexer(
+              member as TSIndexSignatureDeclaration,
+              parent: outputType,
+            );
+            outputType.operators.add(opGet);
+            if (opSetOrNull case final opSet?) {
+              outputType.operators.add(opSet);
+            }
+            break;
+          case TSSyntaxKind.CallSignature:
+            final callSignature = _transformCallSignature(
+              member as TSCallSignatureDeclaration,
+              parentNamer: typeNamer,
+              parent: outputType,
+            );
+            outputType.methods.add(callSignature);
+            break;
+          case TSSyntaxKind.ConstructSignature:
+            final constructor = _transformConstructor(
+              member as TSConstructSignatureDeclaration,
+              parentNamer: typeNamer,
+            );
+            constructor.parent = outputType;
+            outputType.constructors.add(constructor);
+            break;
+          case TSSyntaxKind.Constructor:
+            final constructor = _transformConstructor(
+              member as TSConstructorDeclaration,
+              parentNamer: typeNamer,
+            );
+            constructor.parent = outputType;
+            outputType.constructors.add(constructor);
+            break;
+          case TSSyntaxKind.GetAccessor:
+            final getter = _transformGetter(
+              member as TSGetAccessorDeclaration,
+              parentNamer: typeNamer,
+              parent: outputType,
+            );
+            outputType.methods.add(getter);
+            break;
+          case TSSyntaxKind.SetAccessor:
+            final setter = _transformSetter(
+              member as TSSetAccessorDeclaration,
+              parentNamer: typeNamer,
+              parent: outputType,
+            );
+            outputType.methods.add(setter);
+            break;
+          default:
+            // skipping
+            break;
+        }
       }
+    } finally {
+      _pendingTypes.remove(typeDecl);
     }
 
     return outputType;
@@ -2241,6 +2251,13 @@ class Transformer {
           );
         }
 
+        // If this declaration is currently being transformed, use the
+        // in-progress instance to break the recursion cycle.
+        if (_pendingTypes[declaration] case final pending?) {
+          declarationsMatching = [pending];
+          break;
+        }
+
         var d = declaration as TSNamedDeclaration;
 
         while (d.name?.text != firstName &&
@@ -2278,16 +2295,18 @@ class Transformer {
         }
       }
 
-      map = parent != null
-          ? NodeMap(
-              [
-                ...parent.nestableDeclarations,
-                ...parent.namespaceDeclarations,
-              ].asMap().map((_, v) => MapEntry(v.id.toString(), v)),
-            )
-          : nodeMap;
+      if (declarationsMatching.isEmpty) {
+        map = parent != null
+            ? NodeMap(
+                [
+                  ...parent.nestableDeclarations,
+                  ...parent.namespaceDeclarations,
+                ].asMap().map((_, v) => MapEntry(v.id.toString(), v)),
+              )
+            : nodeMap;
 
-      declarationsMatching = map.findByName(firstName);
+        declarationsMatching = map.findByName(firstName);
+      }
     }
 
     // get node finally

--- a/web_generator/test/integration/interop_gen/self_referential_expected.dart
+++ b/web_generator/test/integration/interop_gen/self_referential_expected.dart
@@ -1,0 +1,70 @@
+// ignore_for_file: camel_case_types, constant_identifier_names
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names, unnecessary_parenthesis
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:js_interop' as _i1;
+
+extension type Configuration._(_i1.JSObject _) implements _i1.JSObject {
+  external Configuration();
+
+  external String get version;
+  external static _i1.JSPromise<Configuration> load(String path);
+  external _i1.JSPromise<_i1.JSAny?> save();
+}
+extension type Shape2D._(_i1.JSObject _) implements _i1.JSObject {
+  external Shape2D();
+
+  external double get area;
+  external _i1.JSPromise<Shape2D> clone();
+}
+extension type Product._(_i1.JSObject _) implements _i1.JSObject {
+  external Product();
+
+  external _i1.JSPromise<User> getOwner();
+}
+extension type User._(_i1.JSObject _) implements _i1.JSObject {
+  external User();
+
+  external _i1.JSPromise<_i1.JSArray<Product>> getProducts();
+}
+extension type Data._(_i1.JSObject _) implements _i1.JSObject {
+  @_i1.JS('Data.Repository')
+  static Data_Repository Repository() => Data_Repository();
+}
+extension type Node<T extends _i1.JSAny?>._(_i1.JSObject _)
+    implements _i1.JSObject {
+  external Node();
+
+  external T get value;
+  external _i1.JSPromise<_i1.JSArray<Node<T>>> children();
+}
+extension type LogEntry._(_i1.JSObject _) implements _i1.JSObject {
+  external LogEntry();
+
+  external String get message;
+  external LogEntry? get previous;
+}
+extension type Point2D._(_i1.JSObject _) implements _i1.JSObject {
+  external Point2D(Point2D source);
+
+  external double get x;
+  external double get y;
+}
+extension type EventEmitter._(_i1.JSObject _) implements _i1.JSObject {
+  external EventEmitter();
+
+  @_i1.JS('on')
+  external void on$(_AnonymousFunction_1729828 handler);
+}
+@_i1.JS('Data.Repository')
+extension type Data_Repository._(_i1.JSObject _) implements _i1.JSObject {
+  external Data_Repository();
+
+  external static _i1.JSPromise<Data_Repository> connect(String url);
+  external _i1.JSPromise<Data_Repository> reconnect();
+}
+extension type _AnonymousFunction_1729828._(_i1.JSFunction _)
+    implements _i1.JSFunction {
+  external void call(EventEmitter emitter);
+}

--- a/web_generator/test/integration/interop_gen/self_referential_input.d.ts
+++ b/web_generator/test/integration/interop_gen/self_referential_input.d.ts
@@ -1,0 +1,53 @@
+// Case 1: Static factory returning Promise<Self>
+export declare class Configuration {
+  readonly version: string;
+  static load(path: string): Promise<Configuration>;
+  save(): Promise<void>;
+}
+
+// Case 2: Instance method returning Promise<Self>
+export declare class Shape2D {
+  clone(): Promise<Shape2D>;
+  readonly area: number;
+}
+
+// Case 3: Mutual references via Promise
+export declare class User {
+  getProducts(): Promise<Product[]>;
+}
+
+export declare class Product {
+  getOwner(): Promise<User>;
+}
+
+// Case 4: Self-referential in namespace
+export declare namespace Data {
+  class Repository {
+    static connect(url: string): Promise<Repository>;
+    reconnect(): Promise<Repository>;
+  }
+}
+
+// Case 5: Generic class with self-referential type argument
+export declare class Node<T> {
+  readonly value: T;
+  children(): Promise<Node<T>[]>;
+}
+
+// Case 6: Property typed as the class itself
+export declare class LogEntry {
+  readonly message: string;
+  readonly previous: LogEntry | undefined;
+}
+
+// Case 7: Constructor parameter typed as the class
+export declare class Point2D {
+  constructor(source: Point2D);
+  readonly x: number;
+  readonly y: number;
+}
+
+// Case 8: Callback parameter containing the class type
+export declare class EventEmitter {
+  on(handler: (emitter: EventEmitter) => void): void;
+}


### PR DESCRIPTION
## Summary

Fixes a stack overflow in `web_generator`'s interop_gen transformer when a class member's return type references the class being transformed (e.g. `static open(): Promise<Database>` inside `Database`).

## Problem

When transforming a class, `_transformClassOrInterface` builds the declaration object and then iterates over members. When it encounters `Promise<Database>`, the type resolver calls `_searchForDeclRecursive("Database")`, which looks in `nodeMap`. The class hasn't been registered yet (that happens after `transformAndReturn` completes), so the lookup fails and triggers a new `transformAndReturn(Database)` call, causing infinite recursion.

## Reproducing the issue

1. Create a file `input.d.ts`:
```typescript
export declare class Database {
  readonly name: string;
  static open(name: string): Promise<Database>;
  close(): void;
}
```

2. Run the generator:
```shell
dart bin/gen_interop_bindings.dart dts input.d.ts -o output.dart
```

3. Observe the stack overflow:
```
RangeError: Maximum call stack size exceeded
    at _SymbolTrackerImpl.trackSymbol (typescript.js:94992)
    at lookupSymbolChain (typescript.js:57448)
    ...
```

Removing the `Promise<Database>` return type (or replacing it with `Promise<void>`) makes the crash go away, confirming the self-referential type is the trigger.

## Solution

Uses an in-progress guard map (`_pendingTypes`).

- `_transformClassOrInterface` registers the declaration as pending before processing members and removes it after via `try/finally`
- `_searchForDeclRecursive` checks `_pendingTypes` before calling `transformAndReturn`. If found, it uses the in-progress instance to break the cycle
- The post-loop re-lookup is guarded so it doesn't overwrite a pending match

This approach:
- Avoids duplicating scope registration logic (no changes to `_transformNamespace` or `_searchForDeclRecursive`'s existing registration paths)
- Does not pollute the global `nodeMap` with nested declarations
- Works identically for top-level and namespace-nested classes

## Test plan

- [x] All 75 existing tests pass
- [x] Add additional self referencing tests