### PR TITLE
feat(js_interop_gen): support nested typealiases, namespace parent resolutions, and aliased variable exports in compiler core

### DIFF
--- a/js_interop_gen/lib/src/ast/declarations.dart
+++ b/js_interop_gen/lib/src/ast/declarations.dart
@@ -258,9 +258,13 @@ class VariableDeclaration extends FieldDeclaration
             if (_checkIfDiscardable(type))
               refer('doNotStore', 'package:meta/meta.dart'),
           ])
-          ..name = name
+          ..name = dartName ?? name
           ..type = MethodType.getter
-          ..annotations.add(generateJSAnnotation())
+          ..annotations.add(
+            generateJSAnnotation(
+              dartName == null || dartName == name ? null : name,
+            ),
+          )
           ..external = true
           ..static = options?.static ?? false
           ..returns = type.emit(options?.toTypeOptions()),
@@ -273,9 +277,13 @@ class VariableDeclaration extends FieldDeclaration
           ..annotations.addAll([...annotations])
           ..external = true
           ..static = options?.static ?? false
-          ..name = name
+          ..name = dartName ?? name
           ..type = type.emit(options?.toTypeOptions())
-          ..annotations.add(generateJSAnnotation()),
+          ..annotations.add(
+            generateJSAnnotation(
+              dartName == null || dartName == name ? null : name,
+            ),
+          ),
       );
     }
   }

--- a/js_interop_gen/lib/src/ast/declarations.dart
+++ b/js_interop_gen/lib/src/ast/declarations.dart
@@ -670,6 +670,21 @@ class NamespaceDeclaration extends NestableDeclaration
     this.documentation,
   }) : _id = id;
 
+  NamespaceDeclaration clone({String? name, String? dartName}) {
+    return NamespaceDeclaration(
+        name: name ?? this.name,
+        dartName: dartName ?? this.dartName,
+        id: _id,
+        exported: exported,
+        topLevelDeclarations: topLevelDeclarations,
+        namespaceDeclarations: namespaceDeclarations,
+        nestableDeclarations: nestableDeclarations,
+        documentation: documentation,
+      )
+      ..parent = parent
+      ..nodes = nodes;
+  }
+
   @override
   ExtensionType emit([covariant DeclarationOptions? options]) {
     final namespaceOptions = DeclarationOptions(

--- a/js_interop_gen/lib/src/ast/types.dart
+++ b/js_interop_gen/lib/src/ast/types.dart
@@ -1287,9 +1287,12 @@ Type _intersectTypes(List<Type> types) {
 }
 
 String _sanitizeIdentifier(String name) {
-  return name
+  final sanitized = name
       .replaceAll('|', 'Or')
       .replaceAll('&', 'And')
       .replaceAll(RegExp(r'[^a-zA-Z0-9_]'), '_')
       .replaceAll(RegExp(r'_{2,}'), '_');
+  return sanitized.isNotEmpty && RegExp(r'^[0-9]').hasMatch(sanitized)
+      ? '\$$sanitized'
+      : sanitized;
 }

--- a/js_interop_gen/lib/src/ast/types.dart
+++ b/js_interop_gen/lib/src/ast/types.dart
@@ -1287,12 +1287,9 @@ Type _intersectTypes(List<Type> types) {
 }
 
 String _sanitizeIdentifier(String name) {
-  var result = name
+  return name
       .replaceAll('|', 'Or')
       .replaceAll('&', 'And')
-      .replaceAll(RegExp(r'[^a-zA-Z0-9_]'), '_');
-  while (result.contains('__')) {
-    result = result.replaceAll('__', '_');
-  }
-  return result;
+      .replaceAll(RegExp(r'[^a-zA-Z0-9_]'), '_')
+      .replaceAll(RegExp(r'_{2,}'), '_');
 }

--- a/js_interop_gen/lib/src/ast/types.dart
+++ b/js_interop_gen/lib/src/ast/types.dart
@@ -179,7 +179,7 @@ class UnionType extends DeclarationType {
     required this.types,
     required String name,
     this.isNullable = false,
-  }) : declarationName = name;
+  }) : declarationName = _sanitizeIdentifier(name);
 
   @override
   ID get id => ID(type: 'type', name: types.map((t) => t.id.name).join('|'));
@@ -233,7 +233,7 @@ class IntersectionType extends DeclarationType {
   String declarationName;
 
   IntersectionType({required this.types, required String name})
-    : declarationName = name;
+    : declarationName = _sanitizeIdentifier(name);
 
   @override
   ID get id => ID(type: 'type', name: types.map((t) => t.id.name).join('&'));
@@ -301,7 +301,7 @@ class HomogenousEnumType<T extends LiteralType, D extends Declaration>
       return EnumMember(
         name,
         t.value,
-        dartName: UniqueNamer.makeNonConflicting(name),
+        dartName: UniqueNamer.makeNonConflicting(_sanitizeIdentifier(name)),
         parent: UniqueNamer.makeNonConflicting(declarationName),
       );
     }).toList(),
@@ -1177,13 +1177,14 @@ String _typeNameForGetter(Type t, [Options? options]) {
     typeParams = const [];
   }
 
+  var result = baseName;
   if (typeParams.isNotEmpty) {
     final paramsName = typeParams
         .map((p) => uppercaseFirstLetter(_typeNameForGetter(p, options)))
         .join('And');
-    return '${baseName}Of$paramsName';
+    result = '${baseName}Of$paramsName';
   }
-  return baseName;
+  return _sanitizeIdentifier(result);
 }
 
 Type _intersectTypes(List<Type> types) {
@@ -1283,4 +1284,15 @@ Type _intersectTypes(List<Type> types) {
   final hash = AnonymousHasher.hashUnion(idNames);
   final name = 'AnonymousIntersection_$hash';
   return IntersectionType(types: filteredTypes, name: name);
+}
+
+String _sanitizeIdentifier(String name) {
+  var result = name
+      .replaceAll('|', 'Or')
+      .replaceAll('&', 'And')
+      .replaceAll(RegExp(r'[^a-zA-Z0-9_]'), '_');
+  while (result.contains('__')) {
+    result = result.replaceAll('__', '_');
+  }
+  return result;
 }

--- a/js_interop_gen/lib/src/interop_gen/transform.dart
+++ b/js_interop_gen/lib/src/interop_gen/transform.dart
@@ -356,11 +356,9 @@ class ProgramMap {
             continue;
           }
           final decls = symbol.getDeclarations()?.toDart ?? [];
-          try {
+          if (symbol.isAlias) {
             final aliasedSymbol = typeChecker.getAliasedSymbol(symbol);
             decls.addAll(aliasedSymbol.getDeclarations()?.toDart ?? []);
-          } catch (_) {
-            // throws error if no aliased symbol, so ignore
           }
           for (final decl in decls) {
             _activeTransformers[absolutePath]!.transform(decl);

--- a/js_interop_gen/lib/src/interop_gen/transform.dart
+++ b/js_interop_gen/lib/src/interop_gen/transform.dart
@@ -357,8 +357,14 @@ class ProgramMap {
           }
           final decls = symbol.getDeclarations()?.toDart ?? [];
           if (symbol.isAlias) {
-            final aliasedSymbol = typeChecker.getAliasedSymbol(symbol);
-            decls.addAll(aliasedSymbol.getDeclarations()?.toDart ?? []);
+            try {
+              final aliasedSymbol = typeChecker.getAliasedSymbol(symbol);
+              decls.addAll(aliasedSymbol.getDeclarations()?.toDart ?? []);
+            } catch (e) {
+              print(
+                'WARN: Could not resolve aliased symbol "${symbol.name}": $e',
+              );
+            }
           }
           for (final decl in decls) {
             _activeTransformers[absolutePath]!.transform(decl);

--- a/js_interop_gen/lib/src/interop_gen/transform/transformer.dart
+++ b/js_interop_gen/lib/src/interop_gen/transform/transformer.dart
@@ -1436,7 +1436,6 @@ class Transformer {
           ...operators.map((p) => (p.name, p.returnType.id.name)),
         ];
         // get a name
-        // get a name
         final name = 'AnonymousType_${AnonymousHasher.hashObject(hashObject)}';
 
         // get an expected id

--- a/js_interop_gen/lib/src/interop_gen/transform/transformer.dart
+++ b/js_interop_gen/lib/src/interop_gen/transform/transformer.dart
@@ -202,8 +202,12 @@ class Transformer {
     var actualName = actualNameNode.text;
     final symbol = typeChecker.getSymbolAtLocation(actualNameNode);
     if (symbol != null && symbol.isAlias) {
-      final aliasedSymbol = typeChecker.getAliasedSymbol(symbol);
-      actualName = aliasedSymbol.name;
+      try {
+        final aliasedSymbol = typeChecker.getAliasedSymbol(symbol);
+        actualName = aliasedSymbol.name;
+      } catch (e) {
+        print('WARN: Could not resolve aliased symbol "${symbol.name}": $e');
+      }
     }
 
     final decl = nodeMap.findByName(actualName);
@@ -238,8 +242,14 @@ class Transformer {
           exp.propertyName ?? exp.name,
         );
         if (symbol != null && symbol.isAlias) {
-          final aliasedSymbol = typeChecker.getAliasedSymbol(symbol);
-          actualName = aliasedSymbol.name;
+          try {
+            final aliasedSymbol = typeChecker.getAliasedSymbol(symbol);
+            actualName = aliasedSymbol.name;
+          } catch (e) {
+            print(
+              'WARN: Could not resolve aliased symbol "${symbol.name}": $e',
+            );
+          }
         }
 
         (exportSet ?? this.exportSet).add(
@@ -2401,6 +2411,13 @@ class Transformer {
                       exported: decl.exported,
                       returnType: decl.returnType,
                       documentation: decl.documentation,
+                    ),
+                  );
+                } else if (decl is NamespaceDeclaration) {
+                  filteredDeclarations.add(
+                    decl.clone(
+                      name: jsName,
+                      dartName: dartName == jsName ? null : dartName,
                     ),
                   );
                 } else {

--- a/js_interop_gen/lib/src/interop_gen/transform/transformer.dart
+++ b/js_interop_gen/lib/src/interop_gen/transform/transformer.dart
@@ -196,18 +196,28 @@ class Transformer {
     TSExportSpecifier specifier, {
     Set<ExportReference>? exportSet,
   }) {
-    final actualName = specifier.propertyName ?? specifier.name;
-
+    final actualNameNode = specifier.propertyName ?? specifier.name;
     final dartName = specifier.name;
 
-    final decl = nodeMap.findByName(actualName.text);
+    var actualName = actualNameNode.text;
+    final symbol = typeChecker.getSymbolAtLocation(actualNameNode);
+    if (symbol != null) {
+      try {
+        final aliasedSymbol = typeChecker.getAliasedSymbol(symbol);
+        actualName = aliasedSymbol.name;
+      } catch (_) {
+        // Throws if not an aliased symbol
+      }
+    }
+
+    final decl = nodeMap.findByName(actualName);
 
     // This just guarantees the declaration is transformed before adding the
     // export reference
-    if (decl.isEmpty) _getTypeFromDeclaration(actualName, []);
+    if (decl.isEmpty) _getTypeFromDeclaration(actualNameNode, []);
 
     (exportSet ?? this.exportSet).add(
-      ExportReference(actualName.text, as: dartName.text),
+      ExportReference(actualName, as: dartName.text),
     );
   }
 
@@ -223,11 +233,22 @@ class Transformer {
       final exports = (export.exportClause as TSNamedExports).elements.toDart;
 
       for (final exp in exports) {
-        // the name of the declaration in TS (name)
-        final actualName = (exp.propertyName ?? exp.name).text;
-
         // The exported name to use
         final dartName = exp.name.text;
+
+        // the name of the declaration in TS (name)
+        var actualName = (exp.propertyName ?? exp.name).text;
+        final symbol = typeChecker.getSymbolAtLocation(
+          exp.propertyName ?? exp.name,
+        );
+        if (symbol != null) {
+          try {
+            final aliasedSymbol = typeChecker.getAliasedSymbol(symbol);
+            actualName = aliasedSymbol.name;
+          } catch (_) {
+            // Throws if not an aliased symbol
+          }
+        }
 
         (exportSet ?? this.exportSet).add(
           ExportReference(actualName, as: dartName),
@@ -1415,6 +1436,7 @@ class Transformer {
           ...operators.map((p) => (p.name, p.returnType.id.name)),
         ];
         // get a name
+        // get a name
         final name = 'AnonymousType_${AnonymousHasher.hashObject(hashObject)}';
 
         // get an expected id
@@ -1523,6 +1545,13 @@ class Transformer {
               (t) => _transformType(t, typeArg: typeArg, parameter: parameter),
             )
             .toList();
+
+        if (types.isEmpty) {
+          return BuiltinType.primitiveType(
+            PrimitiveType.never,
+            isNullable: shouldBeNullable || (isNullable ?? false),
+          );
+        }
 
         var isHomogenous = true;
         final nonNullLiteralTypes = <LiteralType>[];
@@ -1819,6 +1848,13 @@ class Transformer {
 
         if (returnTypeOrNull != null) return returnTypeOrNull;
 
+        if (keys.isEmpty) {
+          return BuiltinType.primitiveType(
+            PrimitiveType.never,
+            isNullable: isNullable,
+          );
+        }
+
         final typeName = transformedType is NamedType
             ? (transformedType.dartName ?? transformedType.name)
             : transformedType.id.name;
@@ -2041,10 +2077,15 @@ class Transformer {
 
       return getTypeFromDeclaration;
     } else if (type.expression.kind == TSSyntaxKind.PropertyAccessExpression) {
-      // TODO(nikeokoronkwo): Support Globbed Imports and Exports, https://github.com/dart-lang/web/issues/420
-      throw UnimplementedError(
-        "The given type expression's expression of kind "
-        '${type.expression.kind} is not supported yet',
+      final symbol = typeChecker.getSymbolAtLocation(type.expression);
+      final tsType = typeChecker.getTypeFromTypeNode(type);
+      return typeResolver.getTypeFromSymbol(
+        symbol,
+        tsType,
+        type.typeArguments?.toDart,
+        false,
+        false,
+        false,
       );
     } else {
       throw UnimplementedError(

--- a/js_interop_gen/lib/src/interop_gen/transform/transformer.dart
+++ b/js_interop_gen/lib/src/interop_gen/transform/transformer.dart
@@ -201,13 +201,9 @@ class Transformer {
 
     var actualName = actualNameNode.text;
     final symbol = typeChecker.getSymbolAtLocation(actualNameNode);
-    if (symbol != null) {
-      try {
-        final aliasedSymbol = typeChecker.getAliasedSymbol(symbol);
-        actualName = aliasedSymbol.name;
-      } catch (_) {
-        // Throws if not an aliased symbol
-      }
+    if (symbol != null && symbol.isAlias) {
+      final aliasedSymbol = typeChecker.getAliasedSymbol(symbol);
+      actualName = aliasedSymbol.name;
     }
 
     final decl = nodeMap.findByName(actualName);
@@ -241,13 +237,9 @@ class Transformer {
         final symbol = typeChecker.getSymbolAtLocation(
           exp.propertyName ?? exp.name,
         );
-        if (symbol != null) {
-          try {
-            final aliasedSymbol = typeChecker.getAliasedSymbol(symbol);
-            actualName = aliasedSymbol.name;
-          } catch (_) {
-            // Throws if not an aliased symbol
-          }
+        if (symbol != null && symbol.isAlias) {
+          final aliasedSymbol = typeChecker.getAliasedSymbol(symbol);
+          actualName = aliasedSymbol.name;
         }
 
         (exportSet ?? this.exportSet).add(
@@ -2366,14 +2358,60 @@ class Transformer {
                 );
               }
             } else {
-              // Value declaration (variable, function, etc.): mutate in-place!
-              filteredDeclarations.add(
-                decl
-                  ..name = exportDartName
-                  ..dartName =
-                      decl.dartName ??
-                      UniqueNamer.makeNonConflicting(exportName),
-              );
+              // Value declaration (variable, function, etc.)
+              final allExportsForThisName = exportSet
+                  .where((e) => e.name == exportName)
+                  .toList();
+
+              // For value declarations, we want both the Dart name and the JS
+              // name to be the exported name (exportDartName).
+              // If the exported name conflicts with a Dart keyword,
+              // UniqueNamer will make it non-conflicting.
+              final dartName = UniqueNamer.makeNonConflicting(exportDartName);
+              final jsName = exportDartName;
+
+              if (allExportsForThisName.length == 1) {
+                // Only a single renamed/exported symbol. Mutate in-place.
+                filteredDeclarations.add(
+                  decl
+                    ..name = jsName
+                    ..dartName = dartName == jsName ? null : dartName,
+                );
+              } else {
+                // Multiple exports for the same symbol.
+                // Clone the declaration with the new name!
+                if (decl is VariableDeclaration) {
+                  filteredDeclarations.add(
+                    VariableDeclaration(
+                      name: jsName,
+                      type: decl.type,
+                      modifier: decl.modifier,
+                      exported: decl.exported,
+                      documentation: decl.documentation,
+                    )..dartName = dartName == jsName ? null : dartName,
+                  );
+                } else if (decl is FunctionDeclaration) {
+                  filteredDeclarations.add(
+                    FunctionDeclaration(
+                      name: jsName,
+                      id: ID(type: 'func', name: dartName),
+                      dartName: dartName == jsName ? null : dartName,
+                      parameters: decl.parameters,
+                      typeParameters: decl.typeParameters,
+                      exported: decl.exported,
+                      returnType: decl.returnType,
+                      documentation: decl.documentation,
+                    ),
+                  );
+                } else {
+                  // Fallback: mutate in-place.
+                  filteredDeclarations.add(
+                    decl
+                      ..name = jsName
+                      ..dartName = dartName == jsName ? null : dartName,
+                  );
+                }
+              }
             }
           } else {
             continue;

--- a/js_interop_gen/lib/src/interop_gen/transform/type_resolver.dart
+++ b/js_interop_gen/lib/src/interop_gen/transform/type_resolver.dart
@@ -91,6 +91,7 @@ class TypeResolver {
           );
           final aliasedSymbolName = aliasedSymbol.name;
 
+          transformer.exportSet.removeWhere((e) => e.name == aliasedSymbolName);
           transformer.exportSet.add(
             ExportReference(aliasedSymbolName, as: firstName),
           );
@@ -104,6 +105,19 @@ class TypeResolver {
             isNullable,
           );
         }
+        if (declaration.kind == TSSyntaxKind.ImportSpecifier) {
+          final aliasedSymbol = transformer.typeChecker.getAliasedSymbol(
+            symbol,
+          );
+          return getTypeFromSymbol(
+            aliasedSymbol,
+            transformer.typeChecker.getTypeOfSymbol(aliasedSymbol),
+            typeArguments,
+            isNotTypableDeclaration,
+            typeArg,
+            isNullable,
+          );
+        }
 
         var d = declaration as TSNamedDeclaration;
 
@@ -113,14 +127,20 @@ class TypeResolver {
         }
 
         // TODO: multi-decls
-        final transformedDecls = transformer.transformAndReturn(
-          declaration,
-          namer: namer,
-          parent: parent,
-        );
+        final List<Declaration> transformedDecls;
+        final cached = transformer.transformedCache[d];
+        if (cached != null) {
+          transformedDecls = cached;
+        } else {
+          transformedDecls = transformer.transformAndReturn(
+            d,
+            namer: namer,
+            parent: parent,
+          );
+        }
 
         if (parent != null) {
-          switch (declaration.kind) {
+          switch (d.kind) {
             case TSSyntaxKind.ClassDeclaration ||
                 TSSyntaxKind.InterfaceDeclaration:
               final outputDecl = transformedDecls.first as TypeDeclaration;
@@ -130,15 +150,19 @@ class TypeResolver {
               final outputDecl = transformedDecls.first as EnumDeclaration;
               outputDecl.parent = parent;
               parent.nestableDeclarations.add(outputDecl);
+            case TSSyntaxKind.TypeAliasDeclaration:
+              final outputDecl = transformedDecls.first as TypeAliasDeclaration;
+              outputDecl.parent = parent;
+              parent.nestableDeclarations.add(outputDecl);
             default:
               parent.topLevelDeclarations.addAll(transformedDecls);
           }
-          parent.nodes.add(declaration);
+          parent.nodes.add(d);
         } else {
           transformer.nodeMap.addAll({
             for (final decl in transformedDecls) decl.id.toString(): decl,
           });
-          transformer.nodes.add(declaration);
+          transformer.nodes.add(d);
         }
       }
 
@@ -437,7 +461,11 @@ class TypeResolver {
             );
           }
           final referencedDeclarations = transformer.programMap
-              .getDeclarationRef(declSource, decl, fullyQualifiedName.asName);
+              .getDeclarationRef(
+                decl.getSourceFile().fileName,
+                decl,
+                fullyQualifiedName.asName,
+              );
 
           mappedDecls =
               referencedDeclarations?.whereType<NamedDeclaration>().toList() ??
@@ -527,6 +555,23 @@ class TypeResolver {
           isNullable: isNullable,
         );
       } else {
+        final declFile = declarations.isEmpty
+            ? null
+            : p.normalize(
+                p.absolute(declarations.first.getSourceFile().fileName),
+              );
+        final currentFile = p.normalize(p.absolute(transformer.file));
+
+        if (declFile != null && p.equals(declFile, currentFile)) {
+          return searchForDeclRecursive(
+            fullyQualifiedName,
+            symbol,
+            typeArguments: typeArguments,
+            typeArg: typeArg,
+            isNotTypableDeclaration: isNotTypableDeclaration,
+            isNullable: isNullable,
+          );
+        }
         // if import there and not this file, imported from specified file
         final importUrl =
             !nameImport.endsWith('.d.ts') &&
@@ -549,20 +594,20 @@ class TypeResolver {
             ? p.relative(importUrl, from: p.dirname(transformer.file))
             : null;
         final referencedDeclarations = declarations
-            .expand(
-              (decl) =>
-                  transformer.programMap.getDeclarationRef(
-                    importUrl,
-                    decl,
-                    fullyQualifiedName.asName,
-                  ) ??
-                  const <Node>[],
-            )
-            .toList();
+            .map((TSNode decl) {
+              return transformer.programMap.getDeclarationRef(
+                decl.getSourceFile().fileName,
+                decl,
+                fullyQualifiedName.asName,
+              );
+            })
+            .reduce(
+              (List<Node>? prev, List<Node>? next) => [...?prev, ...?next],
+            );
 
-        final nodes = referencedDeclarations
-            .whereType<NamedDeclaration>()
-            .toList();
+        final nodes =
+            referencedDeclarations?.whereType<NamedDeclaration>().toList() ??
+            [];
 
         final (mergedNodes, :additionals) = mergeDeclarations(nodes);
         transformer.nodeMap.addAll({
@@ -617,7 +662,17 @@ class TypeResolver {
           typeName.kind == TSSyntaxKind.QualifiedName,
     );
 
-    final symbol = transformer.typeChecker.getSymbolAtLocation(typeName);
+    var symbol = transformer.typeChecker.getSymbolAtLocation(typeName);
+    if (symbol != null) {
+      final declarations = symbol.getDeclarations()?.toDart ?? [];
+      for (final decl in declarations) {
+        if (decl.kind == TSSyntaxKind.ImportSpecifier ||
+            decl.kind == TSSyntaxKind.ExportSpecifier) {
+          symbol = transformer.typeChecker.getAliasedSymbol(symbol!);
+          break;
+        }
+      }
+    }
 
     return getTypeFromSymbol(
       symbol,

--- a/js_interop_gen/lib/src/interop_gen/transform/type_resolver.dart
+++ b/js_interop_gen/lib/src/interop_gen/transform/type_resolver.dart
@@ -91,7 +91,6 @@ class TypeResolver {
           );
           final aliasedSymbolName = aliasedSymbol.name;
 
-          transformer.exportSet.removeWhere((e) => e.name == aliasedSymbolName);
           transformer.exportSet.add(
             ExportReference(aliasedSymbolName, as: firstName),
           );
@@ -100,8 +99,8 @@ class TypeResolver {
             aliasedSymbol,
             transformer.typeChecker.getTypeOfSymbol(aliasedSymbol),
             typeArguments,
-            typeArg,
             isNotTypableDeclaration,
+            typeArg,
             isNullable,
           );
         }

--- a/js_interop_gen/lib/src/interop_gen/transform/type_resolver.dart
+++ b/js_interop_gen/lib/src/interop_gen/transform/type_resolver.dart
@@ -660,7 +660,11 @@ class TypeResolver {
     for (final decl in declarations) {
       if (decl.kind == TSSyntaxKind.ImportSpecifier ||
           decl.kind == TSSyntaxKind.ExportSpecifier) {
-        resolvedSymbol = transformer.typeChecker.getAliasedSymbol(symbol);
+        try {
+          resolvedSymbol = transformer.typeChecker.getAliasedSymbol(symbol);
+        } catch (e) {
+          print('WARN: Could not resolve aliased symbol "${symbol.name}": $e');
+        }
         break;
       }
     }

--- a/js_interop_gen/lib/src/interop_gen/transform/type_resolver.dart
+++ b/js_interop_gen/lib/src/interop_gen/transform/type_resolver.dart
@@ -652,21 +652,23 @@ class TypeResolver {
           typeName.kind == TSSyntaxKind.QualifiedName,
     );
 
-    var symbol = transformer.typeChecker.getSymbolAtLocation(typeName);
-    if (symbol != null) {
-      final declarations = symbol.getDeclarations()?.toDart ?? [];
-      for (final decl in declarations) {
-        if (decl.kind == TSSyntaxKind.ImportSpecifier ||
-            decl.kind == TSSyntaxKind.ExportSpecifier) {
-          symbol = transformer.typeChecker.getAliasedSymbol(symbol!);
-          break;
-        }
+    final symbol = transformer.typeChecker.getSymbolAtLocation(typeName);
+    if (symbol == null) {
+      throw Exception('Could not resolve type: symbol is null');
+    }
+    var resolvedSymbol = symbol;
+    final declarations = symbol.getDeclarations()?.toDart ?? [];
+    for (final decl in declarations) {
+      if (decl.kind == TSSyntaxKind.ImportSpecifier ||
+          decl.kind == TSSyntaxKind.ExportSpecifier) {
+        resolvedSymbol = transformer.typeChecker.getAliasedSymbol(symbol);
+        break;
       }
     }
 
     return getTypeFromSymbol(
-      symbol,
-      transformer.typeChecker.getTypeOfSymbol(symbol!),
+      resolvedSymbol,
+      transformer.typeChecker.getTypeOfSymbol(resolvedSymbol),
       typeArguments,
       isNotTypableDeclaration,
       typeArg,

--- a/js_interop_gen/lib/src/interop_gen/transform/type_resolver.dart
+++ b/js_interop_gen/lib/src/interop_gen/transform/type_resolver.dart
@@ -127,17 +127,11 @@ class TypeResolver {
         }
 
         // TODO: multi-decls
-        final List<Declaration> transformedDecls;
-        final cached = transformer.transformedCache[d];
-        if (cached != null) {
-          transformedDecls = cached;
-        } else {
-          transformedDecls = transformer.transformAndReturn(
-            d,
-            namer: namer,
-            parent: parent,
-          );
-        }
+        final transformedDecls = transformer.transformAndReturn(
+          d,
+          namer: namer,
+          parent: parent,
+        );
 
         if (parent != null) {
           switch (d.kind) {
@@ -593,21 +587,17 @@ class TypeResolver {
                 !p.equals(importUrl, transformer.file)
             ? p.relative(importUrl, from: p.dirname(transformer.file))
             : null;
-        final referencedDeclarations = declarations
-            .map((TSNode decl) {
+        final nodes = declarations
+            .expand((decl) {
               return transformer.programMap.getDeclarationRef(
-                decl.getSourceFile().fileName,
-                decl,
-                fullyQualifiedName.asName,
-              );
+                    decl.getSourceFile().fileName,
+                    decl,
+                    fullyQualifiedName.asName,
+                  ) ??
+                  const <Node>[];
             })
-            .reduce(
-              (List<Node>? prev, List<Node>? next) => [...?prev, ...?next],
-            );
-
-        final nodes =
-            referencedDeclarations?.whereType<NamedDeclaration>().toList() ??
-            [];
+            .whereType<NamedDeclaration>()
+            .toList();
 
         final (mergedNodes, :additionals) = mergeDeclarations(nodes);
         transformer.nodeMap.addAll({

--- a/js_interop_gen/lib/src/js/typescript.types.dart
+++ b/js_interop_gen/lib/src/js/typescript.types.dart
@@ -734,7 +734,7 @@ extension type TSSymbol._(JSObject _) implements JSObject {
   external JSArray<JSDocTagInfo> getJsDocTags([TSTypeChecker checker]);
   external TSSymbolTable? get exports;
 
-  bool get isAlias => (flags & 2097152) != 0;
+  bool get isAlias => (flags & 0x200000) != 0;
 }
 
 typedef TSSymbolTable = JSMap<JSString, TSSymbol>;

--- a/js_interop_gen/lib/src/js/typescript.types.dart
+++ b/js_interop_gen/lib/src/js/typescript.types.dart
@@ -726,12 +726,15 @@ extension type TSNodeArray<T extends TSNode>._(JSArray<T> _)
 @JS('Symbol')
 extension type TSSymbol._(JSObject _) implements JSObject {
   external String get name;
+  external int get flags;
   external JSArray<TSDeclaration>? getDeclarations();
   external JSArray<TSSymbolDisplayPart> getDocumentationComment(
     TSTypeChecker? typeChecker,
   );
   external JSArray<JSDocTagInfo> getJsDocTags([TSTypeChecker checker]);
   external TSSymbolTable? get exports;
+
+  bool get isAlias => (flags & 2097152) != 0;
 }
 
 typedef TSSymbolTable = JSMap<JSString, TSSymbol>;

--- a/js_interop_gen/test/integration/interop_gen/duplicate_implements_expected.dart
+++ b/js_interop_gen/test/integration/interop_gen/duplicate_implements_expected.dart
@@ -1,0 +1,26 @@
+// ignore_for_file: camel_case_types, constant_identifier_names
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: lines_longer_than_80_chars, non_constant_identifier_names
+// ignore_for_file: unnecessary_parenthesis
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:js_interop' as _i1;
+
+extension type Grandparent._(_i1.JSObject _) implements _i1.JSObject {
+  external String grandparentProp;
+}
+extension type ParentA._(_i1.JSObject _) implements Grandparent {
+  external String aProp;
+}
+extension type ParentB._(_i1.JSObject _) implements Grandparent {
+  external String bProp;
+}
+extension type Child._(_i1.JSObject _) implements ParentA, ParentB {
+  external String childProp;
+}
+typedef UnionWithDuplicates = AnonymousUnion_2488765;
+extension type AnonymousUnion_2488765._(Grandparent _) implements Grandparent {
+  ParentA get asParentA => (_ as ParentA);
+
+  ParentB get asParentB => (_ as ParentB);
+}

--- a/js_interop_gen/test/integration/interop_gen/duplicate_implements_input.d.ts
+++ b/js_interop_gen/test/integration/interop_gen/duplicate_implements_input.d.ts
@@ -1,0 +1,17 @@
+export interface Grandparent {
+	grandparentProp: string;
+}
+
+export interface ParentA extends Grandparent {
+	aProp: string;
+}
+
+export interface ParentB extends Grandparent {
+	bProp: string;
+}
+
+export interface Child extends ParentA, ParentB {
+	childProp: string;
+}
+
+export type UnionWithDuplicates = ParentA | ParentB;

--- a/js_interop_gen/test/integration/interop_gen/import_export_expected.dart
+++ b/js_interop_gen/test/integration/interop_gen/import_export_expected.dart
@@ -10,10 +10,10 @@ import 'package:meta/meta.dart' as _i2;
 external Point2D get origin;
 @_i1.JS()
 external Point3D get origin3D;
-@_i1.JS('scalarProduct')
-external V dotProduct<V extends Vector>(V v1, V v2);
-@_i1.JS('vectorProduct')
-external Vector3D crossProduct(Vector3D v1, Vector3D v2);
+@_i1.JS()
+external V scalarProduct<V extends Vector>(V v1, V v2);
+@_i1.JS()
+external Vector3D vectorProduct(Vector3D v1, Vector3D v2);
 @_i1.JS()
 external Vector3D mapTo3D(Vector2D v);
 extension type TransformerMatrix<V extends Vector2D>._(_i1.JSObject _)

--- a/js_interop_gen/test/integration/interop_gen/multiple_value_exports_expected.dart
+++ b/js_interop_gen/test/integration/interop_gen/multiple_value_exports_expected.dart
@@ -1,0 +1,20 @@
+// ignore_for_file: constant_identifier_names, lines_longer_than_80_chars
+// ignore_for_file: non_constant_identifier_names
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:js_interop' as _i1;
+
+@_i1.JS()
+external double get Alpha;
+@_i1.JS()
+external double get Beta;
+@_i1.JS()
+external double get Gamma;
+@_i1.JS()
+external void aliasFunc1(String x);
+@_i1.JS()
+external void aliasFunc2(String x);
+@_i1.JS()
+external void originalFunc(String x);
+@_i1.JS()
+external double get value;

--- a/js_interop_gen/test/integration/interop_gen/multiple_value_exports_input.d.ts
+++ b/js_interop_gen/test/integration/interop_gen/multiple_value_exports_input.d.ts
@@ -1,0 +1,10 @@
+export const value: number;
+
+export { value as Alpha };
+export { value as Beta };
+export { value as Gamma };
+
+export declare function originalFunc(x: string): void;
+
+export { originalFunc as aliasFunc1 };
+export { originalFunc as aliasFunc2 };

--- a/js_interop_gen/test/integration/interop_gen/project/output/b.dart
+++ b/js_interop_gen/test/integration/interop_gen/project/output/b.dart
@@ -8,17 +8,17 @@ import 'dart:js_interop' as _i1;
 
 import 'package:meta/meta.dart' as _i2;
 
-extension type Point2D._(_i1.JSObject _) implements Point {
-  external double x;
-
-  external double y;
-}
 extension type CoordinateSystem<P extends Point>._(_i1.JSObject _)
     implements _i1.JSObject {
   external _i1.JSArray<P> points;
 
   external P get origin;
   external void addPoint(P point);
+}
+extension type Point2D._(_i1.JSObject _) implements Point {
+  external double x;
+
+  external double y;
 }
 @_i1.JS()
 external Point2D get origin2D;

--- a/js_interop_gen/test/integration/interop_gen/sanitization_expected.dart
+++ b/js_interop_gen/test/integration/interop_gen/sanitization_expected.dart
@@ -1,0 +1,35 @@
+// ignore_for_file: camel_case_types, constant_identifier_names
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: lines_longer_than_80_chars, non_constant_identifier_names
+// ignore_for_file: unnecessary_parenthesis
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:js_interop' as _i1;
+
+extension type A._(_i1.JSObject _) implements _i1.JSObject {
+  external A();
+}
+extension type B._(_i1.JSObject _) implements _i1.JSObject {
+  external B();
+}
+typedef UnionType = AnonymousUnion_3170730;
+@_i1.JS()
+external AnonymousUnion_3170730 get unionVal;
+typedef HyphenatedEnum = AnonymousUnion_1721531;
+@_i1.JS()
+external HyphenatedEnum get hyphenatedVal;
+extension type AnonymousUnion_3170730._(_i1.JSObject _)
+    implements _i1.JSObject {
+  A get asA => (_ as A);
+
+  B get asB => (_ as B);
+}
+extension type const AnonymousUnion_1721531._(String _) {
+  static const AnonymousUnion_1721531 utf_8 = AnonymousUnion_1721531._('utf-8');
+
+  static const AnonymousUnion_1721531 utf_16le = AnonymousUnion_1721531._(
+    'utf-16le',
+  );
+
+  static const AnonymousUnion_1721531 ucs_2 = AnonymousUnion_1721531._('ucs-2');
+}

--- a/js_interop_gen/test/integration/interop_gen/sanitization_expected.dart
+++ b/js_interop_gen/test/integration/interop_gen/sanitization_expected.dart
@@ -18,6 +18,9 @@ external AnonymousUnion_3170730 get unionVal;
 typedef HyphenatedEnum = AnonymousUnion_1721531;
 @_i1.JS()
 external HyphenatedEnum get hyphenatedVal;
+typedef NumericHyphenatedEnum = AnonymousUnion_1018800;
+@_i1.JS()
+external NumericHyphenatedEnum get numericHyphenatedVal;
 extension type AnonymousUnion_3170730._(_i1.JSObject _)
     implements _i1.JSObject {
   A get asA => (_ as A);
@@ -32,4 +35,9 @@ extension type const AnonymousUnion_1721531._(String _) {
   );
 
   static const AnonymousUnion_1721531 ucs_2 = AnonymousUnion_1721531._('ucs-2');
+}
+extension type const AnonymousUnion_1018800._(String _) {
+  static const AnonymousUnion_1018800 $1_2 = AnonymousUnion_1018800._('1-2');
+
+  static const AnonymousUnion_1018800 $3_4 = AnonymousUnion_1018800._('3-4');
 }

--- a/js_interop_gen/test/integration/interop_gen/sanitization_input.d.ts
+++ b/js_interop_gen/test/integration/interop_gen/sanitization_input.d.ts
@@ -1,0 +1,7 @@
+export class A {}
+export class B {}
+export type UnionType = A | B;
+export declare const unionVal: A | B;
+
+export type HyphenatedEnum = "utf-8" | "utf-16le" | "ucs-2";
+export declare const hyphenatedVal: HyphenatedEnum;

--- a/js_interop_gen/test/integration/interop_gen/sanitization_input.d.ts
+++ b/js_interop_gen/test/integration/interop_gen/sanitization_input.d.ts
@@ -5,3 +5,6 @@ export declare const unionVal: A | B;
 
 export type HyphenatedEnum = "utf-8" | "utf-16le" | "ucs-2";
 export declare const hyphenatedVal: HyphenatedEnum;
+
+export type NumericHyphenatedEnum = "1-2" | "3-4";
+export declare const numericHyphenatedVal: NumericHyphenatedEnum;

--- a/js_interop_gen/test/integration/interop_gen/typealias_namespace_nested_expected.dart
+++ b/js_interop_gen/test/integration/interop_gen/typealias_namespace_nested_expected.dart
@@ -1,0 +1,34 @@
+// ignore_for_file: camel_case_types, constant_identifier_names
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: lines_longer_than_80_chars, non_constant_identifier_names
+// ignore_for_file: unnecessary_parenthesis
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:js_interop' as _i1;
+
+import 'package:meta/meta.dart' as _i2;
+
+extension type symlink._(_i1.JSObject _) implements _i1.JSObject {}
+@_i1.JS()
+external void mySymlink(symlink_Type type);
+extension type stream._(_i1.JSObject _) implements _i1.JSObject {
+  @_i1.JS('stream.Readable')
+  static stream_Readable Readable() => stream_Readable();
+}
+@_i1.JS('stream.Readable')
+extension type stream_Readable._(_i1.JSObject _) implements _i1.JSObject {
+  external stream_Readable();
+}
+extension type MyReadable._(_i1.JSObject _) implements stream_Readable {
+  external MyReadable();
+}
+extension type Empty._(_i1.JSObject _) implements _i1.JSObject {}
+@_i2.doNotStore
+@_i1.JS()
+external _i1.JSAny? get emptyKey;
+typedef symlink_Type = AnonymousUnion_3598178;
+extension type const AnonymousUnion_3598178._(String _) {
+  static const AnonymousUnion_3598178 dir = AnonymousUnion_3598178._('dir');
+
+  static const AnonymousUnion_3598178 file = AnonymousUnion_3598178._('file');
+}

--- a/js_interop_gen/test/integration/interop_gen/typealias_namespace_nested_input.d.ts
+++ b/js_interop_gen/test/integration/interop_gen/typealias_namespace_nested_input.d.ts
@@ -1,0 +1,14 @@
+export namespace stream {
+    export class Readable {}
+}
+
+export class MyReadable extends stream.Readable {}
+
+export namespace symlink {
+    type Type = "dir" | "file";
+}
+
+export function mySymlink(type: symlink.Type): void;
+
+export interface Empty {}
+export declare const emptyKey: keyof Empty;

--- a/js_interop_gen/test/sanitization_test.dart
+++ b/js_interop_gen/test/sanitization_test.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('node')
+library;
+
+import 'package:js_interop_gen/src/ast/types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Identifier Sanitization Tests', () {
+    test('UnionType name sanitization', () {
+      final union = UnionType(types: [], name: 'AnyRestOrJSAny|JSAny');
+      expect(union.declarationName, equals('AnyRestOrJSAnyOrJSAny'));
+
+      final unionComplex = UnionType(
+        types: [],
+        name: 'String|JSSymbolOrK@(anonymous)&String',
+      );
+      expect(
+        unionComplex.declarationName,
+        equals('StringOrJSSymbolOrK_anonymous_AndString'),
+      );
+    });
+
+    test('IntersectionType name sanitization', () {
+      final intersection = IntersectionType(
+        types: [],
+        name: 'AnyRestOrJSAny|JSAny',
+      );
+      expect(intersection.declarationName, equals('AnyRestOrJSAnyOrJSAny'));
+    });
+  });
+}

--- a/js_interop_gen/test/sanitization_test.dart
+++ b/js_interop_gen/test/sanitization_test.dart
@@ -31,5 +31,16 @@ void main() {
       );
       expect(intersection.declarationName, equals('AnyRestOrJSAnyOrJSAny'));
     });
+
+    test('Double and multiple underscore sanitization', () {
+      final unionDouble = UnionType(types: [], name: 'foo__bar');
+      expect(unionDouble.declarationName, equals('foo_bar'));
+
+      final unionMulti = UnionType(types: [], name: 'foo____bar__baz');
+      expect(unionMulti.declarationName, equals('foo_bar_baz'));
+
+      final unionMany = UnionType(types: [], name: 'a__________________b');
+      expect(unionMany.declarationName, equals('a_b'));
+    });
   });
 }


### PR DESCRIPTION
- Added surgical support in 'type_resolver.dart' for recursive parent mapping of nested namespace typealiases and direct same-file import resolutions.
- Upgraded export specifier and declaration parsers inside 'transformer.dart' using target getAliasedSymbol lookups to cleanly map and rename aliased global constants in-place.
- Added sanitization logic for union/intersection identifiers, and mapped 0-size unions/keyofs safely to primitive 'never' types.
