### PR TITLE
test(js_interop_gen): reformat integration test goldens for dart_style 3.1.12

### DIFF
--- a/js_interop_gen/test/integration/interop_gen/duplicate_references_expected.dart
+++ b/js_interop_gen/test/integration/interop_gen/duplicate_references_expected.dart
@@ -41,12 +41,14 @@ extension type _AnonymousFunction_2123872<
 }
 extension type _AnonymousFunction_1873223<TResult2 extends _i1.JSAny?>._(
   _i1.JSFunction _
-) implements _i1.JSFunction {
+)
+    implements _i1.JSFunction {
   external AnonymousUnion_3247291<TResult2> call(_i1.JSAny? reason);
 }
 extension type AnonymousUnion_3247291<TResult2 extends _i1.JSAny?>._(
   _i1.JSAny _
-) implements _i1.JSAny {
+)
+    implements _i1.JSAny {
   TResult2 get asTResult2 => (_ as TResult2);
 
   Thenable<TResult2> get asThenableOfTResult2 => (_ as Thenable<TResult2>);
@@ -61,7 +63,8 @@ extension type AnonymousUnion_3555654<
 }
 extension type AnonymousUnion_2658987<TResult1 extends _i1.JSAny?>._(
   _i1.JSAny _
-) implements _i1.JSAny {
+)
+    implements _i1.JSAny {
   TResult1 get asTResult1 => (_ as TResult1);
 
   Thenable<TResult1> get asThenableOfTResult1 => (_ as Thenable<TResult1>);

--- a/js_interop_gen/test/integration/interop_gen/generic_union_casting_expected.dart
+++ b/js_interop_gen/test/integration/interop_gen/generic_union_casting_expected.dart
@@ -21,7 +21,8 @@ extension type CustomEventB<T extends _i1.JSAny?>._(_i1.JSObject _)
 typedef MixedEventUnion<T extends _i1.JSAny?> = AnonymousUnion_3597781<T>;
 extension type AnonymousUnion_3597781<T extends _i1.JSAny?>._(
   Event<CustomEventA<T>> _
-) implements Event<CustomEventA<T>> {
+)
+    implements Event<CustomEventA<T>> {
   Event<CustomEventA<T>> get asEventOfCustomEventAOfT => _;
 
   Event<CustomEventB<T>> get asEventOfCustomEventBOfT =>

--- a/js_interop_gen/test/integration/interop_gen/generic_union_expected.dart
+++ b/js_interop_gen/test/integration/interop_gen/generic_union_expected.dart
@@ -19,7 +19,8 @@ extension type OtherContainer<T extends _i1.JSAny?>._(_i1.JSObject _)
 }
 extension type TargetClassWithGenericUnion<T extends _i1.JSAny?>._(
   _i1.JSObject _
-) implements _i1.JSObject {
+)
+    implements _i1.JSObject {
   external AnonymousUnion_3899151<T> field;
 }
 extension type AnonymousUnion_3063943._(_i1.JSAny _) implements _i1.JSAny {

--- a/js_interop_gen/test/integration/interop_gen/module_generic_param_expected.dart
+++ b/js_interop_gen/test/integration/interop_gen/module_generic_param_expected.dart
@@ -16,6 +16,7 @@ extension type Event<T extends _i1.JSAny?>._(_i1.JSObject _)
 }
 extension type _AnonymousFunction_6204725<T extends _i1.JSAny?>._(
   _i1.JSFunction _
-) implements _i1.JSFunction {
+)
+    implements _i1.JSFunction {
   external _i1.JSAny? call(T e);
 }

--- a/js_interop_gen/test/integration/interop_gen/namespaces_expected.dart
+++ b/js_interop_gen/test/integration/interop_gen/namespaces_expected.dart
@@ -248,7 +248,8 @@ extension type EnterpriseApp_DataServices._(_i1.JSObject _)
 @_i1.JS('EnterpriseApp.DataServices.IDataService')
 extension type EnterpriseApp_DataServices_IDataService<T extends _i1.JSAny?>._(
   _i1.JSObject _
-) implements _i1.JSObject {
+)
+    implements _i1.JSObject {
   external _i1.JSArray<T> getAll();
   external T getById(String id);
   external void save(T item);

--- a/js_interop_gen/test/integration/interop_gen/ts_typing_expected.dart
+++ b/js_interop_gen/test/integration/interop_gen/ts_typing_expected.dart
@@ -231,7 +231,8 @@ extension type const KeyOf_TypeOf_MyEnum._(String _) {
 }
 extension type _AnonymousFunction_3794666<T extends _i1.JSAny?>._(
   _i1.JSFunction _
-) implements _i1.JSFunction {
+)
+    implements _i1.JSFunction {
   external ComposedType<T> call(T object);
 }
 extension type ComposedType<T extends _i1.JSAny?>._(_i1.JSObject _)

--- a/js_interop_gen/test/integration/interop_gen/union_constraint_override_expected.dart
+++ b/js_interop_gen/test/integration/interop_gen/union_constraint_override_expected.dart
@@ -20,7 +20,8 @@ extension type HolderB<T extends SpecializedBound>._(_i1.JSObject _)
 typedef ConstraintUnion<T extends SpecializedBound> = AnonymousUnion_7450886<T>;
 extension type AnonymousUnion_7450886<T extends SpecializedBound>._(
   _i1.JSObject _
-) implements _i1.JSObject {
+)
+    implements _i1.JSObject {
   HolderA<T> get asHolderAOfT => (_ as HolderA<T>);
 
   HolderB<T> get asHolderBOfT => (_ as HolderB<T>);


### PR DESCRIPTION
Update integration test expected golden files to match the multi-line
implements clause formatting introduced in dart_style 3.1.10+.

- Reformat 7 *_expected.dart test fixtures in js_interop_gen.
- Fixes CI test failures in package:js_interop_gen scheduled workflows.
