### PR TITLE
Only pass langVersion if snapshot

### DIFF
--- a/web_generator/bin/update_idl_bindings.dart
+++ b/web_generator/bin/update_idl_bindings.dart
@@ -70,11 +70,10 @@ $_usage''');
   }
 
   if (argResult['compile'] as bool) {
-    final webPkgLangVersion = isSnapshot
-        ? dartLanguageVersion.toString()
-        : await getPackageLanguageVersion(_webPackagePath);
+    final generatorPkgLangVersion = isSnapshot
+        ? dartLanguageVersion.toString() : null;
     // Compile Dart to Javascript.
-    await compileDartMain(langVersion: webPkgLangVersion);
+    await compileDartMain(langVersion: generatorPkgLangVersion);
   }
 
   // TODO: we should consider moving package:web related stuff to a separate,

--- a/web_generator/bin/update_idl_bindings.dart
+++ b/web_generator/bin/update_idl_bindings.dart
@@ -70,10 +70,12 @@ $_usage''');
   }
 
   if (argResult['compile'] as bool) {
-    final generatorPkgLangVersion = isSnapshot
-        ? dartLanguageVersion.toString() : null;
     // Compile Dart to Javascript.
-    await compileDartMain(langVersion: generatorPkgLangVersion);
+    if (isSnapshot) {
+      await compileDartMain(langVersion: dartLanguageVersion.toString());
+    } else {
+      await compileDartMain();
+    }
   }
 
   // TODO: we should consider moving package:web related stuff to a separate,


### PR DESCRIPTION
`dart bin/update_idl_bindings.dart` is currently broken when running locally because we use the web package path to determine the language version to run the generator. Because that's 3.10, use of private named parameters throws. We could pass the generator version here instead, but that logic is already in compileDartMain, so only pass the lang version if we're running from snapshot.

CI avoided this because it's presumably running from snapshot.
