### PR TITLE
fix(web): restore accidentally reverted helpers and workflows from #554

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'dart-lang' }}
     steps:
-      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899
         with:
           days-before-stale: -1
           days-before-close: 14

--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: ['3.10', beta, dev]
+        sdk: ['3.12', beta, dev]
         test_config: ['-p chrome', '-p chrome -c dart2wasm']
 
     steps:

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -12,7 +12,12 @@
   extensions to support mutable operations on node lists.
 - Added `asList` to `NodeList` via extension.
 - Removed `CustomEventProviders`. Moved these events to `EventStreamProviders`.
-- Require `sdk: ^3.10.0`.
+- Require `sdk: ^3.12.0` to support `isA` on `Object?`.
+- Rename `*Glue` extensions to `*Extension`.
+- Various extension methods bridging `dart:html` APIs are added to make it
+  easier to migrate. `@Equivalence` annotations are now added to extension
+  methods to document 1-1 replacements of `dart:html` APIs.
+- Combined stream provider extensions to one per type.
 
 ## 1.1.1
 

--- a/web/lib/src/helpers.dart
+++ b/web/lib/src/helpers.dart
@@ -27,4 +27,4 @@ export 'helpers/events/events.dart';
 export 'helpers/events/providers.dart';
 export 'helpers/events/streams.dart' show ElementStream, EventStreamProvider;
 export 'helpers/extensions.dart';
-export 'helpers/lists.dart';
+export 'helpers/lists.dart' show JSImmutableListWrapper;

--- a/web/lib/src/helpers/attributes.dart
+++ b/web/lib/src/helpers/attributes.dart
@@ -1,0 +1,260 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:collection';
+import '../../web.dart';
+
+/// `dart:html` helpers that exposed `attributes` and `dataset` as `Map` types
+/// and used `getAttribute` and `setAttribute` within.
+
+abstract class AttributeMap extends MapBase<String, String> {
+  final Element _element;
+
+  AttributeMap(this._element);
+
+  @override
+  void addAll(Map<String, String> other) {
+    other.forEach((k, v) {
+      this[k] = v;
+    });
+  }
+
+  @override
+  Map<K, V> cast<K, V>() => Map.castFrom<String, String, K, V>(this);
+  @override
+  bool containsValue(Object? value) {
+    for (var v in values) {
+      if (value == v) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @override
+  String putIfAbsent(String key, String Function() ifAbsent) {
+    if (!containsKey(key)) {
+      this[key] = ifAbsent();
+    }
+    return this[key] as String;
+  }
+
+  @override
+  void clear() {
+    for (var key in keys) {
+      remove(key);
+    }
+  }
+
+  @override
+  void forEach(void Function(String key, String value) action) {
+    for (var key in keys) {
+      final value = this[key];
+      action(key, value as String);
+    }
+  }
+
+  @override
+  Iterable<String> get keys {
+    // TODO: generate a lazy collection instead.
+    final attributes = _element.attributes;
+    final keys = <String>[];
+    for (var i = 0, len = attributes.length; i < len; i++) {
+      final attr = attributes.item(i) as Attr;
+      if (_matches(attr)) {
+        keys.add(attr.name);
+      }
+    }
+    return keys;
+  }
+
+  @override
+  Iterable<String> get values {
+    // TODO: generate a lazy collection instead.
+    final attributes = _element.attributes;
+    final values = <String>[];
+    for (var i = 0, len = attributes.length; i < len; i++) {
+      final attr = attributes.item(i) as Attr;
+      if (_matches(attr)) {
+        values.add(attr.value);
+      }
+    }
+    return values;
+  }
+
+  /// Returns true if there is no {key, value} pair in the map.
+  @override
+  bool get isEmpty {
+    return length == 0;
+  }
+
+  /// Returns true if there is at least one {key, value} pair in the map.
+  @override
+  bool get isNotEmpty => !isEmpty;
+
+  /// Checks to see if the node should be included in this map.
+  bool _matches(Attr node);
+}
+
+/// Wrapper to expose [Element.attributes] as a typed map.
+class ElementAttributeMap extends AttributeMap {
+  ElementAttributeMap(super.element);
+
+  @override
+  bool containsKey(Object? key) {
+    return key is String && _element.hasAttribute(key);
+  }
+
+  @override
+  String? operator [](Object? key) {
+    return _element.getAttribute(key as String);
+  }
+
+  @override
+  void operator []=(String key, String value) {
+    _element.setAttribute(key, value);
+  }
+
+  @override
+  @pragma('dart2js:tryInline')
+  String? remove(Object? key) => key is String ? _remove(_element, key) : null;
+
+  /// The number of {key, value} pairs in the map.
+  @override
+  int get length {
+    return keys.length;
+  }
+
+  @override
+  bool _matches(Attr node) => node.namespaceURI == null;
+
+  // Inline this because almost all call sites of [remove] do not use [value],
+  // and the annotations on the `getAttribute` call allow it to be removed.
+  @pragma('dart2js:tryInline')
+  static String? _remove(Element element, String key) {
+    final value = element.getAttribute(key);
+    element.removeAttribute(key);
+    return value;
+  }
+}
+
+/// Provides a Map abstraction on top of data-* attributes, similar to the
+/// dataSet in the old DOM.
+class DataAttributeMap extends MapBase<String, String> {
+  final Map<String, String> _attributes;
+
+  DataAttributeMap(this._attributes);
+
+  @override
+  void addAll(Map<String, String> other) {
+    other.forEach((k, v) {
+      this[k] = v;
+    });
+  }
+
+  @override
+  Map<K, V> cast<K, V>() => Map.castFrom<String, String, K, V>(this);
+
+  @override
+  bool containsValue(Object? value) => values.any((v) => v == value);
+
+  @override
+  bool containsKey(Object? key) =>
+      _attributes.containsKey(_attr(key as String));
+
+  @override
+  String? operator [](Object? key) => _attributes[_attr(key as String)];
+
+  @override
+  void operator []=(String key, String value) {
+    _attributes[_attr(key)] = value;
+  }
+
+  @override
+  String putIfAbsent(String key, String Function() ifAbsent) =>
+      _attributes.putIfAbsent(_attr(key), ifAbsent);
+
+  @override
+  String? remove(Object? key) => _attributes.remove(_attr(key as String));
+
+  @override
+  void clear() {
+    // Needs to operate on a snapshot since we are mutating the collection.
+    for (var key in keys) {
+      remove(key);
+    }
+  }
+
+  @override
+  void forEach(void Function(String key, String value) action) {
+    _attributes.forEach((String key, String value) {
+      if (_matches(key)) {
+        action(_strip(key), value);
+      }
+    });
+  }
+
+  @override
+  Iterable<String> get keys {
+    final keys = <String>[];
+    _attributes.forEach((String key, String value) {
+      if (_matches(key)) {
+        keys.add(_strip(key));
+      }
+    });
+    return keys;
+  }
+
+  @override
+  Iterable<String> get values {
+    final values = <String>[];
+    _attributes.forEach((String key, String value) {
+      if (_matches(key)) {
+        values.add(value);
+      }
+    });
+    return values;
+  }
+
+  @override
+  int get length => keys.length;
+
+  @override
+  bool get isEmpty => length == 0;
+
+  @override
+  bool get isNotEmpty => !isEmpty;
+
+  // Helpers.
+  String _attr(String key) => 'data-${_toHyphenedName(key)}';
+  bool _matches(String key) => key.startsWith('data-');
+  String _strip(String key) => _toCamelCase(key.substring(5));
+
+  /// Converts a string name with hyphens into an identifier, by removing
+  /// hyphens and capitalizing the following letter. Optionally [startUppercase]
+  /// to capitalize the first letter.
+  String _toCamelCase(String hyphenedName, {bool startUppercase = false}) {
+    final segments = hyphenedName.split('-');
+    final start = startUppercase ? 0 : 1;
+    for (var i = start; i < segments.length; i++) {
+      final segment = segments[i];
+      if (segment.isNotEmpty) {
+        // Character between 'a'..'z' mapped to 'A'..'Z'
+        segments[i] = '${segment[0].toUpperCase()}${segment.substring(1)}';
+      }
+    }
+    return segments.join();
+  }
+
+  /// Reverse of [toCamelCase].
+  String _toHyphenedName(String word) {
+    final sb = StringBuffer();
+    for (var i = 0; i < word.length; i++) {
+      final lower = word[i].toLowerCase();
+      if (word[i] != lower && i > 0) sb.write('-');
+      sb.write(lower);
+    }
+    return sb.toString();
+  }
+}

--- a/web/lib/src/helpers/cross_origin.dart
+++ b/web/lib/src/helpers/cross_origin.dart
@@ -5,6 +5,7 @@
 import 'dart:js_interop';
 
 import '../dom.dart' show HTMLIFrameElement, Location, Window;
+import 'equivalence.dart';
 
 // The Dart runtime does not allow this to be typed as any better than `JSAny?`.
 extension type _CrossOriginWindow(JSAny? any) {
@@ -174,30 +175,55 @@ extension CrossOriginContentWindowExtension on HTMLIFrameElement {
 /// objects.
 extension CrossOriginWindowExtension on Window {
   @JS('open')
-  external JSAny? _open(String url);
+  external JSAny? _open([String url, String target, String features]);
 
   /// A [CrossOriginWindow] wrapper of the value returned from calling
-  /// [Window.open] with [url].
-  CrossOriginWindow? openCrossOrigin(String url) =>
-      CrossOriginWindow._create(_open(url));
+  /// [Window.open].
+  ///
+  /// If any of [url], [target], or [features] are null, only passes the args
+  /// before the first null parameter to [Window.open].
+  @Equivalence(type: 'Window', member: 'open')
+  CrossOriginWindow? openCrossOrigin([
+    String? url,
+    String? target,
+    String? features,
+  ]) {
+    JSAny? any;
+    if (url == null) {
+      any = _open();
+    } else if (target == null) {
+      any = _open(url);
+    } else if (features == null) {
+      any = _open(url, target);
+    } else {
+      any = _open(url, target, features);
+    }
+    return CrossOriginWindow._create(any);
+  }
+
   @JS('opener')
   external JSAny? get _opener;
 
   /// A [CrossOriginWindow] wrapper of the [Window.opener] value of this
   /// cross-origin window.
+  @Equivalence(type: 'Window', member: 'opener')
   CrossOriginWindow? get openerCrossOrigin =>
       CrossOriginWindow._create(_opener);
+
   @JS('parent')
   external JSAny? get _parent;
 
   /// A [CrossOriginWindow] wrapper of the [Window.parent] value of this
   /// cross-origin window.
+  @Equivalence(type: 'Window', member: 'parent')
   CrossOriginWindow? get parentCrossOrigin =>
       CrossOriginWindow._create(_parent);
+
   @JS('top')
   external JSAny? get _top;
 
   /// A [CrossOriginWindow] wrapper of the [Window.top] value of this
   /// cross-origin window.
+  @Equivalence(type: 'Window', member: 'top')
   CrossOriginWindow? get topCrossOrigin => CrossOriginWindow._create(_top);
 }

--- a/web/lib/src/helpers/css_class_set.dart
+++ b/web/lib/src/helpers/css_class_set.dart
@@ -1,0 +1,540 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:collection';
+
+import '../../web.dart';
+
+/// A Set that stores the CSS class names for an element.
+abstract class CssClassSet implements Set<String> {
+  /// Adds the class [value] to the element if it is not on it, removes it if it
+  /// is.
+  ///
+  /// If [shouldAdd] is true, then we always add that [value] to the element. If
+  /// [shouldAdd] is false then we always remove [value] from the element.
+  ///
+  /// If this corresponds to one element, returns `true` if [value] is present
+  /// after the operation, and returns `false` if [value] is absent after the
+  /// operation.
+  ///
+  /// If this CssClassSet corresponds to many elements, `false` is always
+  /// returned.
+  ///
+  /// [value] must be a valid 'token' representing a single class, i.e. a
+  /// non-empty string containing no whitespace.  To toggle multiple classes,
+  /// use [toggleAll].
+  bool toggle(String value, [bool? shouldAdd]);
+
+  /// Returns true if classes cannot be added or removed from this
+  /// [CssClassSet].
+  bool get frozen;
+
+  /// Determine if this element contains the class [value].
+  ///
+  /// This is the Dart equivalent of jQuery's
+  /// [hasClass](http://api.jquery.com/hasClass/).
+  ///
+  /// [value] must be a valid 'token' representing a single class, i.e. a
+  /// non-empty string containing no whitespace.
+  @override
+  bool contains(Object? value);
+
+  /// Add the class [value] to element.
+  ///
+  /// [add] and [addAll] are the Dart equivalent of jQuery's
+  /// [addClass](http://api.jquery.com/addClass/).
+  ///
+  /// If this CssClassSet corresponds to one element. Returns true if [value]
+  /// was added to the set, otherwise false.
+  ///
+  /// If this CssClassSet corresponds to many elements, `false` is always
+  /// returned.
+  ///
+  /// [value] must be a valid 'token' representing a single class, i.e. a
+  /// non-empty string containing no whitespace.  To add multiple classes use
+  /// [addAll].
+  @override
+  bool add(String value);
+
+  /// Remove the class [value] from element, and return true on successful
+  /// removal.
+  ///
+  /// [remove] and [removeAll] are the Dart equivalent of jQuery's
+  /// [removeClass](http://api.jquery.com/removeClass/).
+  ///
+  /// [value] must be a valid 'token' representing a single class, i.e. a
+  /// non-empty string containing no whitespace.  To remove multiple classes,
+  /// use [removeAll].
+  @override
+  bool remove(Object? value);
+
+  /// Add all classes specified in [iterable] to element.
+  ///
+  /// [add] and [addAll] are the Dart equivalent of jQuery's
+  /// [addClass](http://api.jquery.com/addClass/).
+  ///
+  /// Each element of [iterable] must be a valid 'token' representing a single
+  /// class, i.e. a non-empty string containing no whitespace.
+  @override
+  void addAll(Iterable<String> iterable);
+
+  /// Remove all classes specified in [iterable] from element.
+  ///
+  /// [remove] and [removeAll] are the Dart equivalent of jQuery's
+  /// [removeClass](http://api.jquery.com/removeClass/).
+  ///
+  /// Each element of [iterable] must be a valid 'token' representing a single
+  /// class, i.e. a non-empty string containing no whitespace.
+  @override
+  void removeAll(Iterable<Object?> iterable);
+
+  /// Toggles all classes specified in [iterable] on element.
+  ///
+  /// Iterate through [iterable]'s items, and add it if it is not on it, or
+  /// remove it if it is. This is the Dart equivalent of jQuery's
+  /// [toggleClass](http://api.jquery.com/toggleClass/). If [shouldAdd] is true,
+  /// then we always add all the classes in [iterable] element. If [shouldAdd]
+  /// is false then we always remove all the classes in [iterable] from the
+  /// element.
+  ///
+  /// Each element of [iterable] must be a valid 'token' representing a single
+  /// class, i.e. a non-empty string containing no whitespace.
+  void toggleAll(Iterable<String> iterable, [bool? shouldAdd]);
+}
+
+abstract class CssClassSetImpl extends SetBase<String> implements CssClassSet {
+  static final RegExp _validTokenRE = RegExp(r'^\S+$');
+
+  String _validateToken(String value) {
+    if (_validTokenRE.hasMatch(value)) return value;
+    throw ArgumentError.value(value, 'value', 'Not a valid class token');
+  }
+
+  @override
+  String toString() {
+    return readClasses().join(' ');
+  }
+
+  /// Adds the class [value] to the element if it is not on it, removes it if it
+  /// is.
+  ///
+  /// If [shouldAdd] is true, then we always add that [value] to the element. If
+  /// [shouldAdd] is false then we always remove [value] from the element.
+  @override
+  bool toggle(String value, [bool? shouldAdd]) {
+    _validateToken(value);
+    final s = readClasses();
+    var result = false;
+    shouldAdd ??= !s.contains(value);
+    if (shouldAdd) {
+      s.add(value);
+      result = true;
+    } else {
+      s.remove(value);
+    }
+    writeClasses(s);
+    return result;
+  }
+
+  /// Returns true if classes cannot be added or removed from this
+  /// [CssClassSet].
+  @override
+  bool get frozen => false;
+
+  @override
+  Iterator<String> get iterator => readClasses().iterator;
+
+  @override
+  void forEach(void Function(String element) f) {
+    readClasses().forEach(f);
+  }
+
+  @override
+  String join([String separator = '']) => readClasses().join(separator);
+
+  @override
+  Iterable<T> map<T>(T Function(String e) f) => readClasses().map<T>(f);
+
+  @override
+  Iterable<String> where(bool Function(String element) f) =>
+      readClasses().where(f);
+
+  @override
+  Iterable<T> expand<T>(Iterable<T> Function(String element) f) =>
+      readClasses().expand<T>(f);
+
+  @override
+  bool every(bool Function(String element) f) => readClasses().every(f);
+
+  @override
+  bool any(bool Function(String element) test) => readClasses().any(test);
+
+  @override
+  bool get isEmpty => readClasses().isEmpty;
+
+  @override
+  bool get isNotEmpty => readClasses().isNotEmpty;
+
+  @override
+  int get length => readClasses().length;
+
+  @override
+  String reduce(String Function(String value, String element) combine) {
+    return readClasses().reduce(combine);
+  }
+
+  @override
+  T fold<T>(
+    T initialValue,
+    T Function(T previousValue, String element) combine,
+  ) {
+    return readClasses().fold<T>(initialValue, combine);
+  }
+
+  /// Determine if this element contains the class [value].
+  ///
+  /// This is the Dart equivalent of jQuery's
+  /// [hasClass](http://api.jquery.com/hasClass/).
+  @override
+  bool contains(Object? value) {
+    if (value is! String) return false;
+    _validateToken(value);
+    return readClasses().contains(value);
+  }
+
+  /// Lookup from the Set interface. Not interesting for a String set.
+  @override
+  String? lookup(Object? value) => contains(value) ? value as String : null;
+
+  /// Add the class [value] to element.
+  ///
+  /// This is the Dart equivalent of jQuery's
+  /// [addClass](http://api.jquery.com/addClass/).
+  @override
+  bool add(String value) {
+    _validateToken(value);
+    // TODO - figure out if we need to do any validation here
+    // or if the browser natively does enough.
+    return modify((Set<String> s) => s.add(value)) ?? false;
+  }
+
+  /// Remove the class [value] from element, and return true on successful
+  /// removal.
+  ///
+  /// This is the Dart equivalent of jQuery's
+  /// [removeClass](http://api.jquery.com/removeClass/).
+  @override
+  bool remove(Object? value) {
+    if (value is! String) return false;
+    _validateToken(value);
+    final s = readClasses();
+    final result = s.remove(value);
+    writeClasses(s);
+    return result;
+  }
+
+  /// Add all classes specified in [iterable] to element.
+  ///
+  /// This is the Dart equivalent of jQuery's
+  /// [addClass](http://api.jquery.com/addClass/).
+  @override
+  void addAll(Iterable<String> iterable) {
+    // TODO - see comment above about validation.
+    modify((s) => s.addAll(iterable.map(_validateToken)));
+  }
+
+  /// Remove all classes specified in [iterable] from element.
+  ///
+  /// This is the Dart equivalent of jQuery's
+  /// [removeClass](http://api.jquery.com/removeClass/).
+  @override
+  void removeAll(Iterable<Object?> iterable) {
+    modify((s) => s.removeAll(iterable));
+  }
+
+  /// Toggles all classes specified in [iterable] on element.
+  ///
+  /// Iterate through [iterable]'s items, and add it if it is not on it, or
+  /// remove it if it is. This is the Dart equivalent of jQuery's
+  /// [toggleClass](http://api.jquery.com/toggleClass/). If [shouldAdd] is true,
+  /// then we always add all the classes in [iterable] element. If [shouldAdd]
+  /// is false then we always remove all the classes in [iterable] from the
+  /// element.
+  @override
+  void toggleAll(Iterable<String> iterable, [bool? shouldAdd]) {
+    for (var e in iterable) {
+      toggle(e, shouldAdd);
+    }
+  }
+
+  @override
+  void retainAll(Iterable<Object?> elements) {
+    modify((s) => s.retainAll(elements));
+  }
+
+  @override
+  void removeWhere(bool Function(String name) test) {
+    modify((s) => s.removeWhere(test));
+  }
+
+  @override
+  void retainWhere(bool Function(String name) test) {
+    modify((s) => s.retainWhere(test));
+  }
+
+  @override
+  bool containsAll(Iterable<Object?> other) => readClasses().containsAll(other);
+
+  @override
+  Set<String> intersection(Set<Object?> other) =>
+      readClasses().intersection(other);
+
+  @override
+  Set<String> union(Set<String> other) => readClasses().union(other);
+
+  @override
+  Set<String> difference(Set<Object?> other) => readClasses().difference(other);
+
+  @override
+  String get first => readClasses().first;
+
+  @override
+  String get last => readClasses().last;
+
+  @override
+  String get single => readClasses().single;
+
+  @override
+  List<String> toList({bool growable = true}) =>
+      readClasses().toList(growable: growable);
+
+  @override
+  Set<String> toSet() => readClasses().toSet();
+
+  @override
+  Iterable<String> take(int n) => readClasses().take(n);
+
+  @override
+  Iterable<String> takeWhile(bool Function(String value) test) =>
+      readClasses().takeWhile(test);
+
+  @override
+  Iterable<String> skip(int n) => readClasses().skip(n);
+
+  @override
+  Iterable<String> skipWhile(bool Function(String value) test) =>
+      readClasses().skipWhile(test);
+
+  @override
+  String firstWhere(
+    bool Function(String value) test, {
+    String Function()? orElse,
+  }) => readClasses().firstWhere(test, orElse: orElse);
+
+  @override
+  String lastWhere(
+    bool Function(String value) test, {
+    String Function()? orElse,
+  }) => readClasses().lastWhere(test, orElse: orElse);
+
+  @override
+  String singleWhere(
+    bool Function(String value) test, {
+    String Function()? orElse,
+  }) => readClasses().singleWhere(test, orElse: orElse);
+
+  @override
+  String elementAt(int index) => readClasses().elementAt(index);
+
+  @override
+  void clear() {
+    // TODO(sra): Do this without reading the classes.
+    modify((s) => s.clear());
+  }
+
+  /// Helper method used to modify the set of css classes on this element.
+  ///
+  ///   f - callback with:
+  ///   s - a Set of all the css class name currently on this element.
+  ///
+  ///   After f returns, the modified set is written to the
+  ///       className property of this element.
+  T modify<T>(T Function(Set<String>) f) {
+    final s = readClasses();
+    final ret = f(s);
+    writeClasses(s);
+    return ret;
+  }
+
+  /// Read the class names from the Element class property, and put them into a
+  /// set (duplicates are discarded). This is intended to be overridden by
+  /// specific implementations.
+  Set<String> readClasses();
+
+  /// Join all the elements of a set into one string and write
+  /// back to the element.
+  /// This is intended to be overridden by specific implementations.
+  void writeClasses(Set<String> s);
+}
+
+class ElementCssClassSet extends CssClassSetImpl {
+  final Element _element;
+
+  ElementCssClassSet(this._element);
+
+  @override
+  Set<String> readClasses() {
+    final s = <String>{};
+    final classname = _element.className;
+
+    for (final name in classname.split(' ')) {
+      final trimmed = name.trim();
+      if (trimmed.isNotEmpty) {
+        s.add(trimmed);
+      }
+    }
+    return s;
+  }
+
+  @override
+  void writeClasses(Set<String> s) {
+    _element.className = s.join(' ');
+  }
+
+  @override
+  int get length => _element.classList.length;
+
+  @override
+  bool get isEmpty => length == 0;
+
+  @override
+  bool get isNotEmpty => length != 0;
+
+  @override
+  void clear() {
+    _element.className = '';
+  }
+
+  @override
+  bool contains(Object? value) {
+    return _contains(_element, value);
+  }
+
+  @override
+  bool add(String value) {
+    return _add(_element, value);
+  }
+
+  @override
+  bool remove(Object? value) {
+    return value is String && _remove(_element, value);
+  }
+
+  @override
+  bool toggle(String value, [bool? shouldAdd]) {
+    return _toggle(_element, value, shouldAdd);
+  }
+
+  @override
+  void addAll(Iterable<String> iterable) {
+    _addAll(_element, iterable);
+  }
+
+  @override
+  void removeAll(Iterable<Object?> iterable) {
+    _removeAll(_element, iterable);
+  }
+
+  @override
+  void retainAll(Iterable<Object?> elements) {
+    _removeWhere(_element, elements.toSet().contains, false);
+  }
+
+  @override
+  void removeWhere(bool Function(String name) test) {
+    _removeWhere(_element, test, true);
+  }
+
+  @override
+  void retainWhere(bool Function(String name) test) {
+    _removeWhere(_element, test, false);
+  }
+
+  static bool _contains(Element element, Object? value) {
+    return value is String && element.classList.contains(value);
+  }
+
+  @pragma('dart2js:tryInline')
+  static bool _add(Element element, String value) {
+    final list = element.classList;
+    // Compute returned result independently of action upon the set.
+    final added = !list.contains(value); // ** side-effects can be ignored
+    list.add(value);
+    return added;
+  }
+
+  @pragma('dart2js:tryInline')
+  static bool _remove(Element element, String value) {
+    final list = element.classList;
+    final removed = list.contains(value); // ** side-effects can be ignored
+    list.remove(value);
+    return removed;
+  }
+
+  static bool _toggle(Element element, String value, bool? shouldAdd) {
+    // There is no value that can be passed as the second argument of
+    // DomTokenList.toggle that behaves the same as passing one argument.
+    // `null` is seen as false, meaning 'remove'.
+    return shouldAdd == null
+        ? _toggleDefault(element, value)
+        : _toggleOnOff(element, value, shouldAdd);
+  }
+
+  static bool _toggleDefault(Element element, String value) {
+    final list = element.classList;
+    return list.toggle(value);
+  }
+
+  static bool _toggleOnOff(Element element, String value, bool? shouldAdd) {
+    final list = element.classList;
+    if (shouldAdd ?? false) {
+      list.add(value);
+      return true;
+    } else {
+      list.remove(value);
+      return false;
+    }
+  }
+
+  static void _addAll(Element element, Iterable<String> iterable) {
+    final list = element.classList;
+    for (var value in iterable) {
+      list.add(value);
+    }
+  }
+
+  static void _removeAll(Element element, Iterable<Object?> iterable) {
+    final list = element.classList;
+    for (var value in iterable) {
+      list.remove(value as String);
+    }
+  }
+
+  static void _removeWhere(
+    Element element,
+    bool Function(String name) test,
+    bool doRemove,
+  ) {
+    final list = element.classList;
+    var i = 0;
+    while (i < list.length) {
+      final item = list.item(i)!;
+      if (doRemove == test(item)) {
+        list.remove(item);
+      } else {
+        ++i;
+      }
+    }
+  }
+}

--- a/web/lib/src/helpers/css_rect.dart
+++ b/web/lib/src/helpers/css_rect.dart
@@ -1,0 +1,340 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:math';
+
+import '../../web.dart';
+
+// `dart:html` helpers for CSS rectangles.
+
+/// Class representing a
+/// [length measurement](https://developer.mozilla.org/en-US/docs/Web/CSS/length)
+/// in CSS.
+class Dimension {
+  num _value;
+  String _unit;
+
+  /// Set this CSS Dimension to a percentage `value`.
+  Dimension.percent(this._value) : _unit = '%';
+
+  /// Set this CSS Dimension to a pixel `value`.
+  Dimension.px(this._value) : _unit = 'px';
+
+  /// Set this CSS Dimension to a pica `value`.
+  Dimension.pc(this._value) : _unit = 'pc';
+
+  /// Set this CSS Dimension to a point `value`.
+  Dimension.pt(this._value) : _unit = 'pt';
+
+  /// Set this CSS Dimension to an inch `value`.
+  Dimension.inch(this._value) : _unit = 'in';
+
+  /// Set this CSS Dimension to a centimeter `value`.
+  Dimension.cm(this._value) : _unit = 'cm';
+
+  /// Set this CSS Dimension to a millimeter `value`.
+  Dimension.mm(this._value) : _unit = 'mm';
+
+  /// Set this CSS Dimension to the specified number of ems.
+  ///
+  /// 1em is equal to the current font size. (So 2ems is equal to double the font
+  /// size). This is useful for producing website layouts that scale nicely with
+  /// the user's desired font size.
+  Dimension.em(this._value) : _unit = 'em';
+
+  /// Set this CSS Dimension to the specified number of x-heights.
+  ///
+  /// One ex is equal to the x-height of a font's baseline to its mean line,
+  /// generally the height of the letter "x" in the font, which is usually about
+  /// half the font-size.
+  Dimension.ex(this._value) : _unit = 'ex';
+
+  /// Construct a Dimension object from the valid, simple CSS string `cssValue`
+  /// that represents a distance measurement.
+  ///
+  /// This constructor is intended as a convenience method for working with
+  /// simplistic CSS length measurements. Non-numeric values such as `auto` or
+  /// `inherit` or invalid CSS will cause this constructor to throw a
+  /// FormatError.
+  Dimension.css(String cssValue) : _unit = '', _value = 0 {
+    if (cssValue == '') cssValue = '0px';
+    if (cssValue.endsWith('%')) {
+      _unit = '%';
+    } else {
+      _unit = cssValue.substring(cssValue.length - 2);
+    }
+    if (cssValue.contains('.')) {
+      _value = double.parse(
+        cssValue.substring(0, cssValue.length - _unit.length),
+      );
+    } else {
+      _value = int.parse(cssValue.substring(0, cssValue.length - _unit.length));
+    }
+  }
+
+  /// Print out the CSS String representation of this value.
+  @override
+  String toString() {
+    return '$_value$_unit';
+  }
+
+  /// Return a unitless, numerical value of this CSS value.
+  num get value => _value;
+}
+
+/// A class for representing CSS dimensions.
+///
+/// In contrast to the more general purpose [Rectangle] class, this class's
+/// values are mutable, so one can change the height of an element
+/// programmatically.
+///
+/// _Important_ _note_: use of these methods will perform CSS calculations that
+/// can trigger a browser reflow. Therefore, use of these properties _during_ an
+/// animation frame is discouraged. See also:
+/// [Browser Reflow](https://developers.google.com/speed/articles/reflow)
+abstract class CssRect implements Rectangle<num> {
+  final Element _element;
+
+  CssRect(this._element);
+
+  @override
+  num get left;
+
+  @override
+  num get top;
+
+  /// The height of this rectangle.
+  ///
+  /// This is equivalent to the `height` function in jQuery and the calculated
+  /// `height` CSS value, converted to a dimensionless num in pixels. Unlike
+  /// [Element.getBoundingClientRect], `height` will return the same numerical
+  /// height if the element is hidden or not.
+  @override
+  num get height;
+
+  /// The width of this rectangle.
+  ///
+  /// This is equivalent to the `width` function in jQuery and the calculated
+  /// `width` CSS value, converted to a dimensionless num in pixels. Unlike
+  /// [Element.getBoundingClientRect], `width` will return the same numerical
+  /// width if the element is hidden or not.
+  @override
+  num get width;
+
+  /// Set the height to `newHeight`.
+  ///
+  /// newHeight can be either a [num] representing the height in pixels or a
+  /// [Dimension] object. Values of newHeight that are less than zero are
+  /// converted to effectively setting the height to 0. This is equivalent to the
+  /// `height` function in jQuery and the calculated `height` CSS value,
+  /// converted to a num in pixels.
+  ///
+  /// Note that only the content height can actually be set via this method.
+  set height(dynamic newHeight) {
+    throw UnsupportedError('Can only set height for content rect.');
+  }
+
+  /// Set the current computed width in pixels of this element.
+  ///
+  /// newWidth can be either a [num] representing the width in pixels or a
+  /// [Dimension] object. This is equivalent to the `width` function in jQuery
+  /// and the calculated
+  /// `width` CSS value, converted to a dimensionless num in pixels.
+  ///
+  /// Note that only the content width can be set via this method.
+  set width(dynamic newWidth) {
+    throw UnsupportedError('Can only set width for content rect.');
+  }
+
+  /// Return a value that is used to modify the initial height or width
+  /// measurement of an element. Depending on the value (ideally an enum) passed
+  /// to augmentingMeasurement, we may need to add or subtract margin, padding,
+  /// or border values, depending on the measurement we're trying to obtain.
+  num _addOrSubtractToBoxModel(
+    List<String> dimensions,
+    String augmentingMeasurement,
+  ) {
+    // getComputedStyle always returns pixel values (hence, computed), so we're
+    // always dealing with pixels in this method.
+    final styles = _element.getComputedStyle();
+
+    num val = 0;
+
+    for (var measurement in dimensions) {
+      // The border-box and default box model both exclude margin in the regular
+      // height/width calculation, so add it if we want it for this measurement.
+      if (augmentingMeasurement == _MARGIN) {
+        val += Dimension.css(
+          styles.getPropertyValue('$augmentingMeasurement-$measurement'),
+        ).value;
+      }
+
+      // The border-box includes padding and border, so remove it if we want
+      // just the content itself.
+      if (augmentingMeasurement == _CONTENT) {
+        val -= Dimension.css(
+          styles.getPropertyValue('$_PADDING-$measurement'),
+        ).value;
+      }
+
+      // At this point, we don't wan't to augment with border or margin,
+      // so remove border.
+      if (augmentingMeasurement != _MARGIN) {
+        val -= Dimension.css(
+          styles.getPropertyValue('border-$measurement-width'),
+        ).value;
+      }
+    }
+    return val;
+  }
+
+  // TODO(jacobr): these methods are duplicated from _RectangleBase in dart:math
+  // Ideally we would provide a RectangleMixin class that provides this
+  // implementation. In an ideal world we would exp
+  /// The x-coordinate of the right edge.
+  @override
+  num get right => left + width;
+
+  /// The y-coordinate of the bottom edge.
+  @override
+  num get bottom => top + height;
+
+  @override
+  String toString() {
+    return 'Rectangle ($left, $top) $width x $height';
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is Rectangle &&
+      left == other.left &&
+      top == other.top &&
+      right == other.right &&
+      bottom == other.bottom;
+
+  @override
+  int get hashCode => Object.hash(left, top, right, bottom);
+
+  /// Computes the intersection of `this` and [other].
+  ///
+  /// The intersection of two axis-aligned rectangles, if any, is always another
+  /// axis-aligned rectangle.
+  ///
+  /// Returns the intersection of this and `other`, or `null` if they don't
+  /// intersect.
+  @override
+  Rectangle<num>? intersection(Rectangle<num> other) {
+    final x0 = max(left, other.left);
+    final x1 = min(left + width, other.left + other.width);
+
+    if (x0 <= x1) {
+      final y0 = max(top, other.top);
+      final y1 = min(top + height, other.top + other.height);
+
+      if (y0 <= y1) {
+        return Rectangle<num>(x0, y0, x1 - x0, y1 - y0);
+      }
+    }
+    return null;
+  }
+
+  /// Returns true if `this` intersects [other].
+  @override
+  bool intersects(Rectangle<num> other) {
+    return left <= other.left + other.width &&
+        other.left <= left + width &&
+        top <= other.top + other.height &&
+        other.top <= top + height;
+  }
+
+  /// Returns a new rectangle which completely contains `this` and [other].
+  @override
+  Rectangle<num> boundingBox(Rectangle<num> other) {
+    final right = max(this.left + width, other.left + other.width);
+    final bottom = max(this.top + height, other.top + other.height);
+
+    final left = min(this.left, other.left);
+    final top = min(this.top, other.top);
+
+    return Rectangle<num>(left, top, right - left, bottom - top);
+  }
+
+  /// Tests whether `this` entirely contains [another].
+  @override
+  bool containsRectangle(Rectangle<num> another) {
+    return left <= another.left &&
+        left + width >= another.left + another.width &&
+        top <= another.top &&
+        top + height >= another.top + another.height;
+  }
+
+  /// Tests whether [another] is inside or along the edges of `this`.
+  @override
+  bool containsPoint(Point<num> another) {
+    return another.x >= left &&
+        another.x <= left + width &&
+        another.y >= top &&
+        another.y <= top + height;
+  }
+
+  @override
+  Point<num> get topLeft => Point<num>(left, top);
+  @override
+  Point<num> get topRight => Point<num>(left + width, top);
+  @override
+  Point<num> get bottomRight => Point<num>(left + width, top + height);
+  @override
+  Point<num> get bottomLeft => Point<num>(left, top + height);
+}
+
+/// A rectangle representing the dimensions of the space occupied by the
+/// element's content + padding + border + margin in the
+/// [box model](http://www.w3.org/TR/CSS2/box.html).
+class MarginCssRect extends CssRect {
+  MarginCssRect(super.element);
+
+  @override
+  num get height =>
+      _element.offsetHeight + _addOrSubtractToBoxModel(_HEIGHT, _MARGIN);
+  @override
+  num get width =>
+      _element.offsetWidth + _addOrSubtractToBoxModel(_WIDTH, _MARGIN);
+
+  @override
+  num get left =>
+      _element.getBoundingClientRect().left -
+      _addOrSubtractToBoxModel(['left'], _MARGIN);
+  @override
+  num get top =>
+      _element.getBoundingClientRect().top -
+      _addOrSubtractToBoxModel(['top'], _MARGIN);
+}
+
+// ignore: non_constant_identifier_names
+final _HEIGHT = ['top', 'bottom'];
+// ignore: non_constant_identifier_names
+final _WIDTH = ['right', 'left'];
+// ignore: constant_identifier_names
+const _CONTENT = 'content';
+// ignore: constant_identifier_names
+const _PADDING = 'padding';
+// ignore: constant_identifier_names
+const _MARGIN = 'margin';
+
+/// A rectangle representing the dimensions of the space occupied by the
+/// element's content + padding + border in the
+/// [box model](http://www.w3.org/TR/CSS2/box.html).
+class BorderCssRect extends CssRect {
+  BorderCssRect(super.element);
+
+  @override
+  num get height => _element.offsetHeight;
+  @override
+  num get width => _element.offsetWidth;
+
+  @override
+  num get left => _element.getBoundingClientRect().left;
+  @override
+  num get top => _element.getBoundingClientRect().top;
+}

--- a/web/lib/src/helpers/enums.dart
+++ b/web/lib/src/helpers/enums.dart
@@ -2,7 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// Helper layer library that exposes enums commonly used from `dart:html`.
+/// Helper layer library that exposes  enum-likes commonly used from
+/// `dart:html`.
 library;
 
 import '../dom/html.dart';
@@ -212,9 +213,66 @@ abstract final class KeyCode {
   static const int NUM_MINUS = 109;
   // ignore: constant_identifier_names
   static const int NUM_PERIOD = 110;
+  // ignore: constant_identifier_names
+  static const int NUM_DIVISION = 111;
+  // ignore: constant_identifier_names
+  static const int SEMICOLON = 186;
+  // ignore: constant_identifier_names
+  static const int EQUALS = 187;
+  // ignore: constant_identifier_names
+  static const int COMMA = 188;
+  // ignore: constant_identifier_names
+  static const int DASH = 189;
+  // ignore: constant_identifier_names
+  static const int PERIOD = 190;
+  // ignore: constant_identifier_names
+  static const int SLASH = 191;
+  // ignore: constant_identifier_names
+  static const int APOSTROPHE = 192;
+  // ignore: constant_identifier_names
+  static const int OPEN_SQUARE_BRACKET = 219;
+  // ignore: constant_identifier_names
+  static const int BACKSLASH = 220;
+  // ignore: constant_identifier_names
+  static const int CLOSE_SQUARE_BRACKET = 221;
+  // ignore: constant_identifier_names
+  static const int SINGLE_QUOTE = 222;
   // Firefox (Gecko) fires this for the meta key instead of 91
   // ignore: constant_identifier_names
   static const int MAC_FF_META = 224;
+
+  static bool isCharacterKey(int keyCode) {
+    if ((keyCode >= ZERO && keyCode <= NINE) ||
+        (keyCode >= NUM_ZERO && keyCode <= NUM_MULTIPLY) ||
+        (keyCode >= A && keyCode <= Z)) {
+      return true;
+    }
+
+    // Safari sends zero key code for non-latin characters.
+    if (Device.isWebKit && keyCode == 0) {
+      return true;
+    }
+
+    return keyCode == SPACE ||
+        keyCode == QUESTION_MARK ||
+        keyCode == NUM_PLUS ||
+        keyCode == NUM_MINUS ||
+        keyCode == NUM_PERIOD ||
+        keyCode == NUM_DIVISION ||
+        keyCode == SEMICOLON ||
+        keyCode == FF_SEMICOLON ||
+        keyCode == DASH ||
+        keyCode == EQUALS ||
+        keyCode == FF_EQUALS ||
+        keyCode == COMMA ||
+        keyCode == PERIOD ||
+        keyCode == SLASH ||
+        keyCode == APOSTROPHE ||
+        keyCode == SINGLE_QUOTE ||
+        keyCode == OPEN_SQUARE_BRACKET ||
+        keyCode == BACKSLASH ||
+        keyCode == CLOSE_SQUARE_BRACKET;
+  }
 }
 
 abstract final class Device {
@@ -297,4 +355,54 @@ abstract class HttpStatus {
   static const int networkAuthenticationRequired = 511;
   // Client generated status code.
   static const int networkConnectTimeoutError = 599;
+}
+
+abstract final class NodeFilterEnum {
+  // ignore: constant_identifier_names
+  static const int SHOW_ALL = 4294967295;
+  // ignore: constant_identifier_names
+  static const int SHOW_ATTRIBUTE = 2;
+  // ignore: constant_identifier_names
+  static const int SHOW_CDATA_SECTION = 8;
+  // ignore: constant_identifier_names
+  static const int SHOW_COMMENT = 128;
+  // ignore: constant_identifier_names
+  static const int SHOW_DOCUMENT = 256;
+  // ignore: constant_identifier_names
+  static const int SHOW_DOCUMENT_FRAGMENT = 1024;
+  // ignore: constant_identifier_names
+  static const int SHOW_DOCUMENT_TYPE = 512;
+  // ignore: constant_identifier_names
+  static const int SHOW_ELEMENT = 1;
+  // ignore: constant_identifier_names
+  static const int SHOW_ENTITY = 32;
+  // ignore: constant_identifier_names
+  static const int SHOW_ENTITY_REFERENCE = 16;
+  // ignore: constant_identifier_names
+  static const int SHOW_NOTATION = 2048;
+  // ignore: constant_identifier_names
+  static const int SHOW_PROCESSING_INSTRUCTION = 64;
+  // ignore: constant_identifier_names
+  static const int SHOW_TEXT = 4;
+}
+
+final class ScrollAlignment {
+  final String _value;
+
+  const ScrollAlignment._internal(this._value);
+
+  @override
+  String toString() => 'ScrollAlignment.$_value';
+
+  /// Attempt to align the element to the top of the scrollable area.
+  // ignore: constant_identifier_names
+  static const TOP = ScrollAlignment._internal('TOP');
+
+  /// Attempt to center the element in the scrollable area.
+  // ignore: constant_identifier_names
+  static const CENTER = ScrollAlignment._internal('CENTER');
+
+  /// Attempt to align the element to the bottom of the scrollable area.
+  // ignore: constant_identifier_names
+  static const BOTTOM = ScrollAlignment._internal('BOTTOM');
 }

--- a/web/lib/src/helpers/equivalence.dart
+++ b/web/lib/src/helpers/equivalence.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Annotation to instruct users and tools of `dart:html`-equivalent members in
+/// helpers.
+///
+/// This should not be exported outside of this library.
+final class Equivalence {
+  /// If null, assumed to be a top-level member.
+  final String? type;
+
+  /// If empty, assumed to be the default constructor.
+  final String member;
+
+  /// Any additional details about potential discrepancies or warnings to the
+  /// user.
+  ///
+  /// APIs annotated with `@Equivalence` are not guaranteed to be the exact
+  /// same as their `dart:html`-equivalent.
+  final String details;
+
+  const Equivalence({
+    required this.type,
+    required this.member,
+    this.details = '',
+  });
+}

--- a/web/lib/src/helpers/events/events.dart
+++ b/web/lib/src/helpers/events/events.dart
@@ -6,7 +6,93 @@ import '../../dom.dart';
 import 'providers.dart';
 import 'streams.dart';
 
-extension ElementEventGetters on Element {
+extension AudioNodeEvents on AudioNode {
+  Stream<Event> get onEnded => EventStreamProviders.endedEvent.forTarget(this);
+}
+
+extension BroadcastChannelEvents on BroadcastChannel {
+  Stream<MessageEvent> get onMessage =>
+      EventStreamProviders.messageEvent.forTarget(this);
+}
+
+extension DocumentEvents on Document {
+  Stream<Event> get onBlur => EventStreamProviders.blurEvent.forTarget(this);
+
+  Stream<MouseEvent> get onClick =>
+      EventStreamProviders.clickEvent.forTarget(this);
+
+  Stream<MouseEvent> get onDrag =>
+      EventStreamProviders.dragEvent.forTarget(this);
+
+  Stream<MouseEvent> get onDragEnd =>
+      EventStreamProviders.dragEndEvent.forTarget(this);
+
+  Stream<MouseEvent> get onDragEnter =>
+      EventStreamProviders.dragEnterEvent.forTarget(this);
+
+  Stream<MouseEvent> get onDragLeave =>
+      EventStreamProviders.dragLeaveEvent.forTarget(this);
+
+  Stream<MouseEvent> get onDragOver =>
+      EventStreamProviders.dragOverEvent.forTarget(this);
+
+  Stream<MouseEvent> get onDragStart =>
+      EventStreamProviders.dragStartEvent.forTarget(this);
+
+  Stream<MouseEvent> get onDrop =>
+      EventStreamProviders.dropEvent.forTarget(this);
+
+  Stream<Event> get onInput => EventStreamProviders.inputEvent.forTarget(this);
+
+  Stream<KeyboardEvent> get onKeyDown =>
+      EventStreamProviders.keyDownEvent.forTarget(this);
+
+  Stream<KeyboardEvent> get onKeyUp =>
+      EventStreamProviders.keyUpEvent.forTarget(this);
+
+  Stream<Event> get onLoad => EventStreamProviders.loadEvent.forTarget(this);
+
+  Stream<MouseEvent> get onMouseDown =>
+      EventStreamProviders.mouseDownEvent.forTarget(this);
+
+  Stream<MouseEvent> get onMouseEnter =>
+      EventStreamProviders.mouseEnterEvent.forTarget(this);
+
+  Stream<MouseEvent> get onMouseLeave =>
+      EventStreamProviders.mouseLeaveEvent.forTarget(this);
+
+  Stream<MouseEvent> get onMouseMove =>
+      EventStreamProviders.mouseMoveEvent.forTarget(this);
+
+  Stream<MouseEvent> get onMouseOut =>
+      EventStreamProviders.mouseOutEvent.forTarget(this);
+
+  Stream<MouseEvent> get onMouseOver =>
+      EventStreamProviders.mouseOverEvent.forTarget(this);
+
+  Stream<MouseEvent> get onMouseUp =>
+      EventStreamProviders.mouseUpEvent.forTarget(this);
+
+  Stream<WheelEvent> get onMouseWheel =>
+      EventStreamProviders.mouseWheelEvent.forTarget(this);
+
+  Stream<TouchEvent> get onTouchCancel =>
+      EventStreamProviders.touchCancelEvent.forTarget(this);
+
+  Stream<TouchEvent> get onTouchEnd =>
+      EventStreamProviders.touchEndEvent.forTarget(this);
+
+  Stream<TouchEvent> get onTouchMove =>
+      EventStreamProviders.touchMoveEvent.forTarget(this);
+
+  Stream<TouchEvent> get onTouchStart =>
+      EventStreamProviders.touchStartEvent.forTarget(this);
+
+  Stream<Event> get onVisibilityChange =>
+      EventStreamProviders.visibilityChangeEvent.forTarget(this);
+}
+
+extension ElementEvents on Element {
   ElementStream<Event> get onAbort =>
       EventStreamProviders.abortEvent.forElement(this);
 
@@ -106,9 +192,6 @@ extension ElementEventGetters on Element {
   ElementStream<Event> get onLoad =>
       EventStreamProviders.loadEvent.forElement(this);
 
-  ElementStream<Event> get onUnload =>
-      EventStreamProviders.unloadEvent.forElement(this);
-
   ElementStream<Event> get onLoadedData =>
       EventStreamProviders.loadedDataEvent.forElement(this);
 
@@ -135,6 +218,9 @@ extension ElementEventGetters on Element {
 
   ElementStream<MouseEvent> get onMouseUp =>
       EventStreamProviders.mouseUpEvent.forElement(this);
+
+  ElementStream<WheelEvent> get onMouseWheel =>
+      EventStreamProviders.mouseWheelEvent.forElement(this);
 
   ElementStream<ClipboardEvent> get onPaste =>
       EventStreamProviders.pasteEvent.forElement(this);
@@ -205,6 +291,12 @@ extension ElementEventGetters on Element {
   ElementStream<TouchEvent> get onTouchStart =>
       EventStreamProviders.touchStartEvent.forElement(this);
 
+  ElementStream<TransitionEvent> get onTransitionEnd =>
+      EventStreamProviders.transitionEndEvent.forElement(this);
+
+  ElementStream<Event> get onUnload =>
+      EventStreamProviders.unloadEvent.forElement(this);
+
   ElementStream<Event> get onVolumeChange =>
       EventStreamProviders.volumeChangeEvent.forElement(this);
 
@@ -221,19 +313,7 @@ extension ElementEventGetters on Element {
       EventStreamProviders.wheelEvent.forElement(this);
 }
 
-extension XHRGetters on XMLHttpRequest {
-  Stream<ProgressEvent> get onLoad =>
-      EventStreamProviders.loadEvent.forTarget(this);
-  Stream<ProgressEvent> get onError =>
-      EventStreamProviders.errorEvent.forTarget(this);
-  Stream<ProgressEvent> get onProgress =>
-      EventStreamProviders.progressEvent.forTarget(this);
-
-  Stream<Event> get onReadyStateChange =>
-      EventStreamProviders.readyStateChangeEvent.forTarget(this);
-}
-
-extension EventSourceEventGetters on EventSource {
+extension EventSourceEvents on EventSource {
   Stream<Event> get onError =>
       EventStreamProviders.errorEventSourceEvent.forTarget(this);
 
@@ -243,40 +323,128 @@ extension EventSourceEventGetters on EventSource {
   Stream<Event> get onOpen => EventStreamProviders.openEvent.forTarget(this);
 }
 
-extension FileReaderEventGetters on FileReader {
+extension FileReaderEvents on FileReader {
   Stream<ProgressEvent> get onAbort =>
       EventStreamProviders.abortEvent.forTarget(this);
+
   Stream<ProgressEvent> get onError =>
       EventStreamProviders.errorEvent.forTarget(this);
+
   Stream<ProgressEvent> get onLoad =>
       EventStreamProviders.loadEvent.forTarget(this);
+
   Stream<ProgressEvent> get onLoadEnd =>
       EventStreamProviders.loadEndEvent.forTarget(this);
+
   Stream<ProgressEvent> get onLoadStart =>
       EventStreamProviders.loadStartEvent.forTarget(this);
+
   Stream<ProgressEvent> get onProgress =>
       EventStreamProviders.progressEvent.forTarget(this);
 }
 
-extension AutoElementEventGetters on AudioNode {
-  Stream<Event> get onEnded => EventStreamProviders.endedEvent.forTarget(this);
+extension FontFaceSetEvents on FontFaceSet {
+  Stream<FontFaceSetLoadEvent> get onLoadingDone =>
+      EventStreamProviders.loadingDoneEvent.forTarget(this);
 }
 
-extension WindowEventGetters on Window {
+extension PerformanceEvents on Performance {
+  Stream<Event> get onResourceTimingBufferFull =>
+      EventStreamProviders.resourceTimingBufferFull.forTarget(this);
+}
+
+extension WebSocketEvents on WebSocket {
+  Stream<CloseEvent> get onClose =>
+      EventStreamProviders.closeEvent.forTarget(this);
+
+  Stream<Event> get onError =>
+      EventStreamProviders.errorEventSourceEvent.forTarget(this);
+
+  Stream<MessageEvent> get onMessage =>
+      EventStreamProviders.messageEvent.forTarget(this);
+
+  Stream<Event> get onOpen => EventStreamProviders.openEvent.forTarget(this);
+}
+
+extension WindowEvents on Window {
+  Stream<Event> get onAnimationEnd =>
+      EventStreamProviders.animationEndEvent.forTarget(this);
+
+  Stream<BeforeUnloadEvent> get onBeforeUnload =>
+      EventStreamProviders.beforeUnloadEvent.forTarget(this);
+
+  Stream<Event> get onBlur => EventStreamProviders.blurEvent.forTarget(this);
+
+  Stream<MouseEvent> get onDrag =>
+      EventStreamProviders.dragEvent.forTarget(this);
+
+  Stream<MouseEvent> get onDragEnd =>
+      EventStreamProviders.dragEndEvent.forTarget(this);
+
+  Stream<MouseEvent> get onDragEnter =>
+      EventStreamProviders.dragEnterEvent.forTarget(this);
+
+  Stream<MouseEvent> get onDragLeave =>
+      EventStreamProviders.dragLeaveEvent.forTarget(this);
+
+  Stream<MouseEvent> get onDragOver =>
+      EventStreamProviders.dragOverEvent.forTarget(this);
+
+  Stream<MouseEvent> get onDragStart =>
+      EventStreamProviders.dragStartEvent.forTarget(this);
+
+  Stream<Event> get onFocus => EventStreamProviders.focusEvent.forTarget(this);
+
   Stream<KeyboardEvent> get onKeyDown =>
       EventStreamProviders.keyDownEvent.forTarget(this);
 
   Stream<KeyboardEvent> get onKeyPress =>
       EventStreamProviders.keyPressEvent.forTarget(this);
 
+  Stream<KeyboardEvent> get onKeyUp =>
+      EventStreamProviders.keyUpEvent.forTarget(this);
+
   Stream<Event> get onLoad => EventStreamProviders.loadEvent.forTarget(this);
 
   Stream<MessageEvent> get onMessage =>
       EventStreamProviders.messageEvent.forTarget(this);
 
+  Stream<MouseEvent> get onMouseDown =>
+      EventStreamProviders.mouseDownEvent.forTarget(this);
+
+  Stream<MouseEvent> get onMouseEnter =>
+      EventStreamProviders.mouseEnterEvent.forTarget(this);
+
+  Stream<MouseEvent> get onMouseLeave =>
+      EventStreamProviders.mouseLeaveEvent.forTarget(this);
+
+  Stream<MouseEvent> get onMouseMove =>
+      EventStreamProviders.mouseMoveEvent.forTarget(this);
+
+  Stream<MouseEvent> get onMouseOut =>
+      EventStreamProviders.mouseOutEvent.forTarget(this);
+
+  Stream<MouseEvent> get onMouseOver =>
+      EventStreamProviders.mouseOverEvent.forTarget(this);
+
+  Stream<MouseEvent> get onMouseUp =>
+      EventStreamProviders.mouseUpEvent.forTarget(this);
+
+  Stream<WheelEvent> get onMouseWheel =>
+      EventStreamProviders.mouseWheelEvent.forTarget(this);
+
   Stream<PopStateEvent> get onPopState =>
       EventStreamProviders.popStateEvent.forTarget(this);
 
+  Stream<Event> get onResize =>
+      EventStreamProviders.resizeEvent.forTarget(this);
+
+  Stream<Event> get onScroll =>
+      EventStreamProviders.scrollEvent.forTarget(this);
+
+  Stream<Event> get onStorage =>
+      EventStreamProviders.storageEvent.forTarget(this);
+
   Stream<TouchEvent> get onTouchCancel =>
       EventStreamProviders.touchCancelEvent.forTarget(this);
 
@@ -288,132 +456,21 @@ extension WindowEventGetters on Window {
 
   Stream<TouchEvent> get onTouchStart =>
       EventStreamProviders.touchStartEvent.forTarget(this);
-
-  Stream<MouseEvent> get onMouseDown =>
-      EventStreamProviders.mouseDownEvent.forTarget(this);
-
-  Stream<MouseEvent> get onMouseEnter =>
-      EventStreamProviders.mouseEnterEvent.forTarget(this);
-
-  Stream<MouseEvent> get onMouseLeave =>
-      EventStreamProviders.mouseLeaveEvent.forTarget(this);
-
-  Stream<MouseEvent> get onMouseMove =>
-      EventStreamProviders.mouseMoveEvent.forTarget(this);
-
-  Stream<MouseEvent> get onMouseOut =>
-      EventStreamProviders.mouseOutEvent.forTarget(this);
-
-  Stream<MouseEvent> get onMouseOver =>
-      EventStreamProviders.mouseOverEvent.forTarget(this);
-
-  Stream<MouseEvent> get onMouseUp =>
-      EventStreamProviders.mouseUpEvent.forTarget(this);
-
-  Stream<MouseEvent> get onDrag =>
-      EventStreamProviders.dragEvent.forTarget(this);
-
-  Stream<MouseEvent> get onDragEnd =>
-      EventStreamProviders.dragEndEvent.forTarget(this);
-
-  Stream<MouseEvent> get onDragEnter =>
-      EventStreamProviders.dragEnterEvent.forTarget(this);
-
-  Stream<MouseEvent> get onDragLeave =>
-      EventStreamProviders.dragLeaveEvent.forTarget(this);
-
-  Stream<MouseEvent> get onDragOver =>
-      EventStreamProviders.dragOverEvent.forTarget(this);
-
-  Stream<MouseEvent> get onDragStart =>
-      EventStreamProviders.dragStartEvent.forTarget(this);
-}
-
-extension DocumentEventGetters on Document {
-  Stream<TouchEvent> get onTouchCancel =>
-      EventStreamProviders.touchCancelEvent.forTarget(this);
-
-  Stream<TouchEvent> get onTouchEnd =>
-      EventStreamProviders.touchEndEvent.forTarget(this);
-
-  Stream<TouchEvent> get onTouchMove =>
-      EventStreamProviders.touchMoveEvent.forTarget(this);
-
-  Stream<TouchEvent> get onTouchStart =>
-      EventStreamProviders.touchStartEvent.forTarget(this);
-
-  Stream<MouseEvent> get onMouseDown =>
-      EventStreamProviders.mouseDownEvent.forTarget(this);
-
-  Stream<MouseEvent> get onMouseEnter =>
-      EventStreamProviders.mouseEnterEvent.forTarget(this);
-
-  Stream<MouseEvent> get onMouseLeave =>
-      EventStreamProviders.mouseLeaveEvent.forTarget(this);
-
-  Stream<MouseEvent> get onMouseMove =>
-      EventStreamProviders.mouseMoveEvent.forTarget(this);
-
-  Stream<MouseEvent> get onMouseOut =>
-      EventStreamProviders.mouseOutEvent.forTarget(this);
-
-  Stream<MouseEvent> get onMouseOver =>
-      EventStreamProviders.mouseOverEvent.forTarget(this);
-
-  Stream<MouseEvent> get onMouseUp =>
-      EventStreamProviders.mouseUpEvent.forTarget(this);
-
-  Stream<MouseEvent> get onDrag =>
-      EventStreamProviders.dragEvent.forTarget(this);
-
-  Stream<MouseEvent> get onDragEnd =>
-      EventStreamProviders.dragEndEvent.forTarget(this);
-
-  Stream<MouseEvent> get onDragEnter =>
-      EventStreamProviders.dragEnterEvent.forTarget(this);
-
-  Stream<MouseEvent> get onDragLeave =>
-      EventStreamProviders.dragLeaveEvent.forTarget(this);
-
-  Stream<MouseEvent> get onDragOver =>
-      EventStreamProviders.dragOverEvent.forTarget(this);
-
-  Stream<MouseEvent> get onDragStart =>
-      EventStreamProviders.dragStartEvent.forTarget(this);
-}
-
-extension ElementCustomEvents on Element {
-  ElementStream<WheelEvent> get onMouseWheel =>
-      EventStreamProviders.mouseWheelEvent.forElement(this);
-
-  ElementStream<TransitionEvent> get onTransitionEnd =>
-      EventStreamProviders.transitionEndEvent.forElement(this);
-}
-
-extension DocumentCustomEvents on Document {
-  Stream<Event> get onLoad => EventStreamProviders.loadEvent.forTarget(this);
-
-  Stream<WheelEvent> get onMouseWheel =>
-      EventStreamProviders.mouseWheelEvent.forTarget(this);
-
-  Stream<Event> get onVisibilityChange =>
-      EventStreamProviders.visibilityChangeEvent.forTarget(this);
-}
-
-extension WindowCustomEvents on Window {
-  Stream<WheelEvent> get onMouseWheel =>
-      EventStreamProviders.mouseWheelEvent.forTarget(this);
 
   Stream<TransitionEvent> get onTransitionEnd =>
       EventStreamProviders.transitionEndEvent.forTarget(this);
 }
 
-extension WebSocketEvents on WebSocket {
-  Stream<Event> get onOpen => EventStreamProviders.openEvent.forTarget(this);
-  Stream<MessageEvent> get onMessage =>
-      EventStreamProviders.messageEvent.forTarget(this);
-  Stream<CloseEvent> get onClose =>
-      EventStreamProviders.closeEvent.forTarget(this);
-  Stream<Event> get onError =>
-      EventStreamProviders.errorEventSourceEvent.forTarget(this);
+extension XMLHttpRequestEvents on XMLHttpRequest {
+  Stream<ProgressEvent> get onError =>
+      EventStreamProviders.errorEvent.forTarget(this);
+
+  Stream<ProgressEvent> get onLoad =>
+      EventStreamProviders.loadEvent.forTarget(this);
+
+  Stream<ProgressEvent> get onProgress =>
+      EventStreamProviders.progressEvent.forTarget(this);
+
+  Stream<Event> get onReadyStateChange =>
+      EventStreamProviders.readyStateChangeEvent.forTarget(this);
 }

--- a/web/lib/src/helpers/events/providers.dart
+++ b/web/lib/src/helpers/events/providers.dart
@@ -453,6 +453,9 @@ abstract final class EventStreamProviders {
   static const EventStreamProvider<Event> resizeEvent =
       EventStreamProvider<Event>('resize');
 
+  static const EventStreamProvider<Event> resourceTimingBufferFull =
+      EventStreamProvider<Event>('resourcetimingbufferfull');
+
   static const EventStreamProvider<SpeechRecognitionEvent> resultEvent =
       EventStreamProvider<SpeechRecognitionEvent>('result');
 

--- a/web/lib/src/helpers/extensions.dart
+++ b/web/lib/src/helpers/extensions.dart
@@ -21,22 +21,294 @@
 ///  * conversions: for example to wrap a `TouchList` as a `List<Touch>`
 library;
 
-import 'dart:convert';
+import 'dart:async';
 import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import 'dart:math' show Point, Rectangle;
 
+import '../dom.dart' as dom;
 import '../dom.dart';
+import 'attributes.dart';
+import 'css_class_set.dart';
+import 'css_rect.dart';
+import 'enums.dart';
+import 'equivalence.dart';
+import 'events/events.dart';
 import 'lists.dart';
+import 'maps.dart';
+import 'string_console.dart';
 
 export 'cross_origin.dart'
     show CrossOriginContentWindowExtension, CrossOriginWindowExtension;
 
-extension HTMLCanvasElementGlue on HTMLCanvasElement {
+extension BlobExtension on Blob {
+  @Equivalence(type: 'Blob', member: '')
+  Blob createBlob(List<Object?> blobParts, [String? type, String? endings]) {
+    final jsParts = blobParts.jsify() as JSArray<JSAny>;
+    if (type != null && endings != null) {
+      return Blob(jsParts, BlobPropertyBag(type: type, endings: endings));
+    } else if (type != null) {
+      return Blob(jsParts, BlobPropertyBag(type: type));
+    } else if (endings != null) {
+      return Blob(jsParts, BlobPropertyBag(endings: endings));
+    } else {
+      return Blob(jsParts);
+    }
+  }
+}
+
+extension CanvasRenderingContext2DExtension on CanvasRenderingContext2D {
+  @Equivalence(type: 'CanvasRenderingContext2D', member: 'drawImageScaled')
+  @JS('drawImage')
+  external void drawImageScaled(
+    CanvasImageSource image,
+    double dx,
+    double dy,
+    double dw,
+    double dh,
+  );
+}
+
+extension CSSStyleDeclarationExtension on CSSStyleDeclaration {
+  @Equivalence(
+    type: 'CssStyleDeclaration',
+    member: 'setProperty',
+    details:
+        "'dart:html' used to check for support and add vendor prefixes for "
+        'properties, but modern browsers no longer need this.',
+  )
+  void setPropertyNullable(String property, String? value, [String? priority]) {
+    value ??= '';
+    priority ??= '';
+    setProperty(property, value, priority);
+  }
+}
+
+extension DataTransferExtension on DataTransfer {
+  @Equivalence(type: 'DataTransfer', member: 'files')
+  List<File>? get filesAsList => has('files') ? files.asList() : null;
+}
+
+extension DocumentExtension on Document {
+  @Equivalence(
+    type: 'Document',
+    member: 'querySelectorAll',
+    details:
+        "'dart:html' returned a `_FrozenElementList`, which provided "
+        'additional helpers like stream listeners.',
+  )
+  JSImmutableListWrapper<NodeList, T> querySelectorAllAsList<T extends Element>(
+    String selectors,
+  ) => JSImmutableListWrapper<NodeList, T>(querySelectorAll(selectors));
+}
+
+extension DOMRectExtension on DOMRect {
+  Rectangle<double> asRectangle() => Rectangle(left, top, width, height);
+}
+
+extension DOMRectListExtension on DOMRectList {
+  List<Rectangle> asList() => JSImmutableListWrapper<DOMRectList, DOMRect>(
+    this,
+  ).map((rect) => rect.asRectangle()).toList();
+}
+
+extension DOMStringMapExtension on DOMStringMap {
+  bool containsKey(String name) => (this as JSObject)[name] != null;
+}
+
+/// Contains subtype members that were moved up in `dart:html` to `Element`.
+extension ElementExtension on Element {
+  @Equivalence(type: 'Element', member: 'appendText')
+  void appendText(String text) => append(Text(text));
+
+  @Equivalence(type: 'Element', member: 'attributes')
+  set attributes(Map<String, String> value) {
+    final attrs = attributesAsMap;
+    attrs.clear();
+    value.forEach((key, val) {
+      attrs[key] = val;
+    });
+  }
+
+  @Equivalence(type: 'Element', member: 'attributes')
+  Map<String, String> get attributesAsMap => ElementAttributeMap(this);
+
+  @Equivalence(type: 'Element', member: 'blur')
+  external void blur();
+
+  @Equivalence(type: 'Element', member: 'borderEdge')
+  CssRect get borderEdge => BorderCssRect(this);
+
+  /// Returns [children] as a modifiable [List].
+  @Equivalence(type: 'Element', member: 'children')
+  List<Element> get childrenAsList => HTMLCollectionListWrapper(this, children);
+
+  @Equivalence(type: 'Element', member: 'classes')
+  CssClassSet get classes => ElementCssClassSet(this);
+
+  @Equivalence(type: 'Element', member: 'click')
+  external void click();
+
+  @Equivalence(type: 'Element', member: 'dataset')
+  Map<String, String> get dataset => DataAttributeMap(attributesAsMap);
+
+  @Equivalence(type: 'Element', member: 'dir')
+  external String? get dir;
+  @Equivalence(type: 'Element', member: 'dir')
+  external set dir(String? s);
+
+  @Equivalence(type: 'Element', member: 'documentOffset')
+  Point get documentOffset => offsetTo(document.documentElement!);
+
+  @Equivalence(type: 'Element', member: 'focus')
+  external void focus();
+
+  @Equivalence(type: 'Element', member: 'getComputedStyle')
+  CSSStyleDeclaration getComputedStyle([String? pseudoElement]) {
+    pseudoElement ??= '';
+    return window.getComputedStyle(this, pseudoElement);
+  }
+
+  @Equivalence(type: 'Element', member: 'innerText')
+  external String get innerText;
+  @Equivalence(type: 'Element', member: 'innerText')
+  external set innerText(String value);
+
+  @Equivalence(type: 'Element', member: 'marginEdge')
+  CssRect get marginEdge => MarginCssRect(this);
+
+  @Equivalence(type: 'Element', member: 'matchesWithAncestors')
+  bool matchesWithAncestors(String selectors) {
+    var elem = this as Element?;
+    while (elem != null) {
+      if (elem.matches(selectors)) return true;
+      elem = elem.parent;
+    }
+    return false;
+  }
+
+  @Equivalence(type: 'Element', member: 'namespaceUri')
+  String? get namespaceUri => namespaceURI;
+
+  @Equivalence(type: 'Element', member: 'offset')
+  Rectangle get offset =>
+      Rectangle(offsetLeft, offsetTop, offsetWidth, offsetHeight);
+
+  @Equivalence(type: 'Element', member: 'offsetHeight')
+  external int get offsetHeight;
+
+  @Equivalence(type: 'Element', member: 'offsetLeft')
+  external int get offsetLeft;
+
+  @Equivalence(type: 'Element', member: 'offsetParent')
+  external Element? get offsetParent;
+
+  @Equivalence(type: 'Element', member: 'offsetTo')
+  Point offsetTo(Element parent) =>
+      ElementExtension._offsetToHelper(this, parent);
+
+  static Point _offsetToHelper(Element? current, Element parent) {
+    // We're hopping from _offsetParent_ to offsetParent (not just parent), so
+    // offsetParent, "tops out" at BODY. But people could conceivably pass in
+    // the document.documentElement and I want it to return an absolute offset,
+    // so we have the special case checking for HTML.
+    final sameAsParent = current.strictEquals(parent).toDart;
+    final foundAsParent = sameAsParent || parent.tagName == 'HTML';
+    if (current == null || sameAsParent) {
+      if (foundAsParent) return const Point(0, 0);
+      throw ArgumentError(
+        'Specified element is not a transitive offset parent of this element.',
+      );
+    }
+    final parentOffset = current.offsetParent;
+    final p = ElementExtension._offsetToHelper(parentOffset, parent);
+    return Point(p.x + current.offsetLeft, p.y + current.offsetTop);
+  }
+
+  @Equivalence(type: 'Element', member: 'offsetTop')
+  external int get offsetTop;
+
+  @Equivalence(type: 'Element', member: 'offsetWidth')
+  external int get offsetWidth;
+
+  @Equivalence(
+    type: 'Element',
+    member: 'querySelectorAll',
+    details:
+        "'dart:html' returned a `_FrozenElementList`, which provided "
+        'additional helpers like stream listeners.',
+  )
+  JSImmutableListWrapper<NodeList, T> querySelectorAllAsList<T extends Element>(
+    String selectors,
+  ) => JSImmutableListWrapper<NodeList, T>(querySelectorAll(selectors));
+
+  @Equivalence(type: 'Element', member: 'scrollIntoViewIfNeeded')
+  @JS('scrollIntoViewIfNeeded')
+  external void scrollIntoViewIfNeeded([bool? centerIfNeeded]);
+
+  @Equivalence(type: 'Element', member: 'scrollIntoView')
+  void scrollIntoViewWithAlignment([ScrollAlignment? alignment]) {
+    final hasScrollIntoViewIfNeeded = has('scrollIntoViewIfNeeded');
+    if (alignment == ScrollAlignment.TOP) {
+      scrollIntoView(true.toJS);
+    } else if (alignment == ScrollAlignment.BOTTOM) {
+      scrollIntoView(false.toJS);
+    } else if (hasScrollIntoViewIfNeeded) {
+      if (alignment == ScrollAlignment.CENTER) {
+        scrollIntoViewIfNeeded(true);
+      } else {
+        scrollIntoViewIfNeeded();
+      }
+    } else {
+      scrollIntoView();
+    }
+  }
+
+  @Equivalence(type: 'Element', member: 'style')
+  external CSSStyleDeclaration get style;
+
+  @Equivalence(type: 'Element', member: 'tabIndex')
+  external int? get tabIndex;
+  @Equivalence(type: 'Element', member: 'tabIndex')
+  external set tabIndex(int? v);
+}
+
+extension EventExtension on Event {
+  @Equivalence(type: 'Event', member: 'path')
+  List<EventTarget> get path =>
+      has('composedPath') ? composedPath().toDart : [];
+}
+
+extension EventTargetExtension on EventTarget {
+  @Equivalence(type: 'EventTarget', member: 'addEventListener')
+  void addEventListenerWithFunction<T extends Event>(
+    String type,
+    void Function(T) onData, [
+    bool useCapture = false,
+  ]) {
+    addEventListener(type, onData.toJS, useCapture.toJS);
+  }
+}
+
+extension FileListExtension on FileList {
+  List<File> asList() => JSImmutableListWrapper<FileList, File>(this);
+
+  @Equivalence(type: 'FileList', member: 'elementAt')
+  File elementAt(int i) => item(i)!;
+
+  @Equivalence(type: 'FileList', member: 'first')
+  File get first => item(0)!;
+
+  @Equivalence(type: 'FileList', member: 'isEmpty')
+  bool get isEmpty => length == 0;
+}
+
+extension HTMLCanvasElementExtension on HTMLCanvasElement {
+  @Equivalence(type: 'CanvasElement', member: 'context2D')
   CanvasRenderingContext2D get context2D =>
       getContext('2d') as CanvasRenderingContext2D;
 
-  String toDataUrl(String type, [num? quality]) =>
-      (quality == null) ? toDataURL(type) : toDataURL(type, quality.toJS);
-
+  @Equivalence(type: 'CanvasElement', member: 'getContext3d')
   RenderingContext? getContext3d({
     bool alpha = true,
     bool depth = true,
@@ -45,55 +317,197 @@ extension HTMLCanvasElementGlue on HTMLCanvasElement {
     bool premultipliedAlpha = true,
     bool preserveDrawingBuffer = false,
   }) {
-    final options = {
-      'alpha': alpha,
-      'depth': depth,
-      'stencil': stencil,
-      'antialias': antialias,
-      'premultipliedAlpha': premultipliedAlpha,
-      'preserveDrawingBuffer': preserveDrawingBuffer,
-    }.jsify();
+    final options = JSObject()
+      ..['alpha'] = alpha.toJS
+      ..['depth'] = depth.toJS
+      ..['stencil'] = stencil.toJS
+      ..['antialias'] = antialias.toJS
+      ..['premultipliedAlpha'] = premultipliedAlpha.toJS
+      ..['preserveDrawingBuffer'] = preserveDrawingBuffer.toJS;
     return getContext('webgl', options) ??
         getContext('experimental-webgl', options);
   }
+
+  @Equivalence(type: 'CanvasElement', member: 'toBlob')
+  Future<Blob> toBlobFuture([String? type, num? quality]) {
+    final completer = Completer<Blob>();
+    void getBlob(Blob value) {
+      completer.complete(value);
+    }
+
+    final blobCallback = getBlob.toJS;
+    if (type == null) {
+      toBlob(blobCallback);
+    } else if (quality == null) {
+      toBlob(blobCallback, type);
+    } else {
+      toBlob(blobCallback, type, quality.toJS);
+    }
+    return completer.future;
+  }
+
+  @Equivalence(type: 'CanvasElement', member: 'toDataUrl')
+  String toDataUrl([String type = 'image/png', num? quality]) =>
+      (quality == null) ? toDataURL(type) : toDataURL(type, quality.toJS);
 }
 
-extension XMLHttpRequestGlue on XMLHttpRequest {
-  /// Returns all response headers as a key-value map.
-  ///
-  /// Multiple values for the same header key can be combined into one,
-  /// separated by a comma and a space.
-  ///
-  /// See: https://xhr.spec.whatwg.org/#the-getresponseheader()-method
-  Map<String, String> get responseHeaders {
-    // from Closure's goog.net.Xhrio.getResponseHeaders.
-    final headers = <String, String>{};
-    final headersString = getAllResponseHeaders();
-    for (final header in LineSplitter.split(
-      headersString,
-    ).where((header) => header.isNotEmpty)) {
-      final split = header.split(': ');
-      if (split.length <= 1) {
-        continue;
-      }
-      final key = split[0].toLowerCase();
-      final value = split.skip(1).join(': ');
-      headers.update(
-        key,
-        (oldValue) => '$oldValue, $value',
-        ifAbsent: () => value,
-      );
+extension HTMLCollectionExtension on HTMLCollection {
+  List<Element> asList() =>
+      JSImmutableListWrapper<HTMLCollection, Element>(this);
+
+  @Equivalence(type: 'HtmlCollection', member: 'first')
+  Element get first => item(0)!;
+
+  @Equivalence(type: 'HtmlCollection', member: 'isEmpty')
+  bool get isEmpty => length == 0;
+
+  @Equivalence(type: 'HtmlCollection', member: 'isNotEmpty')
+  bool get isNotEmpty => length > 0;
+
+  @Equivalence(type: 'HtmlCollection', member: 'last')
+  Element get last => item(length - 1)!;
+
+  @Equivalence(type: 'HtmlCollection', member: 'single')
+  Element get single {
+    if (length != 1) {
+      throw ArgumentError('HTMLCollection must have exactly one element.');
     }
-    return headers;
+    return item(0)!;
+  }
+
+  @Equivalence(type: 'HtmlCollection', member: '[]')
+  Element operator [](int i) => item(i)!;
+}
+
+extension HTMLInputElementExtension on HTMLInputElement {
+  @Equivalence(type: 'InputElement', member: 'files')
+  List<File>? get filesAsList => files?.asList();
+}
+
+extension MouseEventExtension on MouseEvent {
+  @Equivalence(type: 'MouseEvent', member: 'client')
+  Point get client => Point(clientX, clientY);
+
+  // This really belongs on the `DragEvent` subtype, but `dart:html` moved it
+  // up.
+  @Equivalence(type: 'MouseEvent', member: 'dataTransfer')
+  external DataTransfer get dataTransfer;
+
+  @Equivalence(type: 'MouseEvent', member: 'page')
+  Point get page => Point(pageX, pageY);
+
+  @Equivalence(type: 'MouseEvent', member: 'screen')
+  Point get screen => Point(screenX, screenY);
+}
+
+extension NodeExtension on Node {
+  @Equivalence(type: 'Node', member: 'append')
+  Node append(Node other) => appendChild(other);
+
+  /// Returns [childNodes] as a modifiable [List].
+  @Equivalence(type: 'Node', member: 'childNodes')
+  List<Node> get childNodesAsList => NodeListListWrapper(this, childNodes);
+
+  @Equivalence(type: 'Node', member: 'clone')
+  Node clone(bool? deep) => cloneNode(deep ?? false);
+
+  @Equivalence(type: 'Node', member: 'insertAllBefore')
+  void insertAllBefore(Iterable<Node> newNodes, Node child) {
+    // `toList` to avoid potential infinite recursion if `newNodes` is a wrapper
+    // around this `Node`.
+    for (var node in newNodes.toList()) {
+      insertBefore(node, child);
+    }
+  }
+
+  @Equivalence(type: 'Node', member: 'nextNode')
+  Node? get nextNode => nextSibling;
+
+  @Equivalence(type: 'Node', member: 'nodes')
+  List<Node> get nodes => childNodesAsList;
+
+  @Equivalence(type: 'Node', member: 'nodes')
+  set nodes(Iterable<Node> value) {
+    final copy = value.toList();
+    text = '';
+    for (final node in copy) {
+      appendChild(node);
+    }
+  }
+
+  @Equivalence(type: 'Node', member: 'parent')
+  Element? get parent => parentElement;
+
+  @Equivalence(type: 'Node', member: 'remove')
+  void remove() {
+    final parent = parentNode;
+    if (parent != null) {
+      parent.removeChild(this);
+    }
+  }
+
+  @Equivalence(type: 'Node', member: 'text')
+  String? get text => textContent;
+
+  @Equivalence(type: 'Node', member: 'text')
+  set text(String? s) => textContent = s;
+}
+
+extension NodeListExtension on NodeList {
+  /// Returns node list as an immutable [List].
+  List<T> asList<T extends Node>() => JSImmutableListWrapper<NodeList, T>(this);
+
+  @Equivalence(type: 'NodeList', member: 'elementAt')
+  Node elementAt(int i) => item(i)!;
+
+  @Equivalence(type: 'NodeList', member: 'isEmpty')
+  bool get isEmpty => length == 0;
+}
+
+extension StorageExtension on Storage {
+  @Equivalence(type: 'Storage', member: '[]')
+  String? operator [](String key) => getItem(key);
+
+  @Equivalence(type: 'Storage', member: '[]=')
+  void operator []=(String key, String value) => setItem(key, value);
+}
+
+extension TouchEventExtension on TouchEvent {
+  // Safari still doesn't support `TouchEvent`s:
+  // https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent
+  @Equivalence(type: 'TouchEvent', member: 'supported')
+  static bool get supported {
+    try {
+      TouchEvent('touches');
+      return true;
+    } catch (e) {
+      return false;
+    }
   }
 }
 
-extension URLToUri on URL {
-  /// Converts this to a Dart [Uri] object.
-  Uri get toDart => Uri.parse(toString());
+extension TouchExtension on Touch {
+  @Equivalence(type: 'Touch', member: 'client')
+  Point get client => Point(clientX, clientY);
+
+  @Equivalence(type: 'Touch', member: 'page')
+  Point get page => Point(pageX, pageY);
 }
 
-extension UriToURL on Uri {
+extension TouchListExtension on TouchList {
+  List<Touch> asList() => JSImmutableListWrapper<TouchList, Touch>(this);
+
+  @Equivalence(type: 'TouchList', member: 'elementAt')
+  Touch elementAt(int i) => item(i)!;
+
+  @Equivalence(type: 'TouchList', member: 'first')
+  Touch get first => item(0)!;
+
+  @Equivalence(type: 'TouchList', member: 'isEmpty')
+  bool get isEmpty => length == 0;
+}
+
+extension UriExtension on Uri {
   /// Converts this to a JavaScript [URL] object.
   ///
   /// Throws an [ArgumentError] if this isn't an absolute URL, since [URL] can
@@ -107,7 +521,127 @@ extension UriToURL on Uri {
   }
 }
 
-extension NodeListExtension on NodeList {
-  /// Returns node list as a modifiable [List].
-  List<Element> get asList => JSImmutableListWrapper(this);
+extension URLExtension on URL {
+  /// Converts this to a Dart [Uri] object.
+  Uri get toDart => Uri.parse(toString());
 }
+
+extension WindowExtension on Window {
+  @Equivalence(type: 'Window', member: 'animationFrame')
+  Future<num> get animationFrame {
+    final completer = Completer<num>.sync();
+    void getTimestamp(num timestamp) {
+      completer.complete(timestamp);
+    }
+
+    requestAnimationFrame(getTimestamp.toJS);
+    return completer.future;
+  }
+
+  @Equivalence(type: 'Window', member: 'console')
+  StringConsole get console => StringConsole(dom.console);
+
+  @Equivalence(type: 'Window', member: 'localStorage')
+  StorageMap get localStorageAsMap => StorageMap(localStorage);
+
+  @Equivalence(type: 'Window', member: 'sessionStorage')
+  StorageMap get sessionStorageAsMap => StorageMap(sessionStorage);
+}
+
+extension XMLHttpRequestExtension on XMLHttpRequest {
+  @Equivalence(type: 'HttpRequest', member: 'request')
+  static Future<XMLHttpRequest> request(
+    String url, {
+    String? method,
+    bool? withCredentials,
+    String? responseType,
+    String? mimeType,
+    Map<String, String>? requestHeaders,
+    Object? sendData,
+    void Function(ProgressEvent e)? onProgress,
+  }) {
+    final completer = Completer<XMLHttpRequest>();
+
+    final xhr = XMLHttpRequest();
+    method ??= 'GET';
+    xhr.open(method, url, true);
+
+    if (withCredentials != null) {
+      xhr.withCredentials = withCredentials;
+    }
+
+    if (responseType != null) {
+      xhr.responseType = responseType;
+    }
+
+    if (mimeType != null) {
+      xhr.overrideMimeType(mimeType);
+    }
+
+    if (requestHeaders != null) {
+      requestHeaders.forEach(
+        // Can't tear-off a JS interop function.
+        // ignore: unnecessary_lambdas
+        (String name, String value) => xhr.setRequestHeader(name, value),
+      );
+    }
+
+    if (onProgress != null) {
+      xhr.onProgress.listen(onProgress);
+    }
+
+    xhr.onLoad.listen((e) {
+      final status = xhr.status;
+      final accepted = status >= 200 && status < 300;
+      final fileUri = status == 0;
+      final notModified = status == 304;
+      final unknownRedirect = status > 307 && status < 400;
+
+      if (accepted || fileUri || notModified || unknownRedirect) {
+        completer.complete(xhr);
+      } else {
+        completer.completeError(e);
+      }
+    });
+
+    xhr.onError.listen(completer.completeError);
+
+    if (sendData != null) {
+      // `dart:html` accepted any value before. These values may be typed data,
+      // so we may need to do a `jsify`. However, it's faster to check if it's a
+      // JS value before we attempt a `jsify`, so do that.
+      xhr.send(sendData.isA<JSAny?>() ? sendData as JSAny? : sendData.jsify());
+    } else {
+      xhr.send();
+    }
+
+    return completer.future;
+  }
+
+  @Equivalence(type: 'HttpRequest', member: 'responseHeaders')
+  Map<String, String> get responseHeaders {
+    final headers = <String, String>{};
+    final headersString = getAllResponseHeaders();
+    final headersList = headersString.split('\r\n');
+    for (final header in headersList) {
+      if (header.isEmpty) {
+        continue;
+      }
+      final splitIdx = header.indexOf(': ');
+      if (splitIdx == -1) {
+        continue;
+      }
+      final key = header.substring(0, splitIdx).toLowerCase();
+      final value = header.substring(splitIdx + 2);
+      if (headers.containsKey(key)) {
+        headers[key] = '${headers[key]}, $value';
+      } else {
+        headers[key] = value;
+      }
+    }
+    return headers;
+  }
+}
+
+@Equivalence(type: null, member: 'querySelector')
+Element? querySelector(String selectors) => document.querySelector(selectors);

--- a/web/lib/src/helpers/lists.dart
+++ b/web/lib/src/helpers/lists.dart
@@ -68,19 +68,18 @@ class JSImmutableListWrapper<T extends JSObject, U extends JSObject>
   }
 }
 
-/// This mixin exists to avoid repetition in `NodeListListWrapper` and `HTMLCollectionListWrapper`
-/// It can be also used for `HTMLCollection` and `NodeList` that is
+/// This mixin exists to avoid repetition in `NodeListListWrapper` and
+/// `HTMLCollectionListWrapper` It can be also used for `HTMLCollection` and
+/// `NodeList` that is
 /// [live](https://developer.mozilla.org/en-US/docs/Web/API/NodeList#live_vs._static_nodelists)
-/// and can be safely modified at runtime.
-/// This requires an instance of `P`, a container that elements would be added to or removed from.
+/// and can be safely modified at runtime. This requires an instance of `P`, a
+/// container that elements would be added to or removed from.
 abstract mixin class _LiveNodeListMixin<P extends Node, U extends Node> {
   P get _parent;
   _JSList<U> get _list;
 
   bool contains(Object? element) {
-    // TODO(srujzs): migrate this ifs to isJSAny once we have it
-    // ignore: invalid_runtime_check_with_js_interop_types
-    if ((element is JSAny?) && (element?.isA<Node>() ?? false)) {
+    if (element?.isA<Node>() ?? false) {
       if ((element as Node).parentNode.strictEquals(_parent).toDart) {
         return true;
       }
@@ -260,7 +259,7 @@ class _NodeListIterator<E> implements Iterator<E> {
 /// modifiable list interface and allows easier DOM manipulation.
 /// This is loosely based on `_ChildrenElementList` from `dart:html` to
 /// preserve compatibility.
-class _HTMLCollectionListWrapper
+class HTMLCollectionListWrapper
     with ListMixin<Element>, _LiveNodeListMixin<Element, Element> {
   @override
   final Element _parent;
@@ -269,7 +268,7 @@ class _HTMLCollectionListWrapper
 
   final HTMLCollection _htmlCollection;
 
-  _HTMLCollectionListWrapper(this._parent, this._htmlCollection);
+  HTMLCollectionListWrapper(this._parent, this._htmlCollection);
 
   @override
   ///See [_NodeListIterator] for information.
@@ -310,10 +309,10 @@ class _HTMLCollectionListWrapper
   }
 }
 
-/// Wrapper for `NodeList` returned from `childNodes` that implements modifiable list interface and allows easier DOM manipulation.
-/// This is loosely based on `_ChildNodeListLazy` from `dart:html` to preserve compatibility
-class _NodeListListWrapper
-    with ListMixin<Node>, _LiveNodeListMixin<Node, Node> {
+/// Wrapper for `NodeList` returned from `childNodes` that implements modifiable
+/// list interface and allows easier DOM manipulation. This is loosely based on
+/// `_ChildNodeListLazy` from `dart:html` to preserve compatibility
+class NodeListListWrapper with ListMixin<Node>, _LiveNodeListMixin<Node, Node> {
   @override
   final Node _parent;
   @override
@@ -321,10 +320,10 @@ class _NodeListListWrapper
 
   final NodeList _nodeList;
 
-  _NodeListListWrapper(this._parent, this._nodeList);
+  NodeListListWrapper(this._parent, this._nodeList);
 
-  @override
   ///See [_NodeListIterator] for information.
+  @override
   Iterator<Node> get iterator => _NodeListIterator(this);
 
   @override
@@ -360,17 +359,4 @@ class _NodeListListWrapper
       _parent.removeChild(_parent.firstChild!);
     }
   }
-}
-
-extension NodeExtension on Node {
-  /// Returns [childNodes] as a modifiable [List].
-  /// This replaces functionality of the `nodes` getter from `dart:html`.
-  List<Node> get childNodesAsList => _NodeListListWrapper(this, childNodes);
-}
-
-extension ElementExtension on Element {
-  /// Returns [children] as a modifiable [List].
-  /// This replaces functionality of the `children` getter from `dart:html`.
-  List<Element> get childrenAsList =>
-      _HTMLCollectionListWrapper(this, children);
 }

--- a/web/lib/src/helpers/maps.dart
+++ b/web/lib/src/helpers/maps.dart
@@ -1,0 +1,86 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:collection';
+import '../../web.dart';
+
+// Common `Map` types that were exposed through `dart:html`.
+
+class StorageMap with MapMixin<String, String> implements Map<String, String> {
+  final Storage _storage;
+
+  StorageMap(this._storage);
+
+  @override
+  void addAll(Map<String, String> other) {
+    other.forEach((k, v) {
+      this[k] = v;
+    });
+  }
+
+  @override
+  bool containsValue(Object? value) => values.any((e) => e == value);
+
+  @override
+  bool containsKey(Object? key) => _storage.getItem(key as String) != null;
+
+  @override
+  String? operator [](Object? key) => _storage.getItem(key as String);
+
+  @override
+  void operator []=(String key, String value) {
+    _storage.setItem(key, value);
+  }
+
+  @override
+  String putIfAbsent(String key, String Function() ifAbsent) {
+    if (!containsKey(key)) this[key] = ifAbsent();
+    return this[key] as String;
+  }
+
+  @override
+  String? remove(Object? key) {
+    final value = this[key];
+    _storage.removeItem(key as String);
+    return value;
+  }
+
+  @override
+  void clear() => _storage.clear();
+
+  @override
+  void forEach(void Function(String key, String value) action) {
+    var i = 0;
+    while (true) {
+      final key = _storage.key(i);
+      if (key == null) return;
+
+      action(key, this[key]!);
+      i++;
+    }
+  }
+
+  @override
+  Iterable<String> get keys {
+    final keys = <String>[];
+    forEach((k, v) => keys.add(k));
+    return keys;
+  }
+
+  @override
+  Iterable<String> get values {
+    final values = <String>[];
+    forEach((k, v) => values.add(v));
+    return values;
+  }
+
+  @override
+  int get length => _storage.length;
+
+  @override
+  bool get isEmpty => _storage.key(0) == null;
+
+  @override
+  bool get isNotEmpty => !isEmpty;
+}

--- a/web/lib/src/helpers/string_console.dart
+++ b/web/lib/src/helpers/string_console.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:js_interop';
+
+import '../../web.dart';
+
+// Console wrapper that exposes similar APIs as `dart:html` but with Strings for
+// migration convenience.
+
+extension type StringConsole($Console _) implements JSObject {
+  @JS('assert')
+  external void assertCondition(bool condition, [String? s]);
+  external void clear();
+  external void debug(String s);
+  external void error(String s);
+  external void info(String s);
+  external void log(String s);
+  external void trace(String s);
+  external void warn(String s);
+  external void time(String s);
+  external void timeLog(String s);
+  external void timeEnd(String s);
+  // Non-standard.
+  external void profile(String s);
+  external void profileEnd(String s);
+}


### PR DESCRIPTION
Restores the helper files, alphabetization changes, and workflow configurations that were accidentally wiped out during the merge/rebase of PR #554.

Specifically re-applies:
- Srujan's alphabetization work (#557)
- Migration helpers and SDK 3.12 workflow bump (#552)

No changes were made to the js_interop_gen package, preserving the dogfooded generator work from #554.