### PR TITLE
chore: update node invocation to use the source maps we already generate

### DIFF
--- a/js_interop_gen/bin/js_interop_gen.dart
+++ b/js_interop_gen/bin/js_interop_gen.dart
@@ -94,7 +94,7 @@ $_usage''');
       ? p.relative(tsConfigPath, from: bindingsGeneratorPath)
       : null;
   // Run app with `node`.
-  await runProc('node', [
+  await runNode([
     'main.mjs',
     '--declaration',
     if (argResult.rest.isNotEmpty) ...[

--- a/js_interop_gen/lib/src/cli.dart
+++ b/js_interop_gen/lib/src/cli.dart
@@ -59,6 +59,29 @@ Future<void> compileDartMain({String? langVersion, String? dir}) async {
   ], workingDirectory: dir ?? bindingsGeneratorPath);
 }
 
+Future<void> runNode(
+  List<String> arguments, {
+  required String workingDirectory,
+  bool detached = false,
+}) async {
+  await runProc(
+    'node',
+    ['--enable-source-maps', ...arguments],
+    workingDirectory: workingDirectory,
+    detached: detached,
+  );
+}
+
+Future<Process> runNodeWithResult(
+  List<String> arguments, {
+  required String workingDirectory,
+}) async {
+  return runProcWithResult('node', [
+    '--enable-source-maps',
+    ...arguments,
+  ], workingDirectory: workingDirectory);
+}
+
 Future<Process> runProcWithResult(
   String executable,
   List<String> arguments, {

--- a/js_interop_gen/test/config_gen_test.dart
+++ b/js_interop_gen/test/config_gen_test.dart
@@ -29,7 +29,7 @@ void main() {
       final inputFilePath = p.relative(inputFile, from: bindingsGenPath);
       final outFilePath = p.relative(outputFile, from: bindingsGenPath);
 
-      await runProc('node', [
+      await runNode([
         'main.mjs',
         '--input=$inputFilePath',
         '--output=$outFilePath',
@@ -48,7 +48,7 @@ void main() {
       final outFilePath = p.relative(outputFile, from: bindingsGenPath);
       final configFilePath = p.relative(configFile, from: bindingsGenPath);
 
-      await runProc('node', [
+      await runNode([
         'main.mjs',
         '--input=$inputFilePath',
         '--output=$outFilePath',

--- a/js_interop_gen/test/integration/idl_test.dart
+++ b/js_interop_gen/test/integration/idl_test.dart
@@ -57,7 +57,7 @@ void main() {
           from: bindingsGenPath,
         );
 
-        await runProc('node', [
+        await runNode([
           'main.mjs',
           '--input=$inputFilePath',
           '--output=${p.dirname(outFilePath)}',

--- a/js_interop_gen/test/integration/interop_gen_test.dart
+++ b/js_interop_gen/test/integration/interop_gen_test.dart
@@ -52,7 +52,7 @@ void main() {
         final inputFilePath = p.relative(inputFile.path, from: bindingsGenPath);
         final outFilePath = p.relative(outputActualPath, from: bindingsGenPath);
         // run the entrypoint
-        await runProc('node', [
+        await runNode([
           'main.mjs',
           '--input=$inputFilePath',
           '--output=$outFilePath',
@@ -87,7 +87,7 @@ void main() {
         from: bindingsGenPath,
       );
       // run the entrypoint
-      await runProc('node', [
+      await runNode([
         'main.mjs',
         '--config=$inputConfigPath',
         '--declaration',

--- a/js_interop_gen/test/invalid_input_test.dart
+++ b/js_interop_gen/test/invalid_input_test.dart
@@ -27,7 +27,7 @@ void main() {
       final inputFilePath = p.relative(testFile, from: bindingsGenPath);
       final outputFilePath = p.relative(outputFile, from: bindingsGenPath);
 
-      final process = await runProcWithResult('node', [
+      final process = await runNodeWithResult([
         'main.mjs',
         '--input=$inputFilePath',
         '--output=$outputFilePath',

--- a/js_interop_gen/test/unsupported_test.dart
+++ b/js_interop_gen/test/unsupported_test.dart
@@ -32,7 +32,7 @@ void main() {
       final inputFilePath = p.relative(testFile, from: bindingsGenPath);
       final outputFilePath = p.relative(outputFile, from: bindingsGenPath);
 
-      final process = await runProcWithResult('node', [
+      final process = await runNodeWithResult([
         'main.mjs',
         '--input=$inputFilePath',
         '--output=$outputFilePath',
@@ -50,7 +50,7 @@ void main() {
       final inputFilePath = p.relative(testFile, from: bindingsGenPath);
       final outputFilePath = p.relative(outputFile, from: bindingsGenPath);
 
-      await runProc('node', [
+      await runNode([
         'main.mjs',
         '--input=$inputFilePath',
         '--output=$outputFilePath',

--- a/web_generator/bin/update_idl_bindings.dart
+++ b/web_generator/bin/update_idl_bindings.dart
@@ -82,7 +82,7 @@ $_usage''');
   if (isSnapshot) {
     // Do not run webdev setup script stuff for published snapshots
     final generateAll = argResult['generate-all'] as bool;
-    await runProc('node', [
+    await runNode([
       'main.mjs',
       '--idl',
       if (inputFiles.isEmpty)
@@ -115,7 +115,7 @@ $_usage''');
 
   // Run app with `node`.
   final generateAll = argResult['generate-all'] as bool;
-  await runProc('node', [
+  await runNode([
     'main.mjs',
     '--idl',
     if (inputFiles.isEmpty)


### PR DESCRIPTION
Greatly improves debugging when the generator (and tests) fail