### PR TITLE
Add `JSPropertyDescriptor` and associated unsafe object methods

### DIFF
--- a/js_interop/lib/src/unsafe/object.dart
+++ b/js_interop/lib/src/unsafe/object.dart
@@ -4,6 +4,8 @@
 
 import 'dart:js_interop';
 
+import 'property_descriptor.dart';
+
 @JS('Object.assign')
 external void _assign(
   JSObject target, [
@@ -13,6 +15,13 @@ external void _assign(
   JSAny? source4,
 ]);
 
+@JS('Reflect.defineProperty')
+external bool _defineProperty(
+  JSObject object,
+  JSAny name,
+  JSPropertyDescriptor definition,
+);
+
 @JS('Object.entries')
 external JSArray<JSArray<JSAny?>> _entries(JSObject object);
 
@@ -21,6 +30,12 @@ external void _freeze(JSObject object);
 
 @JS('Reflect.get')
 external JSAny? _get(JSObject object, JSAny name, JSAny? thisArg);
+
+@JS('Object.getOwnPropertyDescriptor')
+external JSPropertyDescriptor? _getOwnPropertyDescriptor(
+  JSObject object,
+  JSAny name,
+);
 
 @JS('Object.getOwnPropertyNames')
 external JSArray<JSString> _getOwnPropertyNames(JSObject object);
@@ -91,10 +106,26 @@ extension JSObjectUnsafeExtension on JSObject {
     JSObject? source4,
   ]) => _assign(this, source1, source2, source3, source4);
 
+  /// See [`Reflect.defineProperty()`].
+  ///
+  /// The [name] must be a [JSString] or a [JSSymbol].
+  ///
+  /// [`Reflect.defineProperty()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/defineProperty
+  bool defineProperty(JSAny name, JSPropertyDescriptor definition) =>
+      _defineProperty(this, name, definition);
+
   /// See [`Object.freeze()`].
   ///
   /// [`Object.freeze()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze
   void freeze() => _freeze(this);
+
+  /// See [`Object.getOwnPropertyDescriptor()`].
+  ///
+  /// The [name] must be a [JSString] or a [JSSymbol].
+  ///
+  /// [`Object.getOwnPropertyDescriptor()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor
+  JSPropertyDescriptor? getOwnPropertyDescriptor(JSAny name) =>
+      _getOwnPropertyDescriptor(this, name);
 
   /// See [`Reflect.get()`].
   ///

--- a/js_interop/lib/src/unsafe/property_descriptor.dart
+++ b/js_interop/lib/src/unsafe/property_descriptor.dart
@@ -1,0 +1,140 @@
+import 'dart:js_interop';
+
+/// A record type that defines the precise behavior of a JavaScript property.
+///
+/// This can be passed to [JSObjectUnsafeExtension.defineProperties] or
+/// [JSObjectUnsafeExtension.defineProperty], and it's returned by
+/// [JSObjectUnsafeExtension.getOwnPropertyDescriptor] and
+/// [JSObjectUnsafeExtension.ownPropretyDescriptors]. See [the MDN
+/// documentation] for details.
+///
+/// [the MDN documentation]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#description
+extension type JSPropertyDescriptor.__(JSObject _) implements JSObject {
+  external JSPropertyDescriptor._({
+    bool? configurable,
+    bool? enumerable,
+    JSAny? value,
+    bool? writable,
+    JSFunction? get,
+    JSFunction? set,
+  });
+
+  /// Creates a property descriptor that defines a getter with the given [body].
+  // TODO(nweiz): Make T extend JSUnsafeObject once
+  // https://github.com/dart-lang/sdk/pull/63141 is available to support
+  // introspecting Dart types compiled to JS.
+  static JSPropertyDescriptor getter<T extends JSObject>(
+    JSAny? Function(T thisArg) body, {
+    bool configurable = false,
+    bool enumerable = false,
+  }) => JSPropertyDescriptor._(
+    configurable: configurable,
+    enumerable: enumerable,
+    get: body.toJSCaptureThis,
+  );
+
+  /// Creates a property descriptor that defines a setter with the given [body].
+  // TODO(nweiz): Make T extend JSUnsafeObject once
+  // https://github.com/dart-lang/sdk/pull/63141 is available to support
+  // introspecting Dart types compiled to JS.
+  static JSPropertyDescriptor setter<T extends JSObject, V extends JSAny?>(
+    void Function(T thisArg, V value) body, {
+    bool configurable = false,
+    bool enumerable = false,
+  }) => JSPropertyDescriptor._(
+    configurable: configurable,
+    enumerable: enumerable,
+    set: body.toJSCaptureThis,
+  );
+
+  /// Creates a property descriptor that defines a given [getter] and [setter].
+  // TODO(nweiz): Make T extend JSUnsafeObject once
+  // https://github.com/dart-lang/sdk/pull/63141 is available to support
+  // introspecting Dart types compiled to JS.
+  static JSPropertyDescriptor accessor<T extends JSObject, V extends JSAny?>(
+    V Function(T thisArg) getter,
+    void Function(T thisArg, V value) setter, {
+    bool configurable = false,
+    bool enumerable = false,
+  }) => JSPropertyDescriptor._(
+    configurable: configurable,
+    enumerable: enumerable,
+    get: getter.toJSCaptureThis,
+    set: setter.toJSCaptureThis,
+  );
+
+  /// Creates a property descriptor that defines a property that returns the
+  /// given [value].
+  static JSPropertyDescriptor getValue(
+    JSAny? value, {
+    bool configurable = false,
+    bool enumerable = false,
+    bool writable = false,
+  }) => JSPropertyDescriptor._(
+    configurable: configurable,
+    enumerable: enumerable,
+    value: value,
+    writable: writable,
+  );
+
+  /// Whether various attributes of this property can be changed.
+  ///
+  /// See [the MDN documentation] for details.
+  ///
+  /// [the MDN documentation]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#configurable
+  bool get configurable => _configurable ?? false;
+  external set configurable(bool value);
+
+  @JS('configurable')
+  external bool? get _configurable;
+
+  /// Whether this property shows up during enumeration of the properties on the
+  /// corresponding object.
+  ///
+  /// See [the MDN documentation] for details.
+  ///
+  /// [the MDN documentation]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#enumerable
+  bool get enumerable => _enumerable ?? false;
+  external set enumerable(bool value);
+
+  @JS('enumerable')
+  external bool? get _enumerable;
+
+  /// The value associated with the property.
+  ///
+  /// Only meaningful for data descriptors. See [the MDN documentation] for
+  /// details.
+  ///
+  /// [the MDN documentation]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#value
+  external JSAny? get value;
+  external set value(JSAny? value);
+
+  /// Whether the value associated with the property may be changed with an
+  /// assignment operator.
+  ///
+  /// Only meaningful for data descriptors. See [the MDN documentation] for
+  /// details.
+  ///
+  /// [the MDN documentation]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#writable
+  bool get writable => _writable ?? false;
+  external set writable(bool value);
+
+  @JS('writable')
+  external bool? get _writable;
+
+  /// A function which serves as a getter for the property.
+  ///
+  /// Only meaningful for accessor descriptors. See [the MDN documentation] for
+  /// details.
+  ///
+  /// [the MDN documentation]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#get
+  external JSFunction? get get;
+
+  /// A function which serves as a setter for the property.
+  ///
+  /// Only meaningful for accessor descriptors. See [the MDN documentation] for
+  /// details.
+  ///
+  /// [the MDN documentation]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#set
+  external JSFunction? get set;
+}

--- a/js_interop/lib/unsafe.dart
+++ b/js_interop/lib/unsafe.dart
@@ -10,3 +10,4 @@
 library;
 
 export 'src/unsafe/object.dart';
+export 'src/unsafe/property_descriptor.dart';

--- a/js_interop/test/unsafe/object_test.dart
+++ b/js_interop/test/unsafe/object_test.dart
@@ -37,6 +37,136 @@ void main() {
     expect(object.dartify(), equals({"foo": 1, "bar": 3, "baz": 4}));
   });
 
+  group("defineProperty", () {
+    test("getter", () {
+      object.defineProperty(
+        "baz".toJS,
+        JSPropertyDescriptor.getter(
+          expectAsync1((objectArg) {
+            expect(objectArg, equals(object));
+            return 3.toJS;
+          }),
+        ),
+      );
+      expect(object.getProperty("baz".toJS), equals(3.toJS));
+    });
+
+    test("setter", () {
+      object.defineProperty(
+        "baz".toJS,
+        JSPropertyDescriptor.setter(
+          expectAsync2((objectArg, value) {
+            expect(objectArg, equals(object));
+            expect(value, equals(3.toJS));
+          }),
+        ),
+      );
+      expect(object.getProperty("baz".toJS), isNull);
+      object.setProperty("baz".toJS, 3.toJS);
+    });
+
+    test("accessor", () {
+      object.defineProperty(
+        "baz".toJS,
+        JSPropertyDescriptor.accessor(
+          expectAsync1((objectArg) {
+            expect(objectArg, equals(object));
+            return 3.toJS;
+          }),
+          expectAsync2((objectArg, value) {
+            expect(objectArg, equals(object));
+            expect(value, equals(3.toJS));
+          }),
+        ),
+      );
+      expect(object.getProperty("baz".toJS), 3.toJS);
+      object.setProperty("baz".toJS, 3.toJS);
+    });
+
+    test("getValue", () {
+      var descriptor = JSPropertyDescriptor.getValue(3.toJS);
+      expect(descriptor.value, equals(3.toJS));
+      object.defineProperty("baz".toJS, descriptor);
+      expect(object.getProperty("baz".toJS), 3.toJS);
+    });
+
+    group("configurable", () {
+      test("true", () {
+        var descriptor = JSPropertyDescriptor.getValue(
+          3.toJS,
+          configurable: true,
+        );
+        expect(descriptor.configurable, isTrue);
+        object.defineProperty("baz".toJS, descriptor);
+        object.defineProperty(
+          "baz".toJS,
+          JSPropertyDescriptor.getValue(4.toJS, configurable: true),
+        );
+        expect(object.getProperty("baz".toJS), 4.toJS);
+      });
+
+      test("false", () {
+        var descriptor = JSPropertyDescriptor.getValue(
+          3.toJS,
+          configurable: false,
+        );
+        expect(descriptor.configurable, isFalse);
+        object.defineProperty("baz".toJS, descriptor);
+        object.defineProperty(
+          "baz".toJS,
+          JSPropertyDescriptor.getValue(4.toJS, configurable: false),
+        );
+        expect(object.getProperty("baz".toJS), 3.toJS);
+      });
+    });
+
+    group("enumerable", () {
+      test("true", () {
+        var descriptor = JSPropertyDescriptor.getValue(
+          3.toJS,
+          enumerable: true,
+        );
+        expect(descriptor.enumerable, isTrue);
+        object.defineProperty("baz".toJS, descriptor);
+        expect(object.keys, contains("baz".toJS));
+      });
+
+      test("false", () {
+        var descriptor = JSPropertyDescriptor.getValue(
+          3.toJS,
+          enumerable: false,
+        );
+        expect(descriptor.enumerable, isFalse);
+        object.defineProperty("baz".toJS, descriptor);
+        expect(object.keys, isNot(contains("baz".toJS)));
+      });
+    });
+
+    group("writable", () {
+      test("true", () {
+        var descriptor = JSPropertyDescriptor.getValue(3.toJS, writable: true);
+        expect(descriptor.writable, isTrue);
+        object.defineProperty("baz".toJS, descriptor);
+        object.setProperty("baz".toJS, 4.toJS);
+        expect(object.getProperty("baz".toJS), 4.toJS);
+      });
+
+      test("false", () {
+        var descriptor = JSPropertyDescriptor.getValue(3.toJS, writable: false);
+        expect(descriptor.writable, isFalse);
+        object.defineProperty("baz".toJS, descriptor);
+
+        try {
+          object.setProperty("baz".toJS, 4.toJS);
+        } catch (_) {
+          // This throws an error in WASM.
+        }
+
+        expect(object.getProperty("baz".toJS), 3.toJS);
+      });
+    });
+  });
+
   test("freeze", () {
     object.freeze();
 
@@ -48,6 +178,16 @@ void main() {
     }
 
     expect(object.dartify(), equals({"foo": 1, "bar": 2}));
+  });
+
+  test("getOwnPropertyDescriptor", () {
+    var descriptor = object.getOwnPropertyDescriptor("foo".toJS)!;
+    expect(descriptor.configurable, isTrue);
+    expect(descriptor.enumerable, isTrue);
+    expect(descriptor.writable, isTrue);
+    expect(descriptor.value, equals(1.toJS));
+    expect(descriptor.get, isNull);
+    expect(descriptor.set, isNull);
   });
 
   test(


### PR DESCRIPTION
This is missing `Object.defineProperties` and `Object.ownPropertyDescriptors`, which I'll add along with support for the `JSSymbolicRecord` type.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
