### PR TITLE
Add `Event` and `requestAnimationFrame` helpers and fix `createBlob`

### DIFF
--- a/web/lib/src/helpers/extensions.dart
+++ b/web/lib/src/helpers/extensions.dart
@@ -108,6 +108,7 @@ extension CustomEventExtension on CustomEvent {
         // and store it in a separate property, but that's not symmetrical with
         // `dart:html` and therefore may break partial migrations, so we're
         // forced to leverage `detail`.
+        // ignore: invalid_runtime_check_with_js_interop_types
         detail.toExternalReference as JSAny?,
       );
     }
@@ -120,6 +121,7 @@ extension CustomEventExtension on CustomEvent {
     if (detail.isA<JSAny?>()) {
       return detail.dartify();
     }
+    // ignore: invalid_runtime_check_with_js_interop_types
     return (detail as ExternalDartReference).toDartObject;
   }
 }
@@ -437,7 +439,7 @@ extension HTMLInputElementExtension on HTMLInputElement {
 
 extension KeyboardEventExtension on KeyboardEvent {
   @Equivalence(type: 'KeyboardEvent', member: '')
-  KeyboardEvent createKeyboardEvent(
+  static KeyboardEvent createKeyboardEvent(
     String type, {
     Window? view,
     bool canBubble = true,
@@ -449,11 +451,9 @@ extension KeyboardEventExtension on KeyboardEvent {
     bool shiftKey = false,
     bool metaKey = false,
   }) {
-    if (view == null) {
-      view = window;
-    }
+    view ??= window;
     location ??= keyLocation ?? 1;
-    KeyboardEvent event = KeyboardEvent(
+    final event = KeyboardEvent(
       type,
       KeyboardEventInit(
         view: view,

--- a/web/lib/src/helpers/extensions.dart
+++ b/web/lib/src/helpers/extensions.dart
@@ -43,7 +43,11 @@ export 'cross_origin.dart'
 
 extension BlobExtension on Blob {
   @Equivalence(type: 'Blob', member: '')
-  Blob createBlob(List<Object?> blobParts, [String? type, String? endings]) {
+  static Blob createBlob(
+    List<Object?> blobParts, [
+    String? type,
+    String? endings,
+  ]) {
     final jsParts = blobParts.jsify() as JSArray<JSAny>;
     if (type != null && endings != null) {
       return Blob(jsParts, BlobPropertyBag(type: type, endings: endings));
@@ -81,6 +85,42 @@ extension CSSStyleDeclarationExtension on CSSStyleDeclaration {
     value ??= '';
     priority ??= '';
     setProperty(property, value, priority);
+  }
+}
+
+extension CustomEventExtension on CustomEvent {
+  @Equivalence(type: 'CustomEvent', member: '')
+  static CustomEvent createCustomEvent(
+    String type, {
+    bool canBubble = true,
+    bool cancelable = true,
+    Object? detail,
+  }) {
+    final event = document.createEvent('CustomEvent') as CustomEvent;
+    if (detail is List || detail is Map || detail is String || detail is num) {
+      event.initCustomEvent(type, canBubble, cancelable, detail.jsify());
+    } else {
+      event.initCustomEvent(
+        type,
+        canBubble,
+        cancelable,
+        // A tricky scenario. Ideally, we'd do something similar to `dart:html`
+        // and store it in a separate property, but that's not symmetrical with
+        // `dart:html` and therefore may break partial migrations, so we're
+        // forced to leverage `detail`.
+        detail.toExternalReference as JSAny?,
+      );
+    }
+    return event;
+  }
+
+  @Equivalence(type: 'CustomEvent', member: 'detail')
+  Object? get dartDetail {
+    final detail = this.detail;
+    if (detail.isA<JSAny?>()) {
+      return detail.dartify();
+    }
+    return (detail as ExternalDartReference).toDartObject;
   }
 }
 
@@ -277,6 +317,17 @@ extension EventExtension on Event {
   @Equivalence(type: 'Event', member: 'path')
   List<EventTarget> get path =>
       has('composedPath') ? composedPath().toDart : [];
+
+  @Equivalence(type: 'Event', member: '')
+  static Event createEvent(
+    String type, {
+    bool canBubble = true,
+    bool cancelable = true,
+  }) {
+    final event = document.createEvent('Event');
+    event.initEvent(type, canBubble, cancelable);
+    return event;
+  }
 }
 
 extension EventTargetExtension on EventTarget {
@@ -382,6 +433,43 @@ extension HTMLCollectionExtension on HTMLCollection {
 extension HTMLInputElementExtension on HTMLInputElement {
   @Equivalence(type: 'InputElement', member: 'files')
   List<File>? get filesAsList => files?.asList();
+}
+
+extension KeyboardEventExtension on KeyboardEvent {
+  @Equivalence(type: 'KeyboardEvent', member: '')
+  KeyboardEvent createKeyboardEvent(
+    String type, {
+    Window? view,
+    bool canBubble = true,
+    bool cancelable = true,
+    int? location,
+    int? keyLocation, // Legacy alias for location
+    bool ctrlKey = false,
+    bool altKey = false,
+    bool shiftKey = false,
+    bool metaKey = false,
+  }) {
+    if (view == null) {
+      view = window;
+    }
+    location ??= keyLocation ?? 1;
+    KeyboardEvent event = KeyboardEvent(
+      type,
+      KeyboardEventInit(
+        view: view,
+        bubbles: canBubble,
+        cancelable: cancelable,
+        location: location,
+        ctrlKey: ctrlKey,
+        altKey: altKey,
+        shiftKey: shiftKey,
+        metaKey: metaKey,
+      ),
+    );
+    // `dart:html` calls `initKeyboardEvent`, but that's legacy behavior and
+    // unneeded since the constructor supports all options.
+    return event;
+  }
 }
 
 extension MouseEventExtension on MouseEvent {
@@ -537,6 +625,10 @@ extension WindowExtension on Window {
     requestAnimationFrame(getTimestamp.toJS);
     return completer.future;
   }
+
+  @Equivalence(type: 'Window', member: 'requestAnimationFrame')
+  int requestAnimationFrameBindZone(void Function(num) callback) =>
+      requestAnimationFrame(Zone.current.bindUnaryCallback(callback).toJS);
 
   @Equivalence(type: 'Window', member: 'console')
   StringConsole get console => StringConsole(dom.console);

--- a/web/test/helpers_test.dart
+++ b/web/test/helpers_test.dart
@@ -5,6 +5,7 @@
 @TestOn('browser')
 library;
 
+import 'dart:async';
 import 'dart:js_interop';
 
 import 'package:test/test.dart';
@@ -341,6 +342,26 @@ void main() {
     expect(() => Uri.parse('/path').toJS, throwsArgumentError);
   });
 
+  test('createBlob', () {
+    final blob = BlobExtension.createBlob(['blob'], 'text/plain');
+    expect(blob.type, 'text/plain');
+    expect(blob.size, 4);
+  });
+
+  test('requestAnimationFrameBindZone', () async {
+    final completer = Completer<void>();
+    final testZone = Zone.current.fork();
+
+    testZone.run(() {
+      window.requestAnimationFrameBindZone((num timestamp) {
+        expect(Zone.current, testZone);
+        completer.complete();
+      });
+    });
+
+    await completer.future;
+  });
+
   group('EventStreamProvider and stream type casting', () {
     test('works with explicit correct types (Event and MouseEvent)', () async {
       final div = document.createElement('div') as HTMLElement;
@@ -391,5 +412,53 @@ void main() {
         div.remove();
       },
     );
+  });
+
+  group('Event creation helpers', () {
+    test('createEvent', () {
+      final event = EventExtension.createEvent('look');
+      expect(event.type, 'look');
+      expect(event.bubbles, true);
+      expect(event.cancelable, true);
+    });
+
+    test('createCustomEvent', () {
+      final event = CustomEventExtension.createCustomEvent(
+        'look',
+        detail: 'detail',
+      );
+      expect(event.type, 'look');
+      expect(event.dartDetail, 'detail');
+      expect(event.bubbles, true);
+      expect(event.cancelable, true);
+
+      // Test `jsify`-able `detail`.
+      final event2 = CustomEventExtension.createCustomEvent(
+        'look',
+        detail: [0],
+      );
+      expect(event2.type, 'look');
+      expect(event2.dartDetail, [0]);
+
+      // Test non-`jsify`-able `detail`.
+      final object = Object();
+      final event3 = CustomEventExtension.createCustomEvent(
+        'look',
+        detail: object,
+      );
+      expect(event3.type, 'look');
+      expect(event3.dartDetail, object);
+    });
+
+    test('createKeyboardEvent', () {
+      final event = KeyboardEventExtension.createKeyboardEvent('keydown');
+      expect(event.type, 'keydown');
+      expect(event.bubbles, true);
+      expect(event.cancelable, true);
+      expect(event.ctrlKey, false);
+      expect(event.altKey, false);
+      expect(event.shiftKey, false);
+      expect(event.metaKey, false);
+    });
   });
 }


### PR DESCRIPTION
`CustomEvent`s were handled specially in `dart:html` by `jsify`ing compatible `detail`s and otherwise storing it on the side in variable. When accessing `detail`, it would check for this storage on the side first before directly returning the native `detail`. We could store it on the side here but that won't be symmetric with `dart:html`, so we leverage the native `detail` to store the object.

`Event` and `KeyboardEvent` constructors from `dart:html` have different defaults than the web, so that's reflected here as well.

`requestAnimationFrame` bound the current zone before, so there's a helper for that (mostly so users are aware that that is the equivalent member).

Lastly, `createBlob` should have been static so this fixes that.