### PR TITLE
js_interop_gen: minimize the number of `@docImport` comments we create

### DIFF
--- a/js_interop_gen/lib/src/translator.dart
+++ b/js_interop_gen/lib/src/translator.dart
@@ -1120,10 +1120,7 @@ class Translator {
       );
     }
     final url = _urlForType(dartType);
-    final originalUrl = _typeToLibrary[dartType]?.url;
-    if (originalUrl != null) {
-      _regularImports.add(originalUrl);
-    }
+
     return code.TypeReference(
       (b) => b
         ..symbol = dartType
@@ -1139,6 +1136,9 @@ class Translator {
     // Unfortunately, `code_builder` doesn't know the url of the library we are
     // emitting, so we have to remove it here to avoid importing ourselves.
     var url = _typeToLibrary[dartType]?.url;
+    if (url != null) {
+      _regularImports.add(url);
+    }
 
     // JS types and core types don't have urls.
     if (url == null) {

--- a/js_interop_gen/lib/src/translator.dart
+++ b/js_interop_gen/lib/src/translator.dart
@@ -1120,7 +1120,6 @@ class Translator {
       );
     }
     final url = _urlForType(dartType);
-
     return code.TypeReference(
       (b) => b
         ..symbol = dartType

--- a/js_interop_gen/lib/src/translator.dart
+++ b/js_interop_gen/lib/src/translator.dart
@@ -739,7 +739,7 @@ class Translator {
   final _usedTypes = <idl.Node>{};
   final _renamedClasses = <String, String>{};
   final _currentDocImports = <String>{};
-  final _regularImports = <String>{};
+  final _currentLibraryImports = <String>{};
 
   Map<String, String> get renamedClasses => _renamedClasses;
 
@@ -1135,9 +1135,6 @@ class Translator {
     // Unfortunately, `code_builder` doesn't know the url of the library we are
     // emitting, so we have to remove it here to avoid importing ourselves.
     var url = _typeToLibrary[dartType]?.url;
-    if (url != null) {
-      _regularImports.add(url);
-    }
 
     // JS types and core types don't have urls.
     if (url == null) {
@@ -1148,6 +1145,7 @@ class Translator {
     } else if (url == _currentlyTranslatingUrl) {
       url = null;
     } else {
+      _currentLibraryImports.add(url);
       url = p.url.relative(url, from: p.url.dirname(_currentlyTranslatingUrl));
     }
     return url;
@@ -1663,7 +1661,7 @@ class Translator {
 
   code.Library _library(_Library library) => code.Library((b) {
     _currentDocImports.clear();
-    _regularImports.clear();
+    _currentLibraryImports.clear();
 
     final body = [
       for (final typedef in library.typedefs.where(_usedTypes.contains))
@@ -1694,7 +1692,7 @@ class Translator {
 
     final docImports =
         _currentDocImports
-            .where((url) => !_regularImports.contains(url))
+            .where((url) => !_currentLibraryImports.contains(url))
             .toList()
           ..sort();
 

--- a/js_interop_gen/lib/src/translator.dart
+++ b/js_interop_gen/lib/src/translator.dart
@@ -739,6 +739,7 @@ class Translator {
   final _usedTypes = <idl.Node>{};
   final _renamedClasses = <String, String>{};
   final _currentDocImports = <String>{};
+  final _regularImports = <String>{};
 
   Map<String, String> get renamedClasses => _renamedClasses;
 
@@ -1119,6 +1120,10 @@ class Translator {
       );
     }
     final url = _urlForType(dartType);
+    final originalUrl = _typeToLibrary[dartType]?.url;
+    if (originalUrl != null) {
+      _regularImports.add(originalUrl);
+    }
     return code.TypeReference(
       (b) => b
         ..symbol = dartType
@@ -1659,6 +1664,7 @@ class Translator {
 
   code.Library _library(_Library library) => code.Library((b) {
     _currentDocImports.clear();
+    _regularImports.clear();
 
     final body = [
       for (final typedef in library.typedefs.where(_usedTypes.contains))
@@ -1687,10 +1693,11 @@ class Translator {
         ..._interfacelike(interfacelike),
     ];
 
-    final docImports = <String>[];
-    if (_currentDocImports.isNotEmpty) {
-      docImports.addAll(_currentDocImports.toList()..sort());
-    }
+    final docImports =
+        _currentDocImports
+            .where((url) => !_regularImports.contains(url))
+            .toList()
+          ..sort();
 
     if (_generateForWeb) {
       b.comments.addAll([...licenseHeader, '', ...mozLicenseHeader]);

--- a/web/analysis_options.yaml
+++ b/web/analysis_options.yaml
@@ -12,7 +12,7 @@ analyzer:
   errors:
     # 43 instances in generated code.
     camel_case_types: ignore
-    # 420 instances in the MDN docs.
+    # 811 instances in the MDN docs.
     comment_references: ignore
     # 14 instances in the MDN docs.
     lines_longer_than_80_chars: ignore

--- a/web/lib/src/dom/fetch.dart
+++ b/web/lib/src/dom/fetch.dart
@@ -10,11 +10,8 @@
 
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 
-/// @docImport 'fileapi.dart';
-/// @docImport 'streams.dart';
 /// @docImport 'url.dart';
 /// @docImport 'webidl.dart';
-/// @docImport 'xhr.dart';
 @JS()
 library;
 

--- a/web/lib/src/dom/fileapi.dart
+++ b/web/lib/src/dom/fileapi.dart
@@ -10,7 +10,6 @@
 
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 
-/// @docImport 'webidl.dart';
 @JS()
 library;
 

--- a/web/lib/src/dom/fs.dart
+++ b/web/lib/src/dom/fs.dart
@@ -10,8 +10,6 @@
 
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 
-/// @docImport 'fileapi.dart';
-/// @docImport 'webidl.dart';
 @JS()
 library;
 

--- a/web/lib/src/dom/html.dart
+++ b/web/lib/src/dom/html.dart
@@ -10,12 +10,7 @@
 
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 
-/// @docImport 'fileapi.dart';
-/// @docImport 'media_source.dart';
-/// @docImport 'mediacapture_streams.dart';
-/// @docImport 'service_workers.dart';
 /// @docImport 'svg.dart';
-/// @docImport 'trusted_types.dart';
 /// @docImport 'webcodecs.dart';
 /// @docImport 'webgl1.dart';
 /// @docImport 'webgl2.dart';

--- a/web/lib/src/dom/webcodecs.dart
+++ b/web/lib/src/dom/webcodecs.dart
@@ -11,7 +11,6 @@
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 
 /// @docImport 'streams.dart';
-/// @docImport 'webidl.dart';
 @JS()
 library;
 

--- a/web/lib/src/dom/webgl1.dart
+++ b/web/lib/src/dom/webgl1.dart
@@ -10,7 +10,6 @@
 
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 
-/// @docImport 'html.dart';
 /// @docImport 'webcodecs.dart';
 @JS()
 library;

--- a/web/lib/src/dom/webgl2.dart
+++ b/web/lib/src/dom/webgl2.dart
@@ -10,7 +10,6 @@
 
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 
-/// @docImport 'webgl1.dart';
 @JS()
 library;
 


### PR DESCRIPTION
No need to create these if there is already a library import

Confirmed that we still have the same 811 doc issues before/after the change
So this makes things no worse!
