### PR TITLE
chore: harden GitHub Actions workflows against Zizmor findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
     labels:
       - autosubmit
     groups:

--- a/.github/workflows/js_interop.yaml
+++ b/.github/workflows/js_interop.yaml
@@ -31,6 +31,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/js_interop_gen.yaml
+++ b/.github/workflows/js_interop_gen.yaml
@@ -31,6 +31,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22

--- a/.github/workflows/post_summaries.yaml
+++ b/.github/workflows/post_summaries.yaml
@@ -1,12 +1,14 @@
 # A workflow to allow other workflow to comment on PRs.
 
 name: Comment on the pull request
+permissions:
+  contents: read
 
 on:
   # Trigger this workflow after the Health workflow completes. This workflow
   # will have permissions to do things like create comments on the PR, even if
   # the original workflow couldn't.
-  workflow_run:
+  workflow_run: # zizmor: ignore[dangerous-triggers]
     workflows:
       - Publish
     types:
@@ -14,6 +16,6 @@ on:
 
 jobs:
   upload:
-    uses: dart-lang/ecosystem/.github/workflows/post_summaries.yaml@main
+    uses: dart-lang/ecosystem/.github/workflows/post_summaries.yaml@ed9c592c1d35106c0a8a52044426515017a60646
     permissions:
       pull-requests: write

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,6 +1,8 @@
 # A CI configuration to auto-publish pub packages.
 
 name: Publish
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -11,7 +13,7 @@ on:
 jobs:
   publish:
     if: ${{ github.repository_owner == 'dart-lang' }}
-    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
+    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@ed9c592c1d35106c0a8a52044426515017a60646
     with:
       write-comments: false
     permissions:

--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -31,6 +31,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/web_generator.yaml
+++ b/.github/workflows/web_generator.yaml
@@ -32,6 +32,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -49,6 +51,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
 
       - run: npm install
@@ -64,6 +68,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
 
       - run: npm install


### PR DESCRIPTION
* Add top-level permissions: contents: read to publish and post_summaries workflows
* Pin dart-lang/ecosystem workflows to immutable commit SHAs
* Set persist-credentials: false on actions/checkout steps
* Add cooldown configuration to dependabot.yml
* Add ignore annotation for workflow_run dangerous triggers
