### PR TITLE
Add a `JSAsyncDisposable` type

### DIFF
--- a/.github/workflows/js_interop.yaml
+++ b/.github/workflows/js_interop.yaml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: ['3.10', beta, dev]
+        sdk: ['3.12', beta, dev]
         test_config: ['-p chrome', '-p chrome -c dart2wasm', '-p node']
 
     steps:

--- a/js_interop/lib/js_interop.dart
+++ b/js_interop/lib/js_interop.dart
@@ -4,5 +4,6 @@
 
 export 'src/dart/date_time.dart';
 export 'src/dart/map.dart';
+export 'src/async_disposable_protocol.dart';
 export 'src/date.dart';
 export 'src/record.dart';

--- a/js_interop/lib/src/async_disposable_protocol.dart
+++ b/js_interop/lib/src/async_disposable_protocol.dart
@@ -1,0 +1,50 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.p
+
+import 'dart:async';
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+// TODO(nweiz): Use JSSymbol.asyncDispose once it's available.
+@JS('Symbol.asyncDispose')
+external JSSymbol get _asyncDispose;
+
+/// The `AsyncDisposable` type from the ECMAScript [explicit resource
+/// management] feature.
+///
+/// [explicit resource management]: https://github.com/tc39/proposal-explicit-resource-management
+extension type JSAsyncDisposableProtocol._(JSObject _) implements JSObject {
+  /// The [`@@asyncDispose`] function that disposes this object.
+  ///
+  /// [`@@asyncDispose`]: https://tc39.es/proposal-explicit-resource-management/#table-asyncdisposable-interface-required-properties
+  JSPromise<Null> asyncDispose() => callMethod(_asyncDispose);
+}
+
+/// An extension for [JSAsyncDisposableProtocol] to provide an analog to JavaScript's
+/// `await using` declaration.
+extension JSAsyncDisposableUse<T extends JSAsyncDisposableProtocol> on T {
+  /// Passes [this] to [callback] and disposes of it after the callback
+  /// completes (even if it produces an error).
+  ///
+  /// If [callback] returns a `Future`, [this] is instead disposed after that
+  /// future completes.
+  ///
+  /// This is intended to provide similar functionality to JavaScript's [`await
+  /// using`] declaration. It's recommended that the variable passed to the
+  /// callback be the only binding for this [AsyncDisposable] so that it's
+  /// guaranteed to be disposed if and only if it can't be referenced. For example:
+  ///
+  /// [`await using`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/await_using
+  ///
+  /// ```dart
+  /// void main() {
+  ///   database.connect().use((db) {
+  ///     db.store(Record());
+  ///   });
+  /// }
+  /// ```
+  Future<R> use<R>(FutureOr<R> Function(T) callback) => Future.sync(
+    () => callback(this),
+  ).whenComplete(() => asyncDispose().toDart);
+}

--- a/js_interop/pubspec.yaml
+++ b/js_interop/pubspec.yaml
@@ -4,7 +4,7 @@ description: Utility APIs for dart:js_interop and dart:js_interop_unsafe.
 repository: https://github.com/dart-lang/web
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.12.0
 
 dev_dependencies:
   test: ^1.26.0


### PR DESCRIPTION
There are no tests for this because currently there are no built-in types that implement the async disposable protocol.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
