### PR TITLE
feat: generate descriptive documentation for union typedefs

### DIFF
--- a/js_interop_gen/lib/src/translator.dart
+++ b/js_interop_gen/lib/src/translator.dart
@@ -19,16 +19,6 @@ import 'type_aliases.dart';
 import 'type_union.dart';
 import 'util.dart';
 
-final Map<String, Set<String>> _superToSubtypes = () {
-  final map = <String, Set<String>>{};
-  jsTypeSupertypes.forEach((subtype, supertype) {
-    if (supertype != null) {
-      map.putIfAbsent(supertype, () => {}).add(subtype);
-    }
-  });
-  return map;
-}();
-
 typedef TranslationResult = Map<String, code.Library>;
 
 class _Library {
@@ -761,8 +751,6 @@ class Translator {
   /// Singleton so that various helper methods can access info about the AST.
   static Translator? instance;
 
-  static const _unionDocListThreshold = 4;
-
   Translator(
     this._librarySubDir,
     this._cssStyleDeclarations,
@@ -941,16 +929,25 @@ class Translator {
     }
 
     final typeNames = types.map(_getTypeNameRaw).toList();
-    final collapsedNames = _collapseTypes(typeNames);
+    final uniqueNames = typeNames.toSet().toList();
 
-    final formattedNames = collapsedNames.map((name) {
+    if (uniqueNames.length <= 1) return [];
+
+    final formattedNames = uniqueNames.map((name) {
       final decl = _typeToDeclaration[name];
       if (decl != null && _usedTypes.contains(decl)) {
         return '[$name]';
       }
-      // If it's a generic type (contains <), wrap in ticks to avoid HTML.
+      // If it's a generic type (contains <), use fancy formatting.
       if (name.contains('<')) {
-        return '`$name`';
+        final parts = name.split('<');
+        final base = parts[0];
+        final generic = parts[1].replaceAll('>', '');
+        final genericParts = generic.split(',').map((s) => s.trim());
+        final linkedGenericParts = genericParts
+            .map((part) => '[$part]')
+            .join(', ');
+        return '<code>[$base]\\<$linkedGenericParts\\></code>';
       }
       // Link if it's a mapped primitive or a valid JS interop type from
       // supertypes map.
@@ -961,16 +958,10 @@ class Translator {
       return '`$name`';
     }).toList();
 
-    // Sort: alphabetical, but ticked ones last!
-    formattedNames.sort((a, b) {
-      final aIsTicked = a.startsWith('`');
-      final bIsTicked = b.startsWith('`');
-      if (aIsTicked && !bIsTicked) return 1;
-      if (!aIsTicked && bIsTicked) return -1;
-      return a.compareTo(b);
-    });
+    formattedNames.sort();
 
-    if (formattedNames.length >= _unionDocListThreshold) {
+    final singleLine = '/// Union of: ${formattedNames.join(', ')}';
+    if (singleLine.length > 80) {
       return [
         '/// Union of ${formattedNames.length} types',
         '///',
@@ -978,26 +969,7 @@ class Translator {
       ];
     }
 
-    return ['/// Union of: ${formattedNames.join(', ')}'];
-  }
-
-  List<String> _collapseTypes(List<String> types) {
-    final currentTypes = types.toSet();
-    var changed = true;
-    while (changed) {
-      changed = false;
-      for (final entry in _superToSubtypes.entries) {
-        final supertype = entry.key;
-        final subtypes = entry.value;
-
-        if (subtypes.isNotEmpty && subtypes.every(currentTypes.contains)) {
-          currentTypes.removeAll(subtypes);
-          currentTypes.add(supertype);
-          changed = true;
-        }
-      }
-    }
-    return currentTypes.toList();
+    return [singleLine];
   }
 
   void _collectDocImports(idl.IDLType idlType) {
@@ -1016,37 +988,10 @@ class Translator {
   }
 
   String? _mapIdlPrimitiveToDart(String idlType) {
-    return switch (idlType) {
-      'DOMString' || 'USVString' || 'ByteString' => 'JSString',
-      'boolean' => 'JSBoolean',
-      'byte' ||
-      'octet' ||
-      'short' ||
-      'long' ||
-      'long long' ||
-      'unsigned short' ||
-      'unsigned long' ||
-      'unsigned long long' ||
-      'double' ||
-      'float' ||
-      'unrestricted double' ||
-      'unrestricted float' => 'JSNumber',
-      'object' => 'JSObject',
-      'Function' => 'JSFunction',
-      'WindowProxy' => 'Window',
-      'Int8Array' => 'JSInt8Array',
-      'Int16Array' => 'JSInt16Array',
-      'Int32Array' => 'JSInt32Array',
-      'Uint8Array' => 'JSUint8Array',
-      'Uint16Array' => 'JSUint16Array',
-      'Uint32Array' => 'JSUint32Array',
-      'Uint8ClampedArray' => 'JSUint8ClampedArray',
-      'Float32Array' => 'JSFloat32Array',
-      'Float64Array' => 'JSFloat64Array',
-      'ArrayBuffer' => 'JSArrayBuffer',
-      'DataView' => 'JSDataView',
-      _ => null,
-    };
+    if (idlType == 'WindowProxy') return 'Window';
+    final alias = idlOrBuiltinToJsTypeAliases[idlType];
+    if (alias == 'JSInteger' || alias == 'JSDouble') return 'JSNumber';
+    return alias;
   }
 
   String _getTypeNameRaw(idl.IDLType idlType) {

--- a/js_interop_gen/lib/src/translator.dart
+++ b/js_interop_gen/lib/src/translator.dart
@@ -990,6 +990,7 @@ class Translator {
   String? _mapIdlPrimitiveToDart(String idlType) {
     if (idlType == 'WindowProxy') return 'Window';
     final alias = idlOrBuiltinToJsTypeAliases[idlType];
+    if (alias == 'JSObject' && idlType != 'object') return null;
     if (alias == 'JSInteger' || alias == 'JSDouble') return 'JSNumber';
     return alias;
   }

--- a/js_interop_gen/lib/src/translator.dart
+++ b/js_interop_gen/lib/src/translator.dart
@@ -13,10 +13,21 @@ import 'doc_provider.dart';
 import 'formatting.dart';
 import 'js/webidl_api.dart' as idl;
 import 'js/webref_elements_api.dart';
+import 'js_type_supertypes.dart';
 import 'singletons.dart';
 import 'type_aliases.dart';
 import 'type_union.dart';
 import 'util.dart';
+
+final Map<String, Set<String>> _superToSubtypes = () {
+  final map = <String, Set<String>>{};
+  jsTypeSupertypes.forEach((subtype, supertype) {
+    if (supertype != null) {
+      map.putIfAbsent(supertype, () => {}).add(subtype);
+    }
+  });
+  return map;
+}();
 
 typedef TranslationResult = Map<String, code.Library>;
 
@@ -737,6 +748,7 @@ class Translator {
   final _includes = <String, List<String>>{};
   final _usedTypes = <idl.Node>{};
   final _renamedClasses = <String, String>{};
+  final _currentDocImports = <String>{};
 
   Map<String, String> get renamedClasses => _renamedClasses;
 
@@ -748,6 +760,8 @@ class Translator {
 
   /// Singleton so that various helper methods can access info about the AST.
   static Translator? instance;
+
+  static const _unionDocListThreshold = 4;
 
   Translator(
     this._librarySubDir,
@@ -918,12 +932,166 @@ class Translator {
     _libraries[libraryPath] = library;
   }
 
-  code.TypeDef _typedef(String name, _RawType rawType) => code.TypeDef(
+  List<String> _generateUnionDocs(idl.IDLType idlType) {
+    if (!idlType.union) return [];
+    final types = (idlType.idlType as JSArray<idl.IDLType>).toDart;
+
+    for (final t in types) {
+      _collectDocImports(t);
+    }
+
+    final typeNames = types.map(_getTypeNameRaw).toList();
+    final collapsedNames = _collapseTypes(typeNames);
+
+    final formattedNames = collapsedNames.map((name) {
+      final decl = _typeToDeclaration[name];
+      if (decl != null && _usedTypes.contains(decl)) {
+        return '[$name]';
+      }
+      // If it's a generic type (contains <), wrap in ticks to avoid HTML.
+      if (name.contains('<')) {
+        return '`$name`';
+      }
+      // Link if it's a mapped primitive or a valid JS interop type from
+      // supertypes map.
+      if (_mapIdlPrimitiveToDart(name) != null ||
+          jsTypeSupertypes.containsKey(name)) {
+        return '[$name]';
+      }
+      return '`$name`';
+    }).toList();
+
+    // Sort: alphabetical, but ticked ones last!
+    formattedNames.sort((a, b) {
+      final aIsTicked = a.startsWith('`');
+      final bIsTicked = b.startsWith('`');
+      if (aIsTicked && !bIsTicked) return 1;
+      if (!aIsTicked && bIsTicked) return -1;
+      return a.compareTo(b);
+    });
+
+    if (formattedNames.length >= _unionDocListThreshold) {
+      return [
+        '/// Union of ${formattedNames.length} types',
+        '///',
+        for (final name in formattedNames) '/// - $name',
+      ];
+    }
+
+    return ['/// Union of: ${formattedNames.join(', ')}'];
+  }
+
+  List<String> _collapseTypes(List<String> types) {
+    final currentTypes = types.toSet();
+    var changed = true;
+    while (changed) {
+      changed = false;
+      for (final entry in _superToSubtypes.entries) {
+        final supertype = entry.key;
+        final subtypes = entry.value;
+
+        if (subtypes.isNotEmpty && subtypes.every(currentTypes.contains)) {
+          currentTypes.removeAll(subtypes);
+          currentTypes.add(supertype);
+          changed = true;
+        }
+      }
+    }
+    return currentTypes.toList();
+  }
+
+  void _collectDocImports(idl.IDLType idlType) {
+    if (idlType.union || idlType.generic.isNotEmpty) {
+      final types = (idlType.idlType as JSArray<idl.IDLType>).toDart;
+      for (final t in types) {
+        _collectDocImports(t);
+      }
+      return;
+    }
+    final name = (idlType.idlType as JSString).toDart;
+    final library = _typeToLibrary[name];
+    if (library != null && library.url != _currentlyTranslatingUrl) {
+      _currentDocImports.add(library.url);
+    }
+  }
+
+  String? _mapIdlPrimitiveToDart(String idlType) {
+    return switch (idlType) {
+      'DOMString' || 'USVString' || 'ByteString' => 'JSString',
+      'boolean' => 'JSBoolean',
+      'byte' ||
+      'octet' ||
+      'short' ||
+      'long' ||
+      'long long' ||
+      'unsigned short' ||
+      'unsigned long' ||
+      'unsigned long long' ||
+      'double' ||
+      'float' ||
+      'unrestricted double' ||
+      'unrestricted float' => 'JSNumber',
+      'object' => 'JSObject',
+      'Function' => 'JSFunction',
+      'WindowProxy' => 'Window',
+      'Int8Array' => 'JSInt8Array',
+      'Int16Array' => 'JSInt16Array',
+      'Int32Array' => 'JSInt32Array',
+      'Uint8Array' => 'JSUint8Array',
+      'Uint16Array' => 'JSUint16Array',
+      'Uint32Array' => 'JSUint32Array',
+      'Uint8ClampedArray' => 'JSUint8ClampedArray',
+      'Float32Array' => 'JSFloat32Array',
+      'Float64Array' => 'JSFloat64Array',
+      'ArrayBuffer' => 'JSArrayBuffer',
+      'DataView' => 'JSDataView',
+      _ => null,
+    };
+  }
+
+  String _getTypeNameRaw(idl.IDLType idlType) {
+    if (idlType.union) {
+      final types = (idlType.idlType as JSArray<idl.IDLType>).toDart;
+      return types.map(_getTypeNameRaw).join(' | ');
+    }
+    if (idlType.generic.isNotEmpty) {
+      final types = (idlType.idlType as JSArray<idl.IDLType>).toDart;
+      final genericName =
+          idlOrBuiltinToJsTypeAliases[idlType.generic] ?? idlType.generic;
+      if (types.length == 1) {
+        return '$genericName<${_getTypeNameRaw(types[0])}>';
+      }
+      if (types.length > 1) {
+        return '$genericName<${types.map(_getTypeNameRaw).join(', ')}>';
+      }
+      return genericName;
+    }
+    final name = (idlType.idlType as JSString).toDart;
+
+    final mapped = _mapIdlPrimitiveToDart(name);
+    if (mapped != null) {
+      return mapped;
+    }
+
+    final alias = idlOrBuiltinToJsTypeAliases[name];
+    if (alias == 'JSObject' && name != 'object') {
+      return name;
+    }
+
+    return alias ?? name;
+  }
+
+  code.TypeDef _typedef(
+    String name,
+    _RawType rawType, [
+    idl.Typedef? idlTypedef,
+  ]) => code.TypeDef(
     (b) => b
       ..name = name
-      // Any typedefs that need to be handled differently when used in a return
-      // type context will be handled in `_typeReference` separately.
-      ..definition = _typeReference(rawType),
+      ..definition = _typeReference(rawType)
+      ..docs.addAll([
+        if (idlTypedef != null) ..._generateUnionDocs(idlTypedef.idlType),
+      ]),
   );
 
   code.Method _topLevelGetter(_RawType type, String getterName) => code.Method(
@@ -1029,8 +1197,8 @@ class Translator {
       // Else is a core type, so no import required.
     } else if (url == _currentlyTranslatingUrl) {
       url = null;
-    } else if (p.dirname(url) == p.dirname(_currentlyTranslatingUrl)) {
-      url = p.basename(url);
+    } else {
+      url = p.url.relative(url, from: p.url.dirname(_currentlyTranslatingUrl));
     }
     return url;
   }
@@ -1544,9 +1712,52 @@ class Translator {
   }
 
   code.Library _library(_Library library) => code.Library((b) {
+    _currentDocImports.clear();
+
+    final body = [
+      for (final typedef in library.typedefs.where(_usedTypes.contains))
+        _typedef(
+          typedef.name,
+          _desugarTypedef(_RawType(typedef.name, false))!,
+          typedef,
+        ),
+      for (final callback in library.callbacks.where(_usedTypes.contains))
+        _typedef(
+          callback.name,
+          _desugarTypedef(_RawType(callback.name, false))!,
+        ),
+      for (final callbackInterface in library.callbackInterfaces.where(
+        _usedTypes.contains,
+      ))
+        _typedef(
+          callbackInterface.name,
+          _desugarTypedef(_RawType(callbackInterface.name, false))!,
+        ),
+      for (final enum_ in library.enums.where(_usedTypes.contains))
+        _typedef(enum_.name, _desugarTypedef(_RawType(enum_.name, false))!),
+      for (final interfacelike in library.interfacelikes.where(
+        _usedTypes.contains,
+      ))
+        ..._interfacelike(interfacelike),
+    ];
+
+    final docImports = <String>[];
+    if (_currentDocImports.isNotEmpty) {
+      docImports.addAll(_currentDocImports.toList()..sort());
+    }
+
     if (_generateForWeb) {
       b.comments.addAll([...licenseHeader, '', ...mozLicenseHeader]);
     }
+
+    if (docImports.isNotEmpty) {
+      final currentDir = p.url.dirname(_currentlyTranslatingUrl);
+      b.docs.addAll([
+        for (final url in docImports)
+          '/// @docImport \'${p.url.relative(url, from: currentDir)}\';',
+      ]);
+    }
+
     b
       ..ignoreForFile.addAll([
         // JS constants are allowed to be all uppercased.
@@ -1561,31 +1772,7 @@ class Translator {
       // Once this package moves to an SDK version that contains a fix
       // for that, this can be removed.
       ..annotations.addAll(_jsOverride('', alwaysEmit: true))
-      ..body.addAll([
-        for (final typedef in library.typedefs.where(_usedTypes.contains))
-          _typedef(
-            typedef.name,
-            _desugarTypedef(_RawType(typedef.name, false))!,
-          ),
-        for (final callback in library.callbacks.where(_usedTypes.contains))
-          _typedef(
-            callback.name,
-            _desugarTypedef(_RawType(callback.name, false))!,
-          ),
-        for (final callbackInterface in library.callbackInterfaces.where(
-          _usedTypes.contains,
-        ))
-          _typedef(
-            callbackInterface.name,
-            _desugarTypedef(_RawType(callbackInterface.name, false))!,
-          ),
-        for (final enum_ in library.enums.where(_usedTypes.contains))
-          _typedef(enum_.name, _desugarTypedef(_RawType(enum_.name, false))!),
-        for (final interfacelike in library.interfacelikes.where(
-          _usedTypes.contains,
-        ))
-          ..._interfacelike(interfacelike),
-      ]);
+      ..body.addAll(body);
   });
 
   code.Library generateRootImport(Iterable<String> files) => code.Library(

--- a/js_interop_gen/test/integration/idl/typedefs_expected.dart
+++ b/js_interop_gen/test/integration/idl/typedefs_expected.dart
@@ -7,7 +7,19 @@ library;
 
 import 'dart:js_interop';
 
-/// Union of: [JSDataView], [JSTypedArray]
+/// Union of 11 types
+///
+/// - [JSDataView]
+/// - [JSFloat32Array]
+/// - [JSFloat64Array]
+/// - [JSInt16Array]
+/// - [JSInt32Array]
+/// - [JSInt8Array]
+/// - [JSTypedArray]
+/// - [JSUint16Array]
+/// - [JSUint32Array]
+/// - [JSUint8Array]
+/// - [JSUint8ClampedArray]
 typedef ArrayBufferView = JSObject;
 
 /// Union of: [ArrayBufferView], [JSArrayBuffer]

--- a/js_interop_gen/test/integration/idl/typedefs_expected.dart
+++ b/js_interop_gen/test/integration/idl/typedefs_expected.dart
@@ -7,7 +7,10 @@ library;
 
 import 'dart:js_interop';
 
+/// Union of: [JSDataView], [JSTypedArray]
 typedef ArrayBufferView = JSObject;
+
+/// Union of: [ArrayBufferView], [JSArrayBuffer]
 typedef BufferSource = JSObject;
 typedef Timestamp = int;
 extension type DataHandler._(JSObject _) implements JSObject {

--- a/js_interop_gen/test/integration/idl/union_docs_expected.dart
+++ b/js_interop_gen/test/integration/idl/union_docs_expected.dart
@@ -7,24 +7,32 @@ library;
 
 import 'dart:js_interop';
 
-/// Union of: [JSTypedArray]
+/// Union of 9 types
+///
+/// - [JSFloat32Array]
+/// - [JSFloat64Array]
+/// - [JSInt16Array]
+/// - [JSInt32Array]
+/// - [JSInt8Array]
+/// - [JSUint16Array]
+/// - [JSUint32Array]
+/// - [JSUint8Array]
+/// - [JSUint8ClampedArray]
 typedef AllTypedArrays = JSTypedArray;
 
-/// Union of: [JSArrayBuffer], `SharedArrayBuffer`
+/// Union of: [JSArrayBuffer], [JSObject]
 typedef BufferUnion = JSObject;
 
 /// Union of: [JSBoolean], [JSString]
 typedef PrimitiveUnion = JSAny;
 
-/// Union of: `JSArray<JSString>`, `JSObject<JSString, JSString>`
+/// Union of 2 types
+///
+/// - <code>[JSArray]\<[JSString]\></code>
+/// - <code>[JSObject]\<[JSString], [JSString]\></code>
 typedef GenericUnion = JSObject;
 
-/// Union of 4 types
-///
-/// - [JSInt16Array]
-/// - [JSInt32Array]
-/// - [JSInt8Array]
-/// - [JSString]
+/// Union of: [JSInt16Array], [JSInt32Array], [JSInt8Array], [JSString]
 typedef NonCollapsingLongUnion = JSAny;
 extension type DummyInterface._(JSObject _) implements JSObject {
   external void testAllTypedArrays(AllTypedArrays a);

--- a/js_interop_gen/test/integration/idl/union_docs_expected.dart
+++ b/js_interop_gen/test/integration/idl/union_docs_expected.dart
@@ -20,7 +20,7 @@ import 'dart:js_interop';
 /// - [JSUint8ClampedArray]
 typedef AllTypedArrays = JSTypedArray;
 
-/// Union of: [JSArrayBuffer], [JSObject]
+/// Union of: [JSArrayBuffer], `SharedArrayBuffer`
 typedef BufferUnion = JSObject;
 
 /// Union of: [JSBoolean], [JSString]

--- a/js_interop_gen/test/integration/idl/union_docs_expected.dart
+++ b/js_interop_gen/test/integration/idl/union_docs_expected.dart
@@ -1,0 +1,35 @@
+// Generated from Web IDL definitions.
+
+// ignore_for_file: constant_identifier_names, non_constant_identifier_names
+
+@JS()
+library;
+
+import 'dart:js_interop';
+
+/// Union of: [JSTypedArray]
+typedef AllTypedArrays = JSTypedArray;
+
+/// Union of: [JSArrayBuffer], `SharedArrayBuffer`
+typedef BufferUnion = JSObject;
+
+/// Union of: [JSBoolean], [JSString]
+typedef PrimitiveUnion = JSAny;
+
+/// Union of: `JSArray<JSString>`, `JSObject<JSString, JSString>`
+typedef GenericUnion = JSObject;
+
+/// Union of 4 types
+///
+/// - [JSInt16Array]
+/// - [JSInt32Array]
+/// - [JSInt8Array]
+/// - [JSString]
+typedef NonCollapsingLongUnion = JSAny;
+extension type DummyInterface._(JSObject _) implements JSObject {
+  external void testAllTypedArrays(AllTypedArrays a);
+  external void testBufferUnion(BufferUnion b);
+  external void testPrimitiveUnion(PrimitiveUnion p);
+  external void testGenericUnion(GenericUnion g);
+  external void testNonCollapsingLongUnion(NonCollapsingLongUnion n);
+}

--- a/js_interop_gen/test/integration/idl/union_docs_input.idl
+++ b/js_interop_gen/test/integration/idl/union_docs_input.idl
@@ -1,0 +1,17 @@
+typedef (Int8Array or Int16Array or Int32Array or Uint8Array or Uint16Array or Uint32Array or Uint8ClampedArray or Float32Array or Float64Array) AllTypedArrays;
+
+typedef (SharedArrayBuffer or ArrayBuffer) BufferUnion;
+
+typedef (DOMString or boolean) PrimitiveUnion;
+
+typedef (sequence<DOMString> or record<DOMString, DOMString>) GenericUnion;
+
+typedef (Int8Array or Int16Array or Int32Array or DOMString) NonCollapsingLongUnion;
+
+interface DummyInterface {
+  void testAllTypedArrays(AllTypedArrays a);
+  void testBufferUnion(BufferUnion b);
+  void testPrimitiveUnion(PrimitiveUnion p);
+  void testGenericUnion(GenericUnion g);
+  void testNonCollapsingLongUnion(NonCollapsingLongUnion n);
+};

--- a/web/lib/src/dom/credential_management.dart
+++ b/web/lib/src/dom/credential_management.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 
+/// @docImport 'html.dart';
 @JS()
 library;
 
@@ -21,6 +22,7 @@ import 'fedcm.dart';
 import 'web_otp.dart';
 import 'webauthn.dart';
 
+/// Union of: [HTMLFormElement], [PasswordCredentialData]
 typedef PasswordCredentialInit = JSObject;
 typedef CredentialMediationRequirement = String;
 

--- a/web/lib/src/dom/css_typed_om.dart
+++ b/web/lib/src/dom/css_typed_om.dart
@@ -17,9 +17,16 @@ import 'dart:js_interop';
 
 import 'geometry.dart';
 
+/// Union of: [CSSVariableReferenceValue], [JSString]
 typedef CSSUnparsedSegment = JSAny;
+
+/// Union of: [CSSKeywordValue], [JSString]
 typedef CSSKeywordish = JSAny;
+
+/// Union of: [CSSNumericValue], [JSNumber]
 typedef CSSNumberish = JSAny;
+
+/// Union of: [CSSKeywordish], [CSSNumericValue]
 typedef CSSPerspectiveValue = JSAny;
 typedef CSSNumericBaseType = String;
 typedef CSSMathOperator = String;

--- a/web/lib/src/dom/fetch.dart
+++ b/web/lib/src/dom/fetch.dart
@@ -10,6 +10,11 @@
 
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 
+/// @docImport 'fileapi.dart';
+/// @docImport 'streams.dart';
+/// @docImport 'url.dart';
+/// @docImport 'webidl.dart';
+/// @docImport 'xhr.dart';
 @JS()
 library;
 
@@ -24,9 +29,22 @@ import 'streams.dart';
 import 'trust_token_api.dart';
 import 'xhr.dart';
 
+/// Union of: `JSArray<JSArray<JSString>>`, `JSObject<JSString, JSString>`
 typedef HeadersInit = JSObject;
+
+/// Union of 5 types
+///
+/// - [Blob]
+/// - [BufferSource]
+/// - [FormData]
+/// - [JSString]
+/// - [URLSearchParams]
 typedef XMLHttpRequestBodyInit = JSAny;
+
+/// Union of: [ReadableStream], [XMLHttpRequestBodyInit]
 typedef BodyInit = JSAny;
+
+/// Union of: [JSString], [Request]
 typedef RequestInfo = JSAny;
 typedef RequestDestination = String;
 typedef RequestMode = String;

--- a/web/lib/src/dom/fetch.dart
+++ b/web/lib/src/dom/fetch.dart
@@ -29,16 +29,13 @@ import 'streams.dart';
 import 'trust_token_api.dart';
 import 'xhr.dart';
 
-/// Union of: `JSArray<JSArray<JSString>>`, `JSObject<JSString, JSString>`
+/// Union of 2 types
+///
+/// - <code>[JSArray]\<[JSArray]\></code>
+/// - <code>[JSObject]\<[JSString], [JSString]\></code>
 typedef HeadersInit = JSObject;
 
-/// Union of 5 types
-///
-/// - [Blob]
-/// - [BufferSource]
-/// - [FormData]
-/// - [JSString]
-/// - [URLSearchParams]
+/// Union of: [Blob], [BufferSource], [FormData], [JSString], [URLSearchParams]
 typedef XMLHttpRequestBodyInit = JSAny;
 
 /// Union of: [ReadableStream], [XMLHttpRequestBodyInit]

--- a/web/lib/src/dom/fileapi.dart
+++ b/web/lib/src/dom/fileapi.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 
+/// @docImport 'webidl.dart';
 @JS()
 library;
 
@@ -20,6 +21,7 @@ import 'html.dart';
 import 'streams.dart';
 import 'webidl.dart';
 
+/// Union of: [Blob], [BufferSource], [JSString]
 typedef BlobPart = JSAny;
 typedef EndingType = String;
 

--- a/web/lib/src/dom/fs.dart
+++ b/web/lib/src/dom/fs.dart
@@ -21,12 +21,7 @@ import 'fileapi.dart';
 import 'streams.dart';
 import 'webidl.dart';
 
-/// Union of 4 types
-///
-/// - [Blob]
-/// - [BufferSource]
-/// - [JSString]
-/// - [WriteParams]
+/// Union of: [Blob], [BufferSource], [JSString], [WriteParams]
 typedef FileSystemWriteChunkType = JSAny;
 typedef FileSystemHandleKind = String;
 typedef WriteCommandType = String;

--- a/web/lib/src/dom/fs.dart
+++ b/web/lib/src/dom/fs.dart
@@ -10,6 +10,8 @@
 
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 
+/// @docImport 'fileapi.dart';
+/// @docImport 'webidl.dart';
 @JS()
 library;
 
@@ -19,6 +21,12 @@ import 'fileapi.dart';
 import 'streams.dart';
 import 'webidl.dart';
 
+/// Union of 4 types
+///
+/// - [Blob]
+/// - [BufferSource]
+/// - [JSString]
+/// - [WriteParams]
 typedef FileSystemWriteChunkType = JSAny;
 typedef FileSystemHandleKind = String;
 typedef WriteCommandType = String;

--- a/web/lib/src/dom/html.dart
+++ b/web/lib/src/dom/html.dart
@@ -10,6 +10,16 @@
 
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 
+/// @docImport 'fileapi.dart';
+/// @docImport 'media_source.dart';
+/// @docImport 'mediacapture_streams.dart';
+/// @docImport 'service_workers.dart';
+/// @docImport 'svg.dart';
+/// @docImport 'trusted_types.dart';
+/// @docImport 'webcodecs.dart';
+/// @docImport 'webgl1.dart';
+/// @docImport 'webgl2.dart';
+/// @docImport 'webgpu.dart';
 @JS()
 library;
 
@@ -61,17 +71,53 @@ import 'webidl.dart';
 import 'webmidi.dart';
 import 'xhr.dart';
 
+/// Union of: [HTMLScriptElement], [SVGScriptElement]
 typedef HTMLOrSVGScriptElement = JSObject;
+
+/// Union of: [Blob], [MediaSource], [MediaStream]
 typedef MediaProvider = JSObject;
+
+/// Union of 5 types
+///
+/// - [CanvasRenderingContext2D]
+/// - [ImageBitmapRenderingContext]
+/// - [WebGL2RenderingContext]
+/// - [WebGLRenderingContext]
+/// - `GPUCanvasContext`
 typedef RenderingContext = JSObject;
+
+/// Union of: [HTMLImageElement], [SVGImageElement]
 typedef HTMLOrSVGImageElement = JSObject;
+
+/// Union of 6 types
+///
+/// - [HTMLCanvasElement]
+/// - [HTMLOrSVGImageElement]
+/// - [HTMLVideoElement]
+/// - [ImageBitmap]
+/// - [OffscreenCanvas]
+/// - [VideoFrame]
 typedef CanvasImageSource = JSObject;
+
+/// Union of 5 types
+///
+/// - [ImageBitmapRenderingContext]
+/// - [OffscreenCanvasRenderingContext2D]
+/// - [WebGL2RenderingContext]
+/// - [WebGLRenderingContext]
+/// - `GPUCanvasContext`
 typedef OffscreenRenderingContext = JSObject;
 typedef EventHandler = EventHandlerNonNull?;
 typedef OnErrorEventHandler = OnErrorEventHandlerNonNull?;
 typedef OnBeforeUnloadEventHandler = OnBeforeUnloadEventHandlerNonNull?;
+
+/// Union of: [JSFunction], [JSString], [TrustedScript]
 typedef TimerHandler = JSAny;
+
+/// Union of: [Blob], [CanvasImageSource], [ImageData]
 typedef ImageBitmapSource = JSObject;
+
+/// Union of: [MessagePort], [ServiceWorker], [Window]
 typedef MessageEventSource = JSObject;
 typedef BlobCallback = JSFunction;
 typedef CustomElementConstructor = JSFunction;

--- a/web/lib/src/dom/image_capture.dart
+++ b/web/lib/src/dom/image_capture.dart
@@ -18,6 +18,7 @@ import 'dart:js_interop';
 import 'fileapi.dart';
 import 'mediacapture_streams.dart';
 
+/// Union of: [ConstrainPoint2DParameters], `JSArray<Point2D>`
 typedef ConstrainPoint2D = JSObject;
 typedef RedEyeReduction = String;
 typedef FillLightMode = String;

--- a/web/lib/src/dom/image_capture.dart
+++ b/web/lib/src/dom/image_capture.dart
@@ -18,7 +18,7 @@ import 'dart:js_interop';
 import 'fileapi.dart';
 import 'mediacapture_streams.dart';
 
-/// Union of: [ConstrainPoint2DParameters], `JSArray<Point2D>`
+/// Union of: <code>[JSArray]\<[Point2D]\></code>, [ConstrainPoint2DParameters]
 typedef ConstrainPoint2D = JSObject;
 typedef RedEyeReduction = String;
 typedef FillLightMode = String;

--- a/web/lib/src/dom/mediacapture_streams.dart
+++ b/web/lib/src/dom/mediacapture_streams.dart
@@ -21,9 +21,16 @@ import 'image_capture.dart';
 import 'screen_capture.dart';
 import 'webidl.dart';
 
+/// Union of: [ConstrainULongRange], [JSNumber]
 typedef ConstrainULong = JSAny;
+
+/// Union of: [ConstrainDoubleRange], [JSNumber]
 typedef ConstrainDouble = JSAny;
+
+/// Union of: [ConstrainBooleanParameters], [JSBoolean]
 typedef ConstrainBoolean = JSAny;
+
+/// Union of: [ConstrainDOMStringParameters], [JSString], `JSArray<JSString>`
 typedef ConstrainDOMString = JSAny;
 typedef MediaStreamTrackState = String;
 typedef MediaDeviceKind = String;

--- a/web/lib/src/dom/mediacapture_streams.dart
+++ b/web/lib/src/dom/mediacapture_streams.dart
@@ -30,7 +30,11 @@ typedef ConstrainDouble = JSAny;
 /// Union of: [ConstrainBooleanParameters], [JSBoolean]
 typedef ConstrainBoolean = JSAny;
 
-/// Union of: [ConstrainDOMStringParameters], [JSString], `JSArray<JSString>`
+/// Union of 3 types
+///
+/// - <code>[JSArray]\<[JSString]\></code>
+/// - [ConstrainDOMStringParameters]
+/// - [JSString]
 typedef ConstrainDOMString = JSAny;
 typedef MediaStreamTrackState = String;
 typedef MediaDeviceKind = String;

--- a/web/lib/src/dom/orientation_sensor.dart
+++ b/web/lib/src/dom/orientation_sensor.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 
+/// @docImport 'geometry.dart';
 @JS()
 library;
 
@@ -17,6 +18,7 @@ import 'dart:js_interop';
 
 import 'generic_sensor.dart';
 
+/// Union of: [DOMMatrix], [JSFloat32Array], [JSFloat64Array]
 typedef RotationMatrixType = JSObject;
 typedef OrientationSensorLocalCoordinateSystem = String;
 

--- a/web/lib/src/dom/push_api.dart
+++ b/web/lib/src/dom/push_api.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 
+/// @docImport 'webidl.dart';
 @JS()
 library;
 
@@ -19,6 +20,7 @@ import 'fileapi.dart';
 import 'hr_time.dart';
 import 'service_workers.dart';
 
+/// Union of: [BufferSource], [JSString]
 typedef PushMessageDataInit = JSAny;
 typedef PushEncryptionKeyName = String;
 

--- a/web/lib/src/dom/streams.dart
+++ b/web/lib/src/dom/streams.dart
@@ -18,6 +18,7 @@ import 'dart:js_interop';
 import 'dom.dart';
 import 'webidl.dart';
 
+/// Union of: [ReadableStreamBYOBReader], [ReadableStreamDefaultReader]
 typedef ReadableStreamReader = JSObject;
 typedef QueuingStrategySize = JSFunction;
 typedef ReadableStreamReaderMode = String;

--- a/web/lib/src/dom/vibration.dart
+++ b/web/lib/src/dom/vibration.dart
@@ -15,5 +15,5 @@ library;
 
 import 'dart:js_interop';
 
-/// Union of: [JSNumber], `JSArray<JSNumber>`
+/// Union of: <code>[JSArray]\<[JSNumber]\></code>, [JSNumber]
 typedef VibratePattern = JSAny;

--- a/web/lib/src/dom/vibration.dart
+++ b/web/lib/src/dom/vibration.dart
@@ -15,4 +15,5 @@ library;
 
 import 'dart:js_interop';
 
+/// Union of: [JSNumber], `JSArray<JSNumber>`
 typedef VibratePattern = JSAny;

--- a/web/lib/src/dom/webcodecs.dart
+++ b/web/lib/src/dom/webcodecs.dart
@@ -10,6 +10,8 @@
 
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 
+/// @docImport 'streams.dart';
+/// @docImport 'webidl.dart';
 @JS()
 library;
 
@@ -28,6 +30,7 @@ import 'webcodecs_opus_codec_registration.dart';
 import 'webcodecs_vp9_codec_registration.dart';
 import 'webidl.dart';
 
+/// Union of: [AllowSharedBufferSource], [ReadableStream]
 typedef ImageBufferSource = JSObject;
 typedef AudioDataOutputCallback = JSFunction;
 typedef VideoFrameOutputCallback = JSFunction;

--- a/web/lib/src/dom/webcryptoapi.dart
+++ b/web/lib/src/dom/webcryptoapi.dart
@@ -17,6 +17,7 @@ import 'dart:js_interop';
 
 import 'webidl.dart';
 
+/// Union of: [JSObject], [JSString]
 typedef AlgorithmIdentifier = JSAny;
 typedef KeyType = String;
 typedef KeyUsage = String;

--- a/web/lib/src/dom/webgl1.dart
+++ b/web/lib/src/dom/webgl1.dart
@@ -43,10 +43,10 @@ typedef GLclampf = num;
 /// - [VideoFrame]
 typedef TexImageSource = JSObject;
 
-/// Union of: [JSFloat32Array], `JSArray<GLfloat>`
+/// Union of: <code>[JSArray]\<[GLfloat]\></code>, [JSFloat32Array]
 typedef Float32List = JSObject;
 
-/// Union of: [JSInt32Array], `JSArray<GLint>`
+/// Union of: <code>[JSArray]\<[GLint]\></code>, [JSInt32Array]
 typedef Int32List = JSObject;
 typedef WebGLPowerPreference = String;
 extension type WebGLContextAttributes._(JSObject _) implements JSObject {

--- a/web/lib/src/dom/webgl1.dart
+++ b/web/lib/src/dom/webgl1.dart
@@ -10,6 +10,8 @@
 
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 
+/// @docImport 'html.dart';
+/// @docImport 'webcodecs.dart';
 @JS()
 library;
 
@@ -29,8 +31,22 @@ typedef GLsizeiptr = int;
 typedef GLuint = int;
 typedef GLfloat = num;
 typedef GLclampf = num;
+
+/// Union of 7 types
+///
+/// - [HTMLCanvasElement]
+/// - [HTMLImageElement]
+/// - [HTMLVideoElement]
+/// - [ImageBitmap]
+/// - [ImageData]
+/// - [OffscreenCanvas]
+/// - [VideoFrame]
 typedef TexImageSource = JSObject;
+
+/// Union of: [JSFloat32Array], `JSArray<GLfloat>`
 typedef Float32List = JSObject;
+
+/// Union of: [JSInt32Array], `JSArray<GLint>`
 typedef Int32List = JSObject;
 typedef WebGLPowerPreference = String;
 extension type WebGLContextAttributes._(JSObject _) implements JSObject {

--- a/web/lib/src/dom/webgl2.dart
+++ b/web/lib/src/dom/webgl2.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 
+/// @docImport 'webgl1.dart';
 @JS()
 library;
 
@@ -21,6 +22,8 @@ import 'webidl.dart';
 
 typedef GLint64 = int;
 typedef GLuint64 = int;
+
+/// Union of: [JSUint32Array], `JSArray<GLuint>`
 typedef Uint32List = JSObject;
 
 /// The **`WebGLQuery`** interface is part of the

--- a/web/lib/src/dom/webgl2.dart
+++ b/web/lib/src/dom/webgl2.dart
@@ -23,7 +23,7 @@ import 'webidl.dart';
 typedef GLint64 = int;
 typedef GLuint64 = int;
 
-/// Union of: [JSUint32Array], `JSArray<GLuint>`
+/// Union of: <code>[JSArray]\<[GLuint]\></code>, [JSUint32Array]
 typedef Uint32List = JSObject;
 
 /// The **`WebGLQuery`** interface is part of the

--- a/web/lib/src/dom/webidl.dart
+++ b/web/lib/src/dom/webidl.dart
@@ -33,7 +33,7 @@ typedef ArrayBufferView = JSObject;
 /// Union of: [ArrayBufferView], [JSArrayBuffer]
 typedef BufferSource = JSObject;
 
-/// Union of: [ArrayBufferView], [JSArrayBuffer], [JSObject]
+/// Union of: [ArrayBufferView], [JSArrayBuffer], `SharedArrayBuffer`
 typedef AllowSharedBufferSource = JSObject;
 typedef VoidFunction = JSFunction;
 

--- a/web/lib/src/dom/webidl.dart
+++ b/web/lib/src/dom/webidl.dart
@@ -15,8 +15,13 @@ library;
 
 import 'dart:js_interop';
 
+/// Union of: [JSDataView], [JSTypedArray]
 typedef ArrayBufferView = JSObject;
+
+/// Union of: [ArrayBufferView], [JSArrayBuffer]
 typedef BufferSource = JSObject;
+
+/// Union of: [ArrayBufferView], [JSArrayBuffer], `SharedArrayBuffer`
 typedef AllowSharedBufferSource = JSObject;
 typedef VoidFunction = JSFunction;
 

--- a/web/lib/src/dom/webidl.dart
+++ b/web/lib/src/dom/webidl.dart
@@ -15,13 +15,25 @@ library;
 
 import 'dart:js_interop';
 
-/// Union of: [JSDataView], [JSTypedArray]
+/// Union of 11 types
+///
+/// - [JSDataView]
+/// - [JSFloat32Array]
+/// - [JSFloat64Array]
+/// - [JSInt16Array]
+/// - [JSInt32Array]
+/// - [JSInt8Array]
+/// - [JSTypedArray]
+/// - [JSUint16Array]
+/// - [JSUint32Array]
+/// - [JSUint8Array]
+/// - [JSUint8ClampedArray]
 typedef ArrayBufferView = JSObject;
 
 /// Union of: [ArrayBufferView], [JSArrayBuffer]
 typedef BufferSource = JSObject;
 
-/// Union of: [ArrayBufferView], [JSArrayBuffer], `SharedArrayBuffer`
+/// Union of: [ArrayBufferView], [JSArrayBuffer], [JSObject]
 typedef AllowSharedBufferSource = JSObject;
 typedef VoidFunction = JSFunction;
 

--- a/web/lib/src/dom/webrtc_encoded_transform.dart
+++ b/web/lib/src/dom/webrtc_encoded_transform.dart
@@ -19,6 +19,7 @@ import 'dom.dart';
 import 'html.dart';
 import 'streams.dart';
 
+/// Union of: [RTCRtpScriptTransform], `SFrameTransform`
 typedef RTCRtpTransform = JSObject;
 typedef RTCEncodedVideoFrameType = String;
 extension type RTCEncodedVideoFrameMetadata._(JSObject _) implements JSObject {

--- a/web/lib/src/dom/webvtt.dart
+++ b/web/lib/src/dom/webvtt.dart
@@ -18,6 +18,7 @@ import 'dart:js_interop';
 import 'dom.dart';
 import 'html.dart';
 
+/// Union of: [AutoKeyword], [JSNumber]
 typedef LineAndPositionSetting = JSAny;
 typedef AutoKeyword = String;
 typedef DirectionSetting = String;

--- a/web/lib/src/dom/xhr.dart
+++ b/web/lib/src/dom/xhr.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 
+/// @docImport 'fileapi.dart';
 @JS()
 library;
 
@@ -18,6 +19,7 @@ import 'dart:js_interop';
 import 'dom.dart';
 import 'html.dart';
 
+/// Union of: [File], [JSString]
 typedef FormDataEntryValue = JSAny;
 typedef XMLHttpRequestResponseType = String;
 

--- a/web_generator/package-lock.json
+++ b/web_generator/package-lock.json
@@ -8,11 +8,11 @@
       "name": "web_generator_data",
       "version": "0.0.1",
       "dependencies": {
-        "@mdn/browser-compat-data": "5.6.42",
-        "@webref/css": "6.20.3",
-        "@webref/elements": "2.4.0",
-        "@webref/idl": "3.60.1",
-        "webidl2": "24.4.1"
+        "@mdn/browser-compat-data": "^5.5.2",
+        "@webref/css": "^6.11.0",
+        "@webref/elements": "^2.2.2",
+        "@webref/idl": "^3.43.1",
+        "webidl2": "^24.4.1"
       }
     },
     "node_modules/@mdn/browser-compat-data": {


### PR DESCRIPTION
- Added generator logic to document the types that make up a union typedef.
- Mapped Web IDL primitives and special types to their corresponding `dart:js_interop` types (e.g., DOMString -> JSString, Function -> JSFunction) in docs.
- Wrapped types not generated in the package in backticks to avoid broken links.
- Correctly placed @docImport directives on the library directive using b.docs.

Fixes https://github.com/dart-lang/web/issues/337